### PR TITLE
Implement Spotify search APIs integration Part I

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ List of supported commands:
 | `BrowsePlayingContext`       | browse the current playing context                        | `g space`          |
 | `BrowseSelectedTrackArtists` | open a popup for browsing the selected track's artists    | `g a`, `C-g a`     |
 | `BrowseSelectedTrackAlbum`   | browse to the selected track's album                      | `g A`, `C-g A`     |
-| `PreviousPage`               | go to the previous page                                   | `backspace`        |
+| `PreviousPage`               | go to the previous page                                   | `backspace`, `C-p` |
 | `SortTrackByTitle`           | sort the track table (if any) by track's title            | `s t`              |
 | `SortTrackByArtists`         | sort the track table (if any) by track's artists          | `s a`              |
 | `SortTrackByAlbum`           | sort the track table (if any) by track's album            | `s A`              |

--- a/spotify_player/src/client.rs
+++ b/spotify_player/src/client.rs
@@ -446,7 +446,7 @@ impl Client {
         // update ui states
         if let PageState::Searching(_, ref mut state_search_results) = state.ui.lock().unwrap().page
         {
-            *state_search_results = search_results;
+            *state_search_results = Box::new(search_results);
         }
         state.ui.lock().unwrap().window = WindowState::Search(
             new_list_state(),

--- a/spotify_player/src/client.rs
+++ b/spotify_player/src/client.rs
@@ -459,8 +459,8 @@ impl Client {
         Ok(())
     }
 
-    /// converts a page::Page of items with type Y into a page::Page of items with type X
-    /// given that type Y can be converted to type X through the Into<X> trait
+    /// converts a page of items with type `Y` into a page of items with type `X`
+    /// given that type `Y` can be converted to type `X` through the `Into<X>` trait
     fn into_page<X, Y: Into<X>>(page_y: page::Page<Y>) -> page::Page<X> {
         page::Page {
             items: page_y
@@ -837,6 +837,8 @@ async fn watch_player_events(
             match ui.window {
                 WindowState::Search(..) => {}
                 _ => {
+                    // the current window state doesn't match the current page state,
+                    // this can happen after calling the `PreviousPage` command
                     ui.window = WindowState::Search(
                         new_list_state(),
                         new_list_state(),

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -39,6 +39,8 @@ pub enum Command {
     BrowseSelectedTrackArtists,
     BrowseSelectedTrackAlbum,
 
+    EnterSearchPage,
+
     PreviousPage,
 
     SortTrackByTitle,
@@ -84,6 +86,7 @@ impl Command {
                 "open a popup for browsing the selected track's artists"
             }
             Self::BrowseSelectedTrackAlbum => "browse to the selected track's album",
+            Self::EnterSearchPage => "go to the search page",
             Self::PreviousPage => "go to the previous page",
             Self::SortTrackByTitle => "sort the track table (if any) by track's title",
             Self::SortTrackByArtists => "sort the track table (if any) by track's artists",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -132,6 +132,10 @@ impl Default for KeymapConfig {
                     command: Command::PreviousPage,
                 },
                 Keymap {
+                    key_sequence: "C-p".into(),
+                    command: Command::PreviousPage,
+                },
+                Keymap {
                     key_sequence: "?".into(),
                     command: Command::OpenCommandHelp,
                 },

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -124,6 +124,10 @@ impl Default for KeymapConfig {
                     command: Command::BrowseSelectedTrackAlbum,
                 },
                 Keymap {
+                    key_sequence: "g /".into(),
+                    command: Command::EnterSearchPage,
+                },
+                Keymap {
                     key_sequence: "backspace".into(),
                     command: Command::PreviousPage,
                 },

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -44,6 +44,7 @@ pub enum Event {
     GetContext(ContextURI),
     GetCurrentPlayback,
     TransferPlayback(String, bool),
+    Search(String),
     Player(PlayerEvent),
 }
 

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -316,9 +316,8 @@ fn handle_command_for_context_window(
             );
 
             // needs to set `context_uri` to an empty string
-            // because keeping the original `context_uri` will
-            // prevent the context window from updating when going
-            // back from a search window using `PreviousPage` command
+            // to trigger updating the context window when going
+            // backward from a page (call `PreviousPage` command)
             state.player.write().unwrap().context_uri = "".to_owned();
             Ok(true)
         }

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -2,7 +2,7 @@ use crate::{
     command::Command,
     key::{Key, KeySequence},
     state::*,
-    utils,
+    utils::{self, new_list_state},
 };
 use anyhow::Result;
 use crossterm::event::{self, EventStream, KeyCode, KeyModifiers};
@@ -291,6 +291,19 @@ fn handle_command_for_none_popup(
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
     match command {
+        Command::EnterSearchPage => {
+            // TODO: handle the command properly
+            ui.page = PageState::Searching("blackpink".to_owned());
+            ui.window = WindowState::Search(
+                new_list_state(),
+                new_list_state(),
+                new_list_state(),
+                new_list_state(),
+                SearchFocusState::Tracks,
+            );
+            send.send(Event::Search("blackpink".to_owned()))?;
+            Ok(true)
+        }
         Command::SearchContext => {
             ui.window.select(Some(0));
             ui.popup = PopupState::ContextSearch("".to_owned());

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -293,7 +293,9 @@ fn handle_command_for_none_popup(
     match command {
         Command::EnterSearchPage => {
             // TODO: handle the command properly
-            ui.page = PageState::Searching("blackpink".to_owned());
+            let new_page = PageState::Searching("blackpink".to_owned());
+            ui.history.push(new_page.clone());
+            ui.page = new_page;
             ui.window = WindowState::Search(
                 new_list_state(),
                 new_list_state(),
@@ -301,6 +303,12 @@ fn handle_command_for_none_popup(
                 new_list_state(),
                 SearchFocusState::Tracks,
             );
+            // needs to set `context_uri` to an empty string
+            // because keeping the original `context_uri` will
+            // prevent the context window from updating when going
+            // back from a search window using `PreviousPage` command
+            state.player.write().unwrap().context_uri = "".to_owned();
+
             send.send(Event::Search("blackpink".to_owned()))?;
             Ok(true)
         }
@@ -486,9 +494,9 @@ fn handle_command_for_uri_list_popup(
             };
             send.send(Event::GetContext(context_uri))?;
 
-            let frame_state = PageState::Browsing(uris[id].clone());
-            ui.history.push(frame_state.clone());
-            ui.page = frame_state;
+            let new_page = PageState::Browsing(uris[id].clone());
+            ui.history.push(new_page.clone());
+            ui.page = new_page;
             ui.popup = PopupState::None;
             Ok(())
         },
@@ -611,9 +619,9 @@ fn handle_command(
             if let Some(track) = state.player.read().unwrap().get_current_playing_track() {
                 if let Some(ref uri) = track.album.uri {
                     send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
-                    let frame_state = PageState::Browsing(uri.clone());
-                    ui.history.push(frame_state.clone());
-                    ui.page = frame_state;
+                    let new_page = PageState::Browsing(uri.clone());
+                    ui.history.push(new_page.clone());
+                    ui.page = new_page;
                 }
             }
             Ok(true)
@@ -754,9 +762,9 @@ fn handle_command_for_artist_list(
             if let Some(id) = ui.window.selected() {
                 let uri = artists[id].uri.clone().unwrap();
                 send.send(Event::GetContext(ContextURI::Artist(uri.clone())))?;
-                let frame_state = PageState::Browsing(uri);
-                ui.history.push(frame_state.clone());
-                ui.page = frame_state;
+                let new_page = PageState::Browsing(uri);
+                ui.history.push(new_page.clone());
+                ui.page = new_page;
             }
             Ok(true)
         }
@@ -791,9 +799,9 @@ fn handle_command_for_album_list(
             if let Some(id) = ui.window.selected() {
                 let uri = albums[id].uri.clone().unwrap();
                 send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
-                let frame_state = PageState::Browsing(uri);
-                ui.history.push(frame_state.clone());
-                ui.page = frame_state;
+                let new_page = PageState::Browsing(uri);
+                ui.history.push(new_page.clone());
+                ui.page = new_page;
             }
             Ok(true)
         }
@@ -850,9 +858,9 @@ fn handle_command_for_track_table(
             if let Some(id) = ui.window.selected() {
                 if let Some(ref uri) = tracks[id].album.uri {
                     send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
-                    let frame_state = PageState::Browsing(uri.clone());
-                    ui.history.push(frame_state.clone());
-                    ui.page = frame_state;
+                    let new_page = PageState::Browsing(uri.clone());
+                    ui.history.push(new_page.clone());
+                    ui.page = new_page;
                 }
             }
             Ok(true)

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -304,7 +304,7 @@ fn handle_command_for_context_window(
 ) -> Result<bool> {
     match command {
         Command::EnterSearchPage => {
-            let new_page = PageState::Searching("".to_owned(), SearchResults::empty());
+            let new_page = PageState::Searching("".to_owned(), Box::new(SearchResults::empty()));
             ui.history.push(new_page.clone());
             ui.page = new_page;
             ui.window = WindowState::Search(

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -419,15 +419,17 @@ fn handle_key_sequence_for_search_window(
             match c {
                 KeyCode::Char(c) => {
                     query.push(c);
-                    send.send(ClientRequest::Search(query.clone()))?;
                     return Ok(true);
                 }
                 KeyCode::Backspace => {
                     if !query.is_empty() {
                         query.pop().unwrap();
-                        if !query.is_empty() {
-                            send.send(ClientRequest::Search(query.clone()))?;
-                        }
+                    }
+                    return Ok(true);
+                }
+                KeyCode::Enter => {
+                    if !query.is_empty() {
+                        send.send(ClientRequest::Search(query.clone()))?;
                     }
                     return Ok(true);
                 }

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -121,6 +121,30 @@ impl PlayerState {
     }
 }
 
+impl SearchResults {
+    fn empty_page<T>() -> page::Page<T> {
+        page::Page {
+            href: "".to_owned(),
+            items: vec![],
+            limit: 0,
+            next: None,
+            offset: 0,
+            previous: None,
+            total: 0,
+        }
+    }
+
+    // returns an empty search results
+    pub fn empty() -> Self {
+        Self {
+            tracks: Self::empty_page::<track::FullTrack>(),
+            artists: Self::empty_page::<artist::FullArtist>(),
+            albums: Self::empty_page::<album::SimplifiedAlbum>(),
+            playlists: Self::empty_page::<playlist::SimplifiedPlaylist>(),
+        }
+    }
+}
+
 impl Default for PlayerState {
     fn default() -> Self {
         Self {

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -36,9 +36,9 @@ pub enum Context {
 /// - `playlists`
 #[derive(Debug)]
 pub struct SearchResults {
-    pub tracks: page::Page<track::SimplifiedTrack>,
+    pub tracks: page::Page<track::FullTrack>,
+    pub artists: page::Page<artist::FullArtist>,
     pub albums: page::Page<album::SimplifiedAlbum>,
-    pub artists: page::Page<artist::SimplifiedArtist>,
     pub playlists: page::Page<playlist::SimplifiedPlaylist>,
 }
 

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -13,6 +13,7 @@ pub struct PlayerState {
 
     pub context_uri: String,
     pub context_cache: lru::LruCache<String, Context>,
+    pub search_cache: lru::LruCache<String, SearchResults>,
 
     pub playback: Option<context::CurrentlyPlaybackContext>,
     pub playback_last_updated: Option<std::time::Instant>,
@@ -25,6 +26,20 @@ pub enum Context {
     Album(album::FullAlbum, Vec<Track>),
     Artist(artist::FullArtist, Vec<Track>, Vec<Album>, Vec<Artist>),
     Unknown(String),
+}
+
+/// SearchResults denotes the returned data when searching using Spotify API.
+/// Search results are returned as pages of Spotify objects, which includes
+/// - `tracks`
+/// - `albums`
+/// - `artists`
+/// - `playlists`
+#[derive(Debug)]
+pub struct SearchResults {
+    pub tracks: page::Page<track::SimplifiedTrack>,
+    pub albums: page::Page<album::SimplifiedAlbum>,
+    pub artists: page::Page<artist::SimplifiedArtist>,
+    pub playlists: page::Page<playlist::SimplifiedPlaylist>,
 }
 
 #[derive(Debug)]
@@ -116,6 +131,7 @@ impl Default for PlayerState {
             user_followed_artists: vec![],
             context_uri: "".to_owned(),
             context_cache: lru::LruCache::new(64),
+            search_cache: lru::LruCache::new(64),
             playback: None,
             playback_last_updated: None,
         }

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -36,9 +36,9 @@ pub enum Context {
 /// - `playlists`
 #[derive(Debug)]
 pub struct SearchResults {
-    pub tracks: page::Page<track::FullTrack>,
-    pub artists: page::Page<artist::FullArtist>,
-    pub albums: page::Page<album::SimplifiedAlbum>,
+    pub tracks: page::Page<Track>,
+    pub artists: page::Page<Artist>,
+    pub albums: page::Page<Album>,
     pub playlists: page::Page<playlist::SimplifiedPlaylist>,
 }
 
@@ -137,9 +137,9 @@ impl SearchResults {
     // returns an empty search results
     pub fn empty() -> Self {
         Self {
-            tracks: Self::empty_page::<track::FullTrack>(),
-            artists: Self::empty_page::<artist::FullArtist>(),
-            albums: Self::empty_page::<album::SimplifiedAlbum>(),
+            tracks: Self::empty_page::<Track>(),
+            artists: Self::empty_page::<Artist>(),
+            albums: Self::empty_page::<Album>(),
             playlists: Self::empty_page::<playlist::SimplifiedPlaylist>(),
         }
     }

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -13,7 +13,6 @@ pub struct PlayerState {
 
     pub context_uri: String,
     pub context_cache: lru::LruCache<String, Context>,
-    pub search_cache: lru::LruCache<String, SearchResults>,
 
     pub playback: Option<context::CurrentlyPlaybackContext>,
     pub playback_last_updated: Option<std::time::Instant>,
@@ -34,7 +33,7 @@ pub enum Context {
 /// - `albums`
 /// - `artists`
 /// - `playlists`
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SearchResults {
     pub tracks: page::Page<Track>,
     pub artists: page::Page<Artist>,
@@ -155,7 +154,6 @@ impl Default for PlayerState {
             user_followed_artists: vec![],
             context_uri: "".to_owned(),
             context_cache: lru::LruCache::new(64),
-            search_cache: lru::LruCache::new(64),
             playback: None,
             playback_last_updated: None,
         }

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -231,15 +231,19 @@ impl WindowState {
 
 impl Focusable for WindowState {
     fn next(&mut self) {
-        if let Self::Artist(_, _, _, artist) = self {
-            artist.next()
-        };
+        match self {
+            Self::Artist(_, _, _, focus) => focus.next(),
+            Self::Search(_, _, _, _, focus) => focus.next(),
+            _ => {}
+        }
     }
 
     fn previous(&mut self) {
-        if let Self::Artist(_, _, _, artist) = self {
-            artist.previous()
-        };
+        match self {
+            Self::Artist(_, _, _, focus) => focus.previous(),
+            Self::Search(_, _, _, _, focus) => focus.previous(),
+            _ => {}
+        }
     }
 }
 
@@ -270,4 +274,12 @@ impl_focusable!(
     [TopTracks, Albums],
     [Albums, RelatedArtists],
     [RelatedArtists, TopTracks]
+);
+
+impl_focusable!(
+    SearchFocusState,
+    [Tracks, Albums],
+    [Albums, Artists],
+    [Artists, Playlists],
+    [Playlists, Tracks]
 );

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -26,7 +26,7 @@ pub struct UIState {
 pub enum PageState {
     CurrentPlaying,
     Browsing(String),
-    Searching(String),
+    Searching(String, SearchResults),
 }
 
 /// Window state

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -26,6 +26,7 @@ pub struct UIState {
 pub enum PageState {
     CurrentPlaying,
     Browsing(String),
+    Searching(String),
 }
 
 /// Window state
@@ -38,6 +39,8 @@ pub enum WindowState {
     Album(TableState),
     // top tracks, albums, related artists
     Artist(TableState, ListState, ListState, ArtistFocusState),
+    // tracks, albums, artists, playlists
+    Search(ListState, ListState, ListState, ListState, SearchFocusState),
 }
 
 /// Popup state
@@ -66,6 +69,15 @@ pub enum ArtistFocusState {
     TopTracks,
     Albums,
     RelatedArtists,
+}
+
+/// Search Focus state
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SearchFocusState {
+    Tracks,
+    Albums,
+    Artists,
+    Playlists,
 }
 
 impl UIState {

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -26,7 +26,7 @@ pub struct UIState {
 pub enum PageState {
     CurrentPlaying,
     Browsing(String),
-    Searching(String, SearchResults),
+    Searching(String, Box<SearchResults>),
 }
 
 /// Window state

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -74,6 +74,7 @@ pub enum ArtistFocusState {
 /// Search Focus state
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SearchFocusState {
+    Input,
     Tracks,
     Albums,
     Artists,
@@ -185,6 +186,7 @@ impl WindowState {
                 ref mut playlists,
                 ref focus,
             ) => match focus {
+                SearchFocusState::Input => {}
                 SearchFocusState::Tracks => tracks.select(id),
                 SearchFocusState::Albums => albums.select(id),
                 SearchFocusState::Artists => artists.select(id),
@@ -211,6 +213,7 @@ impl WindowState {
             Self::Unknown => None,
             Self::Search(ref tracks, ref albums, ref artists, ref playlists, ref focus) => {
                 match focus {
+                    &SearchFocusState::Input => None,
                     SearchFocusState::Tracks => tracks.selected(),
                     SearchFocusState::Albums => albums.selected(),
                     SearchFocusState::Artists => artists.selected(),
@@ -278,8 +281,9 @@ impl_focusable!(
 
 impl_focusable!(
     SearchFocusState,
+    [Input, Tracks],
     [Tracks, Albums],
     [Albums, Artists],
     [Artists, Playlists],
-    [Playlists, Tracks]
+    [Playlists, Input]
 );

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -33,13 +33,13 @@ pub enum PageState {
 #[derive(Debug)]
 pub enum WindowState {
     Unknown,
-    // tracks
+    /// tracks
     Playlist(TableState),
-    // tracks
+    /// tracks
     Album(TableState),
-    // top tracks, albums, related artists
+    /// top tracks, albums, related artists
     Artist(TableState, ListState, ListState, ArtistFocusState),
-    // tracks, albums, artists, playlists
+    /// tracks, albums, artists, playlists
     Search(ListState, ListState, ListState, ListState, SearchFocusState),
 }
 
@@ -167,10 +167,10 @@ impl WindowState {
     /// gets the state of the context track table
     pub fn get_track_table_state(&mut self) -> Option<&mut TableState> {
         match self {
-            Self::Unknown => None,
             Self::Playlist(ref mut state) => Some(state),
             Self::Album(ref mut state) => Some(state),
             Self::Artist(ref mut top_tracks, _, _, _) => Some(top_tracks),
+            _ => None,
         }
     }
 
@@ -178,6 +178,18 @@ impl WindowState {
     pub fn select(&mut self, id: Option<usize>) {
         match self {
             Self::Unknown => {}
+            Self::Search(
+                ref mut tracks,
+                ref mut albums,
+                ref mut artists,
+                ref mut playlists,
+                ref focus,
+            ) => match focus {
+                SearchFocusState::Tracks => tracks.select(id),
+                SearchFocusState::Albums => albums.select(id),
+                SearchFocusState::Artists => artists.select(id),
+                SearchFocusState::Playlists => playlists.select(id),
+            },
             Self::Playlist(ref mut state) => state.select(id),
             Self::Album(ref mut state) => state.select(id),
             Self::Artist(
@@ -197,6 +209,14 @@ impl WindowState {
     pub fn selected(&self) -> Option<usize> {
         match self {
             Self::Unknown => None,
+            Self::Search(ref tracks, ref albums, ref artists, ref playlists, ref focus) => {
+                match focus {
+                    SearchFocusState::Tracks => tracks.selected(),
+                    SearchFocusState::Albums => albums.selected(),
+                    SearchFocusState::Artists => artists.selected(),
+                    SearchFocusState::Playlists => playlists.selected(),
+                }
+            }
             Self::Playlist(ref state) => state.selected(),
             Self::Album(ref state) => state.selected(),
             Self::Artist(ref top_tracks, ref albums, ref related_artists, ref focus) => match focus

--- a/spotify_player/src/ui/context.rs
+++ b/spotify_player/src/ui/context.rs
@@ -12,15 +12,19 @@ pub fn render_context_window(
     ui: &mut UIStateGuard,
     state: &SharedState,
     rect: Rect,
-    block: Block,
+    title: &str,
 ) {
+    let block = Block::default()
+        .title(ui.theme.block_title_with_style(title))
+        .borders(Borders::ALL);
+
     let player = state.player.read().unwrap();
 
     match player.get_context() {
         Some(context) => {
             frame.render_widget(block, rect);
 
-            // context description
+            // render context description
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(1)

--- a/spotify_player/src/ui/context.rs
+++ b/spotify_player/src/ui/context.rs
@@ -1,25 +1,20 @@
-use std::sync::RwLockReadGuard;
-
 use super::Frame;
 use crate::{state::*, ui::construct_list_widget, utils};
+use std::sync::RwLockReadGuard;
 use tui::{layout::*, style::*, widgets::*};
 
-pub fn render_context_widget(
+/// renders the context window which can be
+/// - Current Playing: display the playing context of the current track
+/// - Browsing: display the context of an arbitrary context
+pub fn render_context_window(
     is_active: bool,
     frame: &mut Frame,
     ui: &mut UIStateGuard,
     state: &SharedState,
     rect: Rect,
+    block: Block,
 ) {
     let player = state.player.read().unwrap();
-    // context widget box border
-    let context_block_title = match ui.page {
-        PageState::CurrentPlaying => "Context (Current Playing)",
-        PageState::Browsing(_) => "Context (Browsing)",
-    };
-    let block = Block::default()
-        .title(ui.theme.block_title_with_style(context_block_title))
-        .borders(Borders::ALL);
 
     match player.get_context() {
         Some(context) => {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -60,49 +60,11 @@ fn clean_up(mut terminal: Terminal) -> Result<()> {
 
 /// renders the application
 fn render_application(frame: &mut Frame, mut ui: UIStateGuard, state: &SharedState, rect: Rect) {
-    let rect = render_shortcut_help_window(frame, &ui, state, rect);
+    let rect = help::render_shortcut_help_window(frame, &ui, state, rect);
 
     let (rect, is_active) = popup::render_popup(frame, &mut ui, state, rect);
 
     render_main_layout(is_active, frame, &mut ui, state, rect);
-}
-
-/// renders a shortcut help window to show the available shortcuts
-/// based on user's inputs
-fn render_shortcut_help_window(
-    frame: &mut Frame,
-    ui: &UIStateGuard,
-    state: &SharedState,
-    rect: Rect,
-) -> Rect {
-    let input = &ui.input_key_sequence;
-    // render the shortcuts help table if needed
-    let matches = if input.keys.is_empty() {
-        vec![]
-    } else {
-        state
-            .keymap_config
-            .find_matched_prefix_keymaps(input)
-            .into_iter()
-            .map(|keymap| {
-                let mut keymap = keymap.clone();
-                keymap.key_sequence.keys.drain(0..input.keys.len());
-                keymap
-            })
-            .filter(|keymap| !keymap.key_sequence.keys.is_empty())
-            .collect::<Vec<_>>()
-    };
-
-    if matches.is_empty() {
-        rect
-    } else {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(0), Constraint::Length(7)].as_ref())
-            .split(rect);
-        help::render_shortcuts_help_widget(matches, frame, ui, chunks[1]);
-        chunks[0]
-    }
 }
 
 /// renders the application's main layout which consists of:

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -85,16 +85,24 @@ fn render_main_layout(
 
     match ui.page {
         PageState::CurrentPlaying => {
-            let block = Block::default()
-                .title(ui.theme.block_title_with_style("Context (Current Playing)"))
-                .borders(Borders::ALL);
-            context::render_context_window(is_active, frame, ui, state, chunks[1], block);
+            context::render_context_window(
+                is_active,
+                frame,
+                ui,
+                state,
+                chunks[1],
+                "Context (Current Playing)",
+            );
         }
         PageState::Browsing(_) => {
-            let block = Block::default()
-                .title(ui.theme.block_title_with_style("Context (Browsing)"))
-                .borders(Borders::ALL);
-            context::render_context_window(is_active, frame, ui, state, chunks[1], block);
+            context::render_context_window(
+                is_active,
+                frame,
+                ui,
+                state,
+                chunks[1],
+                "Context (Browsing)",
+            );
         }
         PageState::Searching(_) => {
             search::render_search_window(is_active, frame, ui, state, chunks[1]);

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -112,7 +112,7 @@ fn render_main_layout(
 
 /// renders a playback window showing information about the current playback such as
 /// - track title, artists, album
-/// - playback metadata (playing state, repeat state, shuffle state, volume, etc)
+/// - playback metadata (playing state, repeat state, shuffle state, volume, device, etc)
 fn render_playback_window(
     frame: &mut Frame,
     ui: &mut UIStateGuard,
@@ -152,10 +152,11 @@ fn render_playback_window(
                 Span::styled(track.album.name.to_string(), ui.theme.playback_album()).into(),
                 Span::styled(
                     format!(
-                        "repeat: {} | shuffle: {} | volume: {}%",
+                        "repeat: {} | shuffle: {} | volume: {}% | device: {}",
                         playback.repeat_state.as_str(),
                         playback.shuffle_state,
                         playback.device.volume_percent,
+                        playback.device.name,
                     ),
                     ui.theme.playback_metadata(),
                 )

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -200,7 +200,10 @@ fn construct_list_widget<'a>(
     items: Vec<(String, bool)>,
     title: &str,
     is_active: bool,
+    borders: Option<Borders>,
 ) -> List<'a> {
+    let borders = borders.unwrap_or(Borders::ALL);
+
     List::new(
         items
             .into_iter()
@@ -217,6 +220,6 @@ fn construct_list_widget<'a>(
     .block(
         Block::default()
             .title(ui.theme.block_title_with_style(title))
-            .borders(Borders::ALL),
+            .borders(borders),
     )
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -104,8 +104,8 @@ fn render_main_layout(
                 "Context (Browsing)",
             );
         }
-        PageState::Searching(_) => {
-            search::render_search_window(is_active, frame, ui, state, chunks[1]);
+        PageState::Searching(..) => {
+            search::render_search_window(is_active, frame, ui, chunks[1]);
         }
     };
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -193,3 +193,30 @@ fn render_current_playback_widget(
         }
     };
 }
+
+/// constructs a generic list widget
+fn construct_list_widget<'a>(
+    ui: &UIStateGuard,
+    items: Vec<(String, bool)>,
+    title: &str,
+    is_active: bool,
+) -> List<'a> {
+    List::new(
+        items
+            .into_iter()
+            .map(|(s, is_active)| {
+                ListItem::new(s).style(if is_active {
+                    ui.theme.current_active()
+                } else {
+                    Style::default()
+                })
+            })
+            .collect::<Vec<_>>(),
+    )
+    .highlight_style(ui.theme.selection_style(is_active))
+    .block(
+        Block::default()
+            .title(ui.theme.block_title_with_style(title))
+            .borders(Borders::ALL),
+    )
+}

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -1,4 +1,4 @@
-use super::{help, Frame};
+use super::{construct_list_widget, help, Frame};
 use crate::state::*;
 use tui::{layout::*, style::*, widgets::*};
 
@@ -17,6 +17,7 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(7), Constraint::Min(0)].as_ref())
                 .split(rect);
+
             help::render_commands_help_widget(frame, ui, state, chunks[1]);
             (chunks[0], false)
         }
@@ -25,22 +26,20 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(5)].as_ref())
                 .split(rect);
-            frame.render_stateful_widget(
-                {
-                    let current_device_id = match player.playback {
-                        Some(ref playback) => &playback.device.id,
-                        None => "",
-                    };
-                    let items = player
-                        .devices
-                        .iter()
-                        .map(|d| (format!("{} | {}", d.name, d.id), current_device_id == d.id))
-                        .collect();
-                    construct_list_widget(ui, items, "Devices")
-                },
-                chunks[1],
-                ui.popup.get_list_state_mut().unwrap(),
-            );
+            let widget = {
+                let current_device_id = match player.playback {
+                    Some(ref playback) => &playback.device.id,
+                    None => "",
+                };
+                let items = player
+                    .devices
+                    .iter()
+                    .map(|d| (format!("{} | {}", d.name, d.id), current_device_id == d.id))
+                    .collect();
+                construct_list_widget(ui, items, "Devices", true)
+            };
+
+            frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
             (chunks[0], false)
         }
         PopupState::ThemeList(ref themes, _) => {
@@ -48,14 +47,12 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(7)].as_ref())
                 .split(rect);
-            frame.render_stateful_widget(
-                {
-                    let items = themes.iter().map(|t| (t.name.clone(), false)).collect();
-                    construct_list_widget(ui, items, "Themes")
-                },
-                chunks[1],
-                ui.popup.get_list_state_mut().unwrap(),
-            );
+            let widget = {
+                let items = themes.iter().map(|t| (t.name.clone(), false)).collect();
+                construct_list_widget(ui, items, "Themes", true)
+            };
+
+            frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
             (chunks[0], false)
         }
         PopupState::UserPlaylistList(_) => {
@@ -63,18 +60,16 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(10)].as_ref())
                 .split(rect);
-            frame.render_stateful_widget(
-                {
-                    let items = player
-                        .user_playlists
-                        .iter()
-                        .map(|p| (p.name.clone(), false))
-                        .collect();
-                    construct_list_widget(ui, items, "User Playlists")
-                },
-                chunks[1],
-                ui.popup.get_list_state_mut().unwrap(),
-            );
+            let widget = {
+                let items = player
+                    .user_playlists
+                    .iter()
+                    .map(|p| (p.name.clone(), false))
+                    .collect();
+                construct_list_widget(ui, items, "User Playlists", true)
+            };
+
+            frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
             (chunks[0], false)
         }
         PopupState::UserFollowedArtistList(_) => {
@@ -82,18 +77,16 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(10)].as_ref())
                 .split(rect);
-            frame.render_stateful_widget(
-                {
-                    let items = player
-                        .user_followed_artists
-                        .iter()
-                        .map(|a| (a.name.clone(), false))
-                        .collect();
-                    construct_list_widget(ui, items, "User Followed Artists")
-                },
-                chunks[1],
-                ui.popup.get_list_state_mut().unwrap(),
-            );
+            let widget = {
+                let items = player
+                    .user_followed_artists
+                    .iter()
+                    .map(|a| (a.name.clone(), false))
+                    .collect();
+                construct_list_widget(ui, items, "User Followed Artists", true)
+            };
+
+            frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
             (chunks[0], false)
         }
         PopupState::UserSavedAlbumList(_) => {
@@ -101,18 +94,16 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(10)].as_ref())
                 .split(rect);
-            frame.render_stateful_widget(
-                {
-                    let items = player
-                        .user_saved_albums
-                        .iter()
-                        .map(|a| (a.name.clone(), false))
-                        .collect();
-                    construct_list_widget(ui, items, "User Saved Albums")
-                },
-                chunks[1],
-                ui.popup.get_list_state_mut().unwrap(),
-            );
+            let widget = {
+                let items = player
+                    .user_saved_albums
+                    .iter()
+                    .map(|a| (a.name.clone(), false))
+                    .collect();
+                construct_list_widget(ui, items, "User Saved Albums", true)
+            };
+
+            frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
             (chunks[0], false)
         }
         PopupState::ArtistList(ref artists, _) => {
@@ -120,10 +111,11 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(5)].as_ref())
                 .split(rect);
+
             frame.render_stateful_widget(
                 {
                     let items = artists.iter().map(|a| (a.name.clone(), false)).collect();
-                    construct_list_widget(ui, items, "Artists")
+                    construct_list_widget(ui, items, "Artists", true)
                 },
                 chunks[1],
                 ui.popup.get_list_state_mut().unwrap(),
@@ -135,6 +127,7 @@ pub fn render_popup(
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(0), Constraint::Length(3)].as_ref())
                 .split(rect);
+
             render_search_box_widget(frame, ui, chunks[1], format!("/{}", query));
             (chunks[0], true)
         }
@@ -148,29 +141,4 @@ fn render_search_box_widget(frame: &mut Frame, ui: &UIStateGuard, rect: Rect, qu
             .title(ui.theme.block_title_with_style("Search")),
     );
     frame.render_widget(search_box, rect);
-}
-
-fn construct_list_widget<'a>(
-    ui: &UIStateGuard,
-    items: Vec<(String, bool)>,
-    title: &str,
-) -> List<'a> {
-    List::new(
-        items
-            .into_iter()
-            .map(|(s, is_active)| {
-                ListItem::new(s).style(if is_active {
-                    ui.theme.current_active()
-                } else {
-                    Style::default()
-                })
-            })
-            .collect::<Vec<_>>(),
-    )
-    .highlight_style(ui.theme.selection_style(true))
-    .block(
-        Block::default()
-            .title(ui.theme.block_title_with_style(title))
-            .borders(Borders::ALL),
-    )
 }

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -36,7 +36,7 @@ pub fn render_popup(
                     .iter()
                     .map(|d| (format!("{} | {}", d.name, d.id), current_device_id == d.id))
                     .collect();
-                construct_list_widget(ui, items, "Devices", true)
+                construct_list_widget(ui, items, "Devices", true, None)
             };
 
             frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
@@ -49,7 +49,7 @@ pub fn render_popup(
                 .split(rect);
             let widget = {
                 let items = themes.iter().map(|t| (t.name.clone(), false)).collect();
-                construct_list_widget(ui, items, "Themes", true)
+                construct_list_widget(ui, items, "Themes", true, None)
             };
 
             frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
@@ -66,7 +66,7 @@ pub fn render_popup(
                     .iter()
                     .map(|p| (p.name.clone(), false))
                     .collect();
-                construct_list_widget(ui, items, "User Playlists", true)
+                construct_list_widget(ui, items, "User Playlists", true, None)
             };
 
             frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
@@ -83,7 +83,7 @@ pub fn render_popup(
                     .iter()
                     .map(|a| (a.name.clone(), false))
                     .collect();
-                construct_list_widget(ui, items, "User Followed Artists", true)
+                construct_list_widget(ui, items, "User Followed Artists", true, None)
             };
 
             frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
@@ -100,7 +100,7 @@ pub fn render_popup(
                     .iter()
                     .map(|a| (a.name.clone(), false))
                     .collect();
-                construct_list_widget(ui, items, "User Saved Albums", true)
+                construct_list_widget(ui, items, "User Saved Albums", true, None)
             };
 
             frame.render_stateful_widget(widget, chunks[1], ui.popup.get_list_state_mut().unwrap());
@@ -115,7 +115,7 @@ pub fn render_popup(
             frame.render_stateful_widget(
                 {
                     let items = artists.iter().map(|a| (a.name.clone(), false)).collect();
-                    construct_list_widget(ui, items, "Artists", true)
+                    construct_list_widget(ui, items, "Artists", true, None)
                 },
                 chunks[1],
                 ui.popup.get_list_state_mut().unwrap(),

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -1,6 +1,6 @@
 use super::{construct_list_widget, help, Frame};
 use crate::state::*;
-use tui::{layout::*, style::*, widgets::*};
+use tui::{layout::*, widgets::*};
 
 /// renders a popup to handle a command or show additional information
 /// depending on the current popup state
@@ -19,7 +19,7 @@ pub fn render_popup(
                 .constraints([Constraint::Length(7), Constraint::Min(0)].as_ref())
                 .split(rect);
 
-            help::render_commands_help_widget(frame, ui, state, chunks[1]);
+            help::render_commands_help_window(frame, ui, state, chunks[1]);
             (chunks[0], false)
         }
         PopupState::DeviceList(_) => {

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -2,13 +2,14 @@ use super::{construct_list_widget, help, Frame};
 use crate::state::*;
 use tui::{layout::*, style::*, widgets::*};
 
+/// renders a popup to handle a command or show additional information
+/// depending on the current popup state
 pub fn render_popup(
     frame: &mut Frame,
     ui: &mut UIStateGuard,
     state: &SharedState,
     rect: Rect,
 ) -> (Rect, bool) {
-    // handle popup windows
     let player = state.player.read().unwrap();
     match ui.popup {
         PopupState::None => (rect, true),
@@ -128,13 +129,13 @@ pub fn render_popup(
                 .constraints([Constraint::Min(0), Constraint::Length(3)].as_ref())
                 .split(rect);
 
-            render_search_box_widget(frame, ui, chunks[1], format!("/{}", query));
+            render_context_search_box(frame, ui, chunks[1], format!("/{}", query));
             (chunks[0], true)
         }
     }
 }
 
-fn render_search_box_widget(frame: &mut Frame, ui: &UIStateGuard, rect: Rect, query: String) {
+fn render_context_search_box(frame: &mut Frame, ui: &UIStateGuard, rect: Rect, query: String) {
     let search_box = Paragraph::new(query).block(
         Block::default()
             .borders(Borders::ALL)

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -22,11 +22,10 @@ pub fn render_search_window(
 
     let player = state.player.read().unwrap();
     // gets the search results from the query
+    let empty_results = SearchResults::empty();
     let search_results = match player.search_cache.peek(query) {
         Some(search_results) => search_results,
-        None => {
-            return;
-        }
+        None => &empty_results,
     };
 
     let focus_state = match ui.window {

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -31,9 +31,6 @@ pub fn render_search_window(
     let focus_state = match ui.window {
         WindowState::Search(_, _, _, _, focus) => focus,
         _ => {
-            // `WindowState` and `PageState` can be updated independently
-            // and therefore having unmatching data.
-            // So should not use `unreachable!()` for this match
             return;
         }
     };
@@ -120,7 +117,12 @@ pub fn render_search_window(
             .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
             .split(rect);
 
-        frame.render_widget(Paragraph::new(query.clone()), chunks[0]);
+        let is_active = is_active && focus_state == SearchFocusState::Input;
+
+        frame.render_widget(
+            Paragraph::new(query.clone()).style(ui.theme.selection_style(is_active)),
+            chunks[0],
+        );
 
         chunks[1]
     };

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -40,7 +40,7 @@ pub fn render_search_window(
             .tracks
             .items
             .iter()
-            .map(|a| (a.name.clone(), false))
+            .map(|a| (format!("{} - {}", a.name, a.get_artists_info()), false))
             .collect::<Vec<_>>();
 
         construct_list_widget(

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -113,10 +113,22 @@ pub fn render_search_window(
         .borders(Borders::ALL);
     frame.render_widget(block, rect);
 
+    // renders the query input box
+    let rect = {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
+            .split(rect);
+
+        frame.render_widget(Paragraph::new(query.clone()), chunks[0]);
+
+        chunks[1]
+    };
+
     // split the given `rect` layout into a 2x2 layout consiting of 4 chunks
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(1)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
         .split(rect)
         .into_iter()

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -7,25 +7,11 @@ use {tui::layout::*, tui::widgets::*};
 ///
 /// # Panic
 /// This function will panic if the current UI's `PageState` is not `PageState::Searching`
-pub fn render_search_window(
-    is_active: bool,
-    frame: &mut Frame,
-    ui: &mut UIStateGuard,
-    state: &SharedState,
-    rect: Rect,
-) {
+pub fn render_search_window(is_active: bool, frame: &mut Frame, ui: &mut UIStateGuard, rect: Rect) {
     // gets the search query from UI's `PageState`
-    let query = match ui.page {
-        PageState::Searching(ref query) => query,
+    let (query, search_results) = match ui.page {
+        PageState::Searching(ref query, ref search_results) => (query, search_results),
         _ => unreachable!(),
-    };
-
-    let player = state.player.read().unwrap();
-    // gets the search results from the query
-    let empty_results = SearchResults::empty();
-    let search_results = match player.search_cache.peek(query) {
-        Some(search_results) => search_results,
-        None => &empty_results,
     };
 
     let focus_state = match ui.window {

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -52,7 +52,7 @@ pub fn render_search_window(
             track_items,
             "Tracks",
             is_active && focus_state == SearchFocusState::Tracks,
-            Some(Borders::TOP),
+            Some(Borders::TOP | Borders::RIGHT),
         )
     };
 
@@ -86,7 +86,7 @@ pub fn render_search_window(
             artist_items,
             "Artists",
             is_active && focus_state == SearchFocusState::Artists,
-            Some(Borders::TOP),
+            Some(Borders::TOP | Borders::RIGHT),
         )
     };
 
@@ -107,9 +107,16 @@ pub fn render_search_window(
         )
     };
 
+    // renders borders with title
+    let block = Block::default()
+        .title(ui.theme.block_title_with_style("Search"))
+        .borders(Borders::ALL);
+    frame.render_widget(block, rect);
+
     // split the given `rect` layout into a 2x2 layout consiting of 4 chunks
     let chunks = Layout::default()
         .direction(Direction::Vertical)
+        .margin(1)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
         .split(rect)
         .into_iter()

--- a/spotify_player/src/ui/search.rs
+++ b/spotify_player/src/ui/search.rs
@@ -1,0 +1,146 @@
+use super::Frame;
+use crate::{state::*, ui::construct_list_widget};
+use {tui::layout::*, tui::widgets::*};
+
+/// renders the search window showing the search results
+/// of Spotify items (tracks, artists, albums, playlists) that match a given query
+///
+/// # Panic
+/// This function will panic if the current UI's `PageState` is not `PageState::Searching`
+pub fn render_search_window(
+    is_active: bool,
+    frame: &mut Frame,
+    ui: &mut UIStateGuard,
+    state: &SharedState,
+    rect: Rect,
+) {
+    // gets the search query from UI's `PageState`
+    let query = match ui.page {
+        PageState::Searching(ref query) => query,
+        _ => unreachable!(),
+    };
+
+    let player = state.player.read().unwrap();
+    // gets the search results from the query
+    let search_results = match player.search_cache.peek(query) {
+        Some(search_results) => search_results,
+        None => {
+            return;
+        }
+    };
+
+    let focus_state = match ui.window {
+        WindowState::Search(_, _, _, _, focus) => focus,
+        _ => {
+            // `WindowState` and `PageState` can be updated independently
+            // and therefore having unmatching data.
+            // So should not use `unreachable!()` for this match
+            return;
+        }
+    };
+
+    let tracks_list = {
+        let track_items = search_results
+            .tracks
+            .items
+            .iter()
+            .map(|a| (a.name.clone(), false))
+            .collect::<Vec<_>>();
+
+        construct_list_widget(
+            ui,
+            track_items,
+            "Tracks",
+            is_active && focus_state == SearchFocusState::Tracks,
+            Some(Borders::TOP),
+        )
+    };
+
+    let albums_list = {
+        let album_items = search_results
+            .albums
+            .items
+            .iter()
+            .map(|a| (a.name.clone(), false))
+            .collect::<Vec<_>>();
+
+        construct_list_widget(
+            ui,
+            album_items,
+            "Albums",
+            is_active && focus_state == SearchFocusState::Albums,
+            Some(Borders::TOP),
+        )
+    };
+
+    let artists_list = {
+        let artist_items = search_results
+            .artists
+            .items
+            .iter()
+            .map(|a| (a.name.clone(), false))
+            .collect::<Vec<_>>();
+
+        construct_list_widget(
+            ui,
+            artist_items,
+            "Artists",
+            is_active && focus_state == SearchFocusState::Artists,
+            Some(Borders::TOP),
+        )
+    };
+
+    let playlists_list = {
+        let playlist_items = search_results
+            .playlists
+            .items
+            .iter()
+            .map(|a| (a.name.clone(), false))
+            .collect::<Vec<_>>();
+
+        construct_list_widget(
+            ui,
+            playlist_items,
+            "Playlists",
+            is_active && focus_state == SearchFocusState::Playlists,
+            Some(Borders::TOP),
+        )
+    };
+
+    // split the given `rect` layout into a 2x2 layout consiting of 4 chunks
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+        .split(rect)
+        .into_iter()
+        .flat_map(|rect| {
+            Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                .split(rect)
+        })
+        .collect::<Vec<_>>();
+
+    // get the list states inside the UI's `WindowState` to render the search window's sub-windows
+    let (tracks_list_state, albums_list_state, artists_list_state, playlists_list_state) =
+        match ui.window {
+            WindowState::Search(
+                ref mut tracks_list_state,
+                ref mut albums_list_state,
+                ref mut artists_list_state,
+                ref mut playlists_list_state,
+                _,
+            ) => (
+                tracks_list_state,
+                albums_list_state,
+                artists_list_state,
+                playlists_list_state,
+            ),
+            _ => unreachable!(),
+        };
+
+    frame.render_stateful_widget(tracks_list, chunks[0], tracks_list_state);
+    frame.render_stateful_widget(albums_list, chunks[1], albums_list_state);
+    frame.render_stateful_widget(artists_list, chunks[2], artists_list_state);
+    frame.render_stateful_widget(playlists_list, chunks[3], playlists_list_state);
+}

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -65,7 +65,7 @@ pub fn update_context(state: &state::SharedState, context_uri: String) {
                     let mut ui = state.ui.lock().unwrap();
                     // update the UI's context state based on the player's context state
                     match context {
-                        state::Context::Artist(_, _, _, _) => {
+                        state::Context::Artist(..) => {
                             ui.window = WindowState::Artist(
                                 new_table_state(),
                                 new_list_state(),
@@ -73,10 +73,10 @@ pub fn update_context(state: &state::SharedState, context_uri: String) {
                                 ArtistFocusState::TopTracks,
                             );
                         }
-                        state::Context::Album(_, _) => {
+                        state::Context::Album(..) => {
                             ui.window = WindowState::Album(new_table_state());
                         }
-                        state::Context::Playlist(_, _) => {
+                        state::Context::Playlist(..) => {
                             ui.window = WindowState::Playlist(new_table_state());
                         }
                         state::Context::Unknown(_) => {


### PR DESCRIPTION
# Brief description of changes
- added `SearchResults` representing returned data when searching
- added `ui/search.rs` including handling logics for rendering the search page
- implemented client's `search` function
- separated handling logics for search window's commands and context window's commands
- added command handler functions for sub windows (track, album, artist, playlist lists) of the search page
- added `EnterSearchPage` command for entering the search page
- other code refactors