### PR TITLE
Use non-blocking implementation for client request handler

### DIFF
--- a/spotify_player/src/client.rs
+++ b/spotify_player/src/client.rs
@@ -24,7 +24,7 @@ impl Client {
 
     /// handles a player request
     fn handle_player_request(&self, state: &SharedState, event: PlayerRequest) -> Result<()> {
-        log::info!("handle player event: {:?}", event);
+        log::info!("handle player request: {:?}", event);
 
         let player = state.player.read().unwrap();
         let playback = match player.playback {
@@ -52,17 +52,12 @@ impl Client {
 
     /// handles a client request
     pub async fn handle_request(
-        &mut self,
+        &self,
         state: &SharedState,
         send: &std::sync::mpsc::Sender<ClientRequest>,
         request: ClientRequest,
     ) -> Result<()> {
-        log::info!("handle the client event {:?}", request);
-
-        // use the authentication token stored inside the player state
-        // for making API calls to Spotify
-        self.spotify.access_token =
-            Some(state.player.read().unwrap().token.access_token.to_owned());
+        log::info!("handle the client request {:?}", request);
 
         match request {
             ClientRequest::Player(event) => {
@@ -561,6 +556,11 @@ pub async fn start_client_handler(
     recv: std::sync::mpsc::Receiver<ClientRequest>,
 ) {
     while let Ok(request) = recv.recv() {
+        // use the authentication token stored inside the player state
+        // for making API calls to Spotify
+        client.spotify.access_token =
+            Some(state.player.read().unwrap().token.access_token.to_owned());
+
         if let Err(err) = client.handle_request(&state, &send, request).await {
             log::warn!("{:#?}", err);
         }

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -20,8 +20,8 @@ pub enum ContextURI {
 }
 
 #[derive(Debug)]
-/// An event that modifies the player's playback
-pub enum PlayerEvent {
+/// A request that modifies the player's playback
+pub enum PlayerRequest {
     NextTrack,
     PreviousTrack,
     ResumePause,
@@ -30,20 +30,19 @@ pub enum PlayerEvent {
     Shuffle,
     Volume(u8),
     PlayTrack(Option<String>, Option<Vec<String>>, Option<offset::Offset>),
+    TransferPlayback(String, bool),
 }
 
 #[derive(Debug)]
-/// An event to communicate with the client
-/// TODO: renaming this enum (e.g to `ClientRequest`)
-pub enum Event {
+/// A request to the client
+pub enum ClientRequest {
     GetDevices,
     GetUserPlaylists,
     GetUserSavedAlbums,
     GetUserFollowedArtists,
     GetContext(ContextURI),
     GetCurrentPlayback,
-    TransferPlayback(String, bool),
-    Player(PlayerEvent),
+    Player(PlayerRequest),
 }
 
 impl From<event::KeyEvent> for Key {
@@ -59,8 +58,8 @@ impl From<event::KeyEvent> for Key {
 }
 
 #[tokio::main]
-/// starts a terminal event handler
-pub async fn start_event_handler(send: mpsc::Sender<Event>, state: SharedState) {
+/// starts a handler to handle terminal events (key pressed, mouse clicked, etc)
+pub async fn start_event_handler(send: mpsc::Sender<ClientRequest>, state: SharedState) {
     let mut event_stream = EventStream::new();
 
     while let Some(event) = event_stream.next().await {
@@ -80,7 +79,7 @@ pub async fn start_event_handler(send: mpsc::Sender<Event>, state: SharedState) 
 
 fn handle_terminal_event(
     event: event::Event,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<()> {
     let key: Key = match event {
@@ -137,7 +136,7 @@ fn handle_terminal_event(
                             _ => unreachable!(),
                         };
                         let uri = artists[id].uri.clone().unwrap();
-                        send.send(Event::GetContext(ContextURI::Artist(uri.clone())))?;
+                        send.send(ClientRequest::GetContext(ContextURI::Artist(uri.clone())))?;
 
                         let frame_state = PageState::Browsing(uri);
                         ui.history.push(frame_state.clone());
@@ -229,10 +228,10 @@ fn handle_terminal_event(
                         player.devices.len(),
                         |_: &mut UIStateGuard, _: usize| {},
                         |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                            send.send(Event::TransferPlayback(
+                            send.send(ClientRequest::Player(PlayerRequest::TransferPlayback(
                                 player.devices[id].id.clone(),
                                 true,
-                            ))?;
+                            )))?;
                             ui.popup = PopupState::None;
                             Ok(())
                         },
@@ -263,7 +262,7 @@ fn handle_terminal_event(
 
 fn handle_mouse_event(
     event: event::MouseEvent,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<()> {
     let ui = state.ui.lock().unwrap();
@@ -275,7 +274,7 @@ fn handle_mouse_event(
             if let Some(track) = track {
                 let position_ms =
                     track.duration_ms * (event.column as u32) / (ui.progress_bar_rect.width as u32);
-                send.send(Event::Player(PlayerEvent::SeekTrack(position_ms)))?;
+                send.send(ClientRequest::Player(PlayerRequest::SeekTrack(position_ms)))?;
             }
         }
     }
@@ -284,7 +283,7 @@ fn handle_mouse_event(
 
 fn handle_command_for_none_popup(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
@@ -309,7 +308,7 @@ fn handle_command_for_none_popup(
                             offset::for_uri(tracks[id].uri.clone())
                         }
                     };
-                    send.send(Event::Player(PlayerEvent::PlayTrack(
+                    send.send(ClientRequest::Player(PlayerRequest::PlayTrack(
                         Some(player.context_uri.clone()),
                         None,
                         offset,
@@ -371,7 +370,7 @@ fn handle_command_for_none_popup(
 
 fn handle_key_sequence_for_search_popup(
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
@@ -426,7 +425,7 @@ fn handle_key_sequence_for_search_popup(
 
 fn handle_command_for_uri_list_popup(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     uris: Vec<String>,
     base_uri: ContextURI,
@@ -443,7 +442,7 @@ fn handle_command_for_uri_list_popup(
                 ContextURI::Album(_) => ContextURI::Album(uri),
                 ContextURI::Unknown(_) => ContextURI::Unknown(uri),
             };
-            send.send(Event::GetContext(context_uri))?;
+            send.send(ClientRequest::GetContext(context_uri))?;
 
             let frame_state = PageState::Browsing(uris[id].clone());
             ui.history.push(frame_state.clone());
@@ -510,7 +509,7 @@ fn handle_command_for_command_help_popup(command: Command, ui: &mut UIStateGuard
 
 fn handle_command(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
@@ -520,36 +519,36 @@ fn handle_command(
             Ok(true)
         }
         Command::NextTrack => {
-            send.send(Event::Player(PlayerEvent::NextTrack))?;
+            send.send(ClientRequest::Player(PlayerRequest::NextTrack))?;
             Ok(true)
         }
         Command::PreviousTrack => {
-            send.send(Event::Player(PlayerEvent::PreviousTrack))?;
+            send.send(ClientRequest::Player(PlayerRequest::PreviousTrack))?;
             Ok(true)
         }
         Command::ResumePause => {
-            send.send(Event::Player(PlayerEvent::ResumePause))?;
+            send.send(ClientRequest::Player(PlayerRequest::ResumePause))?;
             Ok(true)
         }
         Command::Repeat => {
-            send.send(Event::Player(PlayerEvent::Repeat))?;
+            send.send(ClientRequest::Player(PlayerRequest::Repeat))?;
             Ok(true)
         }
         Command::Shuffle => {
-            send.send(Event::Player(PlayerEvent::Shuffle))?;
+            send.send(ClientRequest::Player(PlayerRequest::Shuffle))?;
             Ok(true)
         }
         Command::VolumeUp => {
             if let Some(ref playback) = state.player.read().unwrap().playback {
                 let volume = std::cmp::min(playback.device.volume_percent + 5, 100_u32);
-                send.send(Event::Player(PlayerEvent::Volume(volume as u8)))?;
+                send.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
             }
             Ok(true)
         }
         Command::VolumeDown => {
             if let Some(ref playback) = state.player.read().unwrap().playback {
                 let volume = std::cmp::max(playback.device.volume_percent as i32 - 5, 0_i32);
-                send.send(Event::Player(PlayerEvent::Volume(volume as u8)))?;
+                send.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
             }
             Ok(true)
         }
@@ -558,7 +557,7 @@ fn handle_command(
             Ok(true)
         }
         Command::RefreshPlayback => {
-            send.send(Event::GetCurrentPlayback)?;
+            send.send(ClientRequest::GetCurrentPlayback)?;
             Ok(true)
         }
         Command::BrowsePlayingContext => {
@@ -569,7 +568,7 @@ fn handle_command(
         Command::BrowsePlayingTrackAlbum => {
             if let Some(track) = state.player.read().unwrap().get_current_playing_track() {
                 if let Some(ref uri) = track.album.uri {
-                    send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
+                    send.send(ClientRequest::GetContext(ContextURI::Album(uri.clone())))?;
                     let frame_state = PageState::Browsing(uri.clone());
                     ui.history.push(frame_state.clone());
                     ui.page = frame_state;
@@ -594,17 +593,17 @@ fn handle_command(
             Ok(true)
         }
         Command::BrowseUserPlaylists => {
-            send.send(Event::GetUserPlaylists)?;
+            send.send(ClientRequest::GetUserPlaylists)?;
             ui.popup = PopupState::UserPlaylistList(utils::new_list_state());
             Ok(true)
         }
         Command::BrowseUserFollowedArtists => {
-            send.send(Event::GetUserFollowedArtists)?;
+            send.send(ClientRequest::GetUserFollowedArtists)?;
             ui.popup = PopupState::UserFollowedArtistList(utils::new_list_state());
             Ok(true)
         }
         Command::BrowseUserSavedAlbums => {
-            send.send(Event::GetUserSavedAlbums)?;
+            send.send(ClientRequest::GetUserSavedAlbums)?;
             ui.popup = PopupState::UserSavedAlbumList(utils::new_list_state());
             Ok(true)
         }
@@ -617,7 +616,7 @@ fn handle_command(
         }
         Command::SwitchDevice => {
             ui.popup = PopupState::DeviceList(utils::new_list_state());
-            send.send(Event::GetDevices)?;
+            send.send(ClientRequest::GetDevices)?;
             Ok(true)
         }
         Command::SwitchTheme => {
@@ -630,7 +629,7 @@ fn handle_command(
 
 fn handle_command_for_focused_context_window(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     state: &SharedState,
 ) -> Result<bool> {
@@ -682,7 +681,7 @@ fn handle_command_for_focused_context_window(
 
 fn handle_command_for_artist_list(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     artists: &[Artist],
 ) -> Result<bool> {
@@ -708,7 +707,7 @@ fn handle_command_for_artist_list(
         Command::ChooseSelected => {
             if let Some(id) = ui.window.selected() {
                 let uri = artists[id].uri.clone().unwrap();
-                send.send(Event::GetContext(ContextURI::Artist(uri.clone())))?;
+                send.send(ClientRequest::GetContext(ContextURI::Artist(uri.clone())))?;
                 let frame_state = PageState::Browsing(uri);
                 ui.history.push(frame_state.clone());
                 ui.page = frame_state;
@@ -721,7 +720,7 @@ fn handle_command_for_artist_list(
 
 fn handle_command_for_album_list(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     albums: &[Album],
 ) -> Result<bool> {
@@ -747,7 +746,7 @@ fn handle_command_for_album_list(
         Command::ChooseSelected => {
             if let Some(id) = ui.window.selected() {
                 let uri = albums[id].uri.clone().unwrap();
-                send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
+                send.send(ClientRequest::GetContext(ContextURI::Album(uri.clone())))?;
                 let frame_state = PageState::Browsing(uri);
                 ui.history.push(frame_state.clone());
                 ui.page = frame_state;
@@ -760,7 +759,7 @@ fn handle_command_for_album_list(
 
 fn handle_command_for_track_table(
     command: Command,
-    send: &mpsc::Sender<Event>,
+    send: &mpsc::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     context_uri: Option<String>,
     track_uris: Option<Vec<String>>,
@@ -789,14 +788,14 @@ fn handle_command_for_track_table(
             if let Some(id) = ui.window.selected() {
                 if track_uris.is_some() {
                     // play a track from a list of tracks, use ID offset for finding the track
-                    send.send(Event::Player(PlayerEvent::PlayTrack(
+                    send.send(ClientRequest::Player(PlayerRequest::PlayTrack(
                         None,
                         track_uris,
                         offset::for_position(id as u32),
                     )))?;
                 } else if context_uri.is_some() {
                     // play a track from a context, use URI offset for finding the track
-                    send.send(Event::Player(PlayerEvent::PlayTrack(
+                    send.send(ClientRequest::Player(PlayerRequest::PlayTrack(
                         context_uri,
                         None,
                         offset::for_uri(tracks[id].uri.clone()),
@@ -808,7 +807,7 @@ fn handle_command_for_track_table(
         Command::BrowseSelectedTrackAlbum => {
             if let Some(id) = ui.window.selected() {
                 if let Some(ref uri) = tracks[id].album.uri {
-                    send.send(Event::GetContext(ContextURI::Album(uri.clone())))?;
+                    send.send(ClientRequest::GetContext(ContextURI::Album(uri.clone())))?;
                     let frame_state = PageState::Browsing(uri.clone());
                     ui.history.push(frame_state.clone());
                     ui.page = frame_state;

--- a/spotify_player/src/event.rs
+++ b/spotify_player/src/event.rs
@@ -36,7 +36,6 @@ pub enum PlayerEvent {
 /// An event to communicate with the client
 /// TODO: renaming this enum (e.g to `ClientRequest`)
 pub enum Event {
-    RefreshToken,
     GetDevices,
     GetUserPlaylists,
     GetUserSavedAlbums,

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -71,6 +71,9 @@ async fn main() -> anyhow::Result<()> {
     let (send, recv) = std::sync::mpsc::channel::<event::ClientRequest>();
 
     let session = auth::new_session(&cache_folder, state.app_config.device.audio_cache).await?;
+    // get the auth token and store it inside the player state
+    let token = token::get_token(&session, &state.app_config.client_id).await?;
+    state.player.write().unwrap().token = token;
 
     // connection thread (used to initialize the integrated Spotify client using librespot)
     #[cfg(feature = "streaming")]

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
     std::thread::spawn({
         let state = state.clone();
         let send = send.clone();
-        let client = client::Client::new(session, &state).await?;
+        let client = client::Client::new();
         move || {
             client::start_client_handler(state, client, send, recv);
         }
@@ -102,7 +102,13 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // player event watcher thread(s)
-    client::start_player_event_watchers(state.clone(), send.clone())?;
+    std::thread::spawn({
+        let send = send.clone();
+        let state = state.clone();
+        move || {
+            client::start_player_event_watchers(state, send, session);
+        }
+    });
 
     // application's UI as the main thread
     ui::start_ui(state)

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     let state = std::sync::Arc::new(state);
 
     // start application's threads
-    let (send, recv) = std::sync::mpsc::channel::<event::Event>();
+    let (send, recv) = std::sync::mpsc::channel::<event::ClientRequest>();
 
     let session = auth::new_session(&cache_folder, state.app_config.device.audio_cache).await?;
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -85,10 +85,9 @@ async fn main() -> anyhow::Result<()> {
     // client event handler thread
     std::thread::spawn({
         let state = state.clone();
-        let send = send.clone();
         let client = client::Client::new();
         move || {
-            client::start_client_handler(state, client, send, recv);
+            client::start_client_handler(state, client, recv);
         }
     });
 

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -39,7 +39,10 @@ pub fn truncate_string(s: String, max_len: usize) -> String {
 
 /// updates the current playback by fetching playback data from spotify every
 /// `AppConfig::refresh_delay_in_ms_each_playback_update`, repeated `AppConfig::n_refreshes_each_playback_update` times.
-pub fn update_playback(state: &state::SharedState, send: &std::sync::mpsc::Sender<event::Event>) {
+pub fn update_playback(
+    state: &state::SharedState,
+    send: &std::sync::mpsc::Sender<event::ClientRequest>,
+) {
     let n_refreshes = state.app_config.n_refreshes_each_playback_update;
     let delay_duration =
         std::time::Duration::from_millis(state.app_config.refresh_delay_in_ms_each_playback_update);
@@ -49,7 +52,7 @@ pub fn update_playback(state: &state::SharedState, send: &std::sync::mpsc::Sende
         move || {
             (0..n_refreshes).for_each(|_| {
                 std::thread::sleep(delay_duration);
-                send.send(event::Event::GetCurrentPlayback)
+                send.send(event::ClientRequest::GetCurrentPlayback)
                     .unwrap_or_else(|err| {
                         log::warn!("failed to send GetCurrentPlayback event: {:#?}", err);
                     });

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -1,10 +1,7 @@
 use tui::widgets::{ListState, TableState};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::{
-    event,
-    state::{self, ArtistFocusState, PopupState, WindowState},
-};
+use crate::state::{self, ArtistFocusState, PopupState, WindowState};
 
 /// formats a time duration (in ms) into a "{minutes}:{seconds}" format
 pub fn format_duration(duration: u32) -> String {
@@ -35,30 +32,6 @@ pub fn truncate_string(s: String, max_len: usize) -> String {
     } else {
         s
     }
-}
-
-/// updates the current playback by fetching playback data from spotify every
-/// `AppConfig::refresh_delay_in_ms_each_playback_update`, repeated `AppConfig::n_refreshes_each_playback_update` times.
-pub fn update_playback(
-    state: &state::SharedState,
-    send: &std::sync::mpsc::Sender<event::ClientRequest>,
-) {
-    let n_refreshes = state.app_config.n_refreshes_each_playback_update;
-    let delay_duration =
-        std::time::Duration::from_millis(state.app_config.refresh_delay_in_ms_each_playback_update);
-
-    std::thread::spawn({
-        let send = send.clone();
-        move || {
-            (0..n_refreshes).for_each(|_| {
-                std::thread::sleep(delay_duration);
-                send.send(event::ClientRequest::GetCurrentPlayback)
-                    .unwrap_or_else(|err| {
-                        log::warn!("failed to send GetCurrentPlayback event: {:#?}", err);
-                    });
-            });
-        }
-    });
 }
 
 pub fn new_list_state() -> ListState {


### PR DESCRIPTION
# Brief description of new changes
- Rename `Event` and `PlayerEvent` to `ClientRequest` and `PlayerRequest`
- Make the client request handler non-blocking by cloning the client and handle the request separately