### PR TITLE
Rewrite the context page state's structure

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -259,6 +259,12 @@ fn handle_global_command(
                 ui.history.pop();
                 ui.popup = None;
                 ui.window = WindowState::Unknown;
+
+                // empty the previous page's `context_id` to force
+                // updating the context page's window state and requesting the context data
+                if let PageState::Context(ref mut context_id, _) = ui.current_page_mut() {
+                    *context_id = None;
+                }
             }
         }
         Command::SwitchDevice => {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -131,7 +131,7 @@ fn handle_key_event(
                         state,
                     )?
                 }
-                PageState::Browsing(_) | PageState::CurrentPlaying => {
+                PageState::Context(..) => {
                     drop(ui);
                     window::handle_key_sequence_for_context_window(&key_sequence, send, state)?
                 }
@@ -228,7 +228,7 @@ fn handle_global_command(
             }
         }
         Command::BrowsePlayingContext => {
-            ui.create_new_page(PageState::CurrentPlaying);
+            ui.create_new_page(PageState::Context(None, ContextPageType::CurrentPlaying));
         }
         Command::BrowseUserPlaylists => {
             send.send(ClientRequest::GetUserPlaylists)?;
@@ -253,7 +253,6 @@ fn handle_global_command(
                 input: "".to_owned(),
                 current_query: "".to_owned(),
             });
-            ui.window = WindowState::new_search_state();
         }
         Command::PreviousPage => {
             if ui.history.len() > 1 {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -121,7 +121,7 @@ fn handle_key_event(
             match ui.current_page() {
                 PageState::Library => {
                     drop(ui);
-                    window::handle_key_sequence_for_library_window(&key_sequence, send, state)?
+                    window::handle_key_sequence_for_library_window(&key_sequence, state)?
                 }
                 PageState::Recommendations(..) => {
                     drop(ui);

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -31,8 +31,10 @@ pub fn handle_key_sequence_for_popup(
                     };
 
                     let context_id = ContextId::Artist(artists[id].id.clone());
-                    send.send(ClientRequest::GetContext(context_id.clone()))?;
-                    ui.create_new_page(PageState::Browsing(context_id));
+                    ui.create_new_page(PageState::Context(
+                        None,
+                        ContextPageType::Browsing(context_id),
+                    ));
 
                     Ok(())
                 },
@@ -255,7 +257,7 @@ fn handle_key_sequence_for_search_popup(
                     drop(ui);
                     window::handle_key_sequence_for_recommendation_window(key_sequence, send, state)
                 }
-                PageState::Browsing(_) | PageState::CurrentPlaying => {
+                PageState::Context(..) => {
                     drop(ui);
                     window::handle_key_sequence_for_context_window(key_sequence, send, state)
                 }
@@ -296,9 +298,10 @@ fn handle_key_sequence_for_context_browsing_list_popup(
                 }
             };
 
-            send.send(ClientRequest::GetContext(context_id.clone()))?;
-
-            ui.create_new_page(PageState::Browsing(context_id));
+            ui.create_new_page(PageState::Context(
+                None,
+                ContextPageType::Browsing(context_id),
+            ));
 
             Ok(())
         },
@@ -423,8 +426,10 @@ fn handle_key_sequence_for_action_list_popup(
                         if let Some(ref album) = track.album {
                             let uri = album.id.uri();
                             let context_id = ContextId::Album(AlbumId::from_uri(&uri)?);
-                            send.send(ClientRequest::GetContext(context_id.clone()))?;
-                            ui.create_new_page(PageState::Browsing(context_id));
+                            ui.create_new_page(PageState::Context(
+                                None,
+                                ContextPageType::Browsing(context_id),
+                            ));
                         }
                     }
                     Action::BrowseArtist => {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -58,7 +58,6 @@ pub fn handle_key_sequence_for_popup(
                     drop(ui);
                     handle_key_sequence_for_context_browsing_list_popup(
                         key_sequence,
-                        send,
                         state,
                         playlist_uris,
                         rspotify_model::Type::Playlist,
@@ -118,7 +117,6 @@ pub fn handle_key_sequence_for_popup(
             drop(ui);
             handle_key_sequence_for_context_browsing_list_popup(
                 key_sequence,
-                send,
                 state,
                 artist_uris,
                 rspotify_model::Type::Artist,
@@ -137,7 +135,6 @@ pub fn handle_key_sequence_for_popup(
             drop(ui);
             handle_key_sequence_for_context_browsing_list_popup(
                 key_sequence,
-                send,
                 state,
                 album_uris,
                 rspotify_model::Type::Album,
@@ -251,7 +248,7 @@ fn handle_key_sequence_for_search_popup(
             _ => match ui.current_page() {
                 PageState::Library => {
                     drop(ui);
-                    window::handle_key_sequence_for_library_window(key_sequence, send, state)
+                    window::handle_key_sequence_for_library_window(key_sequence, state)
                 }
                 PageState::Recommendations(..) => {
                     drop(ui);
@@ -277,7 +274,6 @@ fn handle_key_sequence_for_search_popup(
 /// - `uri_type`: an enum represents the type of a context in the list (`playlist`, `artist`, etc)
 fn handle_key_sequence_for_context_browsing_list_popup(
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     uris: Vec<String>,
     context_type: rspotify_model::Type,

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -1,4 +1,4 @@
-use crate::{command::Action, utils::new_table_state};
+use crate::command::Action;
 
 use super::*;
 
@@ -449,9 +449,6 @@ fn handle_key_sequence_for_action_list_popup(
                         let seed = SeedItem::Track(track.clone());
                         send.send(ClientRequest::GetRecommendations(seed.clone()))?;
                         ui.create_new_page(PageState::Recommendations(seed));
-                        ui.window = WindowState::Recommendations {
-                            track_table: new_table_state(),
-                        };
                     }
                 },
                 Item::Album(album) => match actions[id] {
@@ -476,9 +473,6 @@ fn handle_key_sequence_for_action_list_popup(
                         let seed = SeedItem::Artist(artist.clone());
                         send.send(ClientRequest::GetRecommendations(seed.clone()))?;
                         ui.create_new_page(PageState::Recommendations(seed));
-                        ui.window = WindowState::Recommendations {
-                            track_table: new_table_state(),
-                        };
                     }
                     _ => {}
                 },

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -29,30 +29,33 @@ pub fn handle_key_sequence_for_context_window(
             });
         }
         Command::PlayRandom => {
-            let player = state.player.read();
-            let data = state.data.read();
-            let context = player.context(&data.caches);
+            if let Some(uri) = ui.current_page().context_uri() {
+                let data = state.data.read();
 
-            // randomly play a track from the current context
-            if let Some(context) = context {
-                let tracks = context.tracks();
-                let offset = match context {
-                    // Spotify does not allow to manually specify `offset` for artist context
-                    Context::Artist { .. } => None,
-                    _ => {
-                        let id = rand::thread_rng().gen_range(0..tracks.len());
-                        Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()))
-                    }
-                };
+                // randomly play a track from the current context
+                if let Some(context) = data.caches.context.peek(&uri) {
+                    let tracks = context.tracks();
+                    let offset = match context {
+                        // Spotify does not allow to manually specify `offset` for artist context
+                        Context::Artist { .. } => None,
+                        _ => {
+                            let id = rand::thread_rng().gen_range(0..tracks.len());
+                            Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()))
+                        }
+                    };
 
-                send.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                    Playback::Context(player.context_id.clone().unwrap(), offset),
-                )))?;
+                    let context_id = match ui.current_page() {
+                        PageState::Context(context_id, _) => context_id.clone().unwrap(),
+                        _ => unreachable!(),
+                    };
+
+                    send.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                        Playback::Context(context_id, offset),
+                    )))?;
+                }
             }
         }
         _ => {
-            drop(ui);
-
             // handle sort/reverse tracks commands
             let order = match command {
                 Command::SortTrackByTitle => Some(TrackOrder::TrackName),
@@ -64,27 +67,26 @@ pub fn handle_key_sequence_for_context_window(
             };
 
             if let Some(order) = order {
-                let player = state.player.read();
-                let mut data = state.data.write();
-                let context = player.context_mut(&mut data.caches);
-
-                if let Some(context) = context {
-                    context.sort_tracks(order);
+                if let Some(uri) = ui.current_page().context_uri() {
+                    let mut data = state.data.write();
+                    if let Some(context) = data.caches.context.peek_mut(&uri) {
+                        context.sort_tracks(order);
+                    }
                 }
                 return Ok(true);
             }
             if command == Command::ReverseTrackOrder {
-                let player = state.player.read();
-                let mut data = state.data.write();
-                let context = player.context_mut(&mut data.caches);
-
-                if let Some(context) = context {
-                    context.reverse_tracks();
+                if let Some(uri) = ui.current_page().context_uri() {
+                    let mut data = state.data.write();
+                    if let Some(context) = data.caches.context.peek_mut(&uri) {
+                        context.reverse_tracks();
+                    }
                 }
                 return Ok(true);
             }
 
             // the command hasn't been handled, assign the job to the focused subwindow's handler
+            drop(ui);
             return handle_command_for_focused_context_subwindow(command, send, state);
         }
     }
@@ -329,10 +331,12 @@ pub fn handle_command_for_focused_context_subwindow(
     send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
-    let data = state.data.read();
-    let context = state.player.read().context(&data.caches);
+    let uri = match state.ui.lock().current_page().context_uri() {
+        Some(uri) => uri,
+        None => return Ok(false),
+    };
 
-    match context {
+    match state.data.read().caches.context.peek(&uri) {
         Some(context) => match context {
             Context::Artist {
                 top_tracks,
@@ -513,8 +517,10 @@ fn handle_command_for_artist_list_subwindow(
         }
         Command::ChooseSelected => {
             let context_id = ContextId::Artist(artists[id].id.clone());
-            send.send(ClientRequest::GetContext(context_id.clone()))?;
-            ui.create_new_page(PageState::Browsing(context_id));
+            ui.create_new_page(PageState::Context(
+                None,
+                ContextPageType::Browsing(context_id),
+            ));
         }
         Command::ShowActionsOnSelectedItem => {
             ui.popup = Some(PopupState::ActionList(
@@ -549,8 +555,10 @@ fn handle_command_for_album_list_subwindow(
         }
         Command::ChooseSelected => {
             let context_id = ContextId::Album(albums[id].id.clone());
-            send.send(ClientRequest::GetContext(context_id.clone()))?;
-            ui.create_new_page(PageState::Browsing(context_id));
+            ui.create_new_page(PageState::Context(
+                None,
+                ContextPageType::Browsing(context_id),
+            ));
         }
         Command::ShowActionsOnSelectedItem => {
             ui.popup = Some(PopupState::ActionList(
@@ -585,8 +593,10 @@ fn handle_command_for_playlist_list_subwindow(
         }
         Command::ChooseSelected => {
             let context_id = ContextId::Playlist(playlists[id].id.clone());
-            send.send(ClientRequest::GetContext(context_id.clone()))?;
-            ui.create_new_page(PageState::Browsing(context_id));
+            ui.create_new_page(PageState::Context(
+                None,
+                ContextPageType::Browsing(context_id),
+            ));
         }
         Command::ShowActionsOnSelectedItem => {
             ui.popup = Some(PopupState::ActionList(

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -96,7 +96,6 @@ pub fn handle_key_sequence_for_context_window(
 /// handles a key sequence for a library window
 pub fn handle_key_sequence_for_library_window(
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let command = match state
@@ -134,19 +133,16 @@ pub fn handle_key_sequence_for_library_window(
             match focus_state {
                 LibraryFocusState::Playlists => handle_command_for_playlist_list_subwindow(
                     command,
-                    send,
                     state,
                     state.filtered_items_by_search(&data.user_data.playlists),
                 ),
                 LibraryFocusState::SavedAlbums => handle_command_for_album_list_subwindow(
                     command,
-                    send,
                     state,
                     state.filtered_items_by_search(&data.user_data.saved_albums),
                 ),
                 LibraryFocusState::FollowedArtists => handle_command_for_artist_list_subwindow(
                     command,
-                    send,
                     state,
                     state.filtered_items_by_search(&data.user_data.followed_artists),
                 ),
@@ -303,19 +299,19 @@ pub fn handle_key_sequence_for_search_window(
                     let artists = search_results
                         .map(|s| s.artists.iter().collect())
                         .unwrap_or_default();
-                    handle_command_for_artist_list_subwindow(command, send, state, artists)
+                    handle_command_for_artist_list_subwindow(command, state, artists)
                 }
                 SearchFocusState::Albums => {
                     let albums = search_results
                         .map(|s| s.albums.iter().collect())
                         .unwrap_or_default();
-                    handle_command_for_album_list_subwindow(command, send, state, albums)
+                    handle_command_for_album_list_subwindow(command, state, albums)
                 }
                 SearchFocusState::Playlists => {
                     let playlists = search_results
                         .map(|s| s.playlists.iter().collect())
                         .unwrap_or_default();
-                    handle_command_for_playlist_list_subwindow(command, send, state, playlists)
+                    handle_command_for_playlist_list_subwindow(command, state, playlists)
                 }
             }
         }
@@ -352,13 +348,11 @@ pub fn handle_command_for_focused_context_subwindow(
                 match focus_state {
                     ArtistFocusState::Albums => handle_command_for_album_list_subwindow(
                         command,
-                        send,
                         state,
                         state.filtered_items_by_search(albums),
                     ),
                     ArtistFocusState::RelatedArtists => handle_command_for_artist_list_subwindow(
                         command,
-                        send,
                         state,
                         state.filtered_items_by_search(related_artists),
                     ),
@@ -497,7 +491,6 @@ fn handle_command_for_track_list_subwindow(
 
 fn handle_command_for_artist_list_subwindow(
     command: Command,
-    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     artists: Vec<&Artist>,
 ) -> Result<bool> {
@@ -535,7 +528,6 @@ fn handle_command_for_artist_list_subwindow(
 
 fn handle_command_for_album_list_subwindow(
     command: Command,
-    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     albums: Vec<&Album>,
 ) -> Result<bool> {
@@ -573,7 +565,6 @@ fn handle_command_for_album_list_subwindow(
 
 fn handle_command_for_playlist_list_subwindow(
     command: Command,
-    send: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
     playlists: Vec<&Playlist>,
 ) -> Result<bool> {

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -1,4 +1,4 @@
-use super::{data, model::*};
+use super::model::*;
 
 /// Player state
 #[derive(Default, Debug)]
@@ -10,7 +10,7 @@ pub struct PlayerState {
 }
 
 impl PlayerState {
-    /// gets a simplified playback
+    /// gets a simplified version of the current playback
     pub fn simplified_playback(&self) -> Option<SimplifiedPlayback> {
         self.playback.as_ref().map(|p| SimplifiedPlayback {
             device_id: p.device.id.clone(),
@@ -45,6 +45,28 @@ impl PlayerState {
                     };
                 Some(progress_ms)
             }
+        }
+    }
+
+    /// gets the current playing context's ID
+    pub fn playing_context_id(&self) -> Option<ContextId> {
+        match self.playback {
+            Some(ref playback) => match playback.context {
+                Some(ref context) => match context._type {
+                    rspotify_model::Type::Playlist => Some(ContextId::Playlist(
+                        PlaylistId::from_uri(&context.uri).expect("invalid playing context URI"),
+                    )),
+                    rspotify_model::Type::Album => Some(ContextId::Album(
+                        AlbumId::from_uri(&context.uri).expect("invalid playing context URI"),
+                    )),
+                    rspotify_model::Type::Artist => Some(ContextId::Artist(
+                        ArtistId::from_uri(&context.uri).expect("invalid playing context URI"),
+                    )),
+                    _ => None,
+                },
+                None => None,
+            },
+            None => None,
         }
     }
 }

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -5,8 +5,6 @@ use super::{data, model::*};
 pub struct PlayerState {
     pub devices: Vec<Device>,
 
-    pub context_id: Option<ContextId>,
-
     pub playback: Option<rspotify_model::CurrentPlaybackContext>,
     pub playback_last_updated: Option<std::time::Instant>,
 }
@@ -47,22 +45,6 @@ impl PlayerState {
                     };
                 Some(progress_ms)
             }
-        }
-    }
-
-    /// gets the current context (immutable)
-    pub fn context<'a>(&self, caches: &'a data::Caches) -> Option<&'a Context> {
-        match self.context_id {
-            Some(ref id) => caches.context.peek(&id.uri()),
-            None => None,
-        }
-    }
-
-    /// gets the current context (mutable)
-    pub fn context_mut<'a>(&self, caches: &'a mut data::Caches) -> Option<&'a mut Context> {
-        match self.context_id {
-            Some(ref id) => caches.context.peek_mut(&id.uri()),
-            None => None,
         }
     }
 }

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -25,13 +25,18 @@ pub struct UIState {
 #[derive(Clone, Debug)]
 pub enum PageState {
     Library,
-    CurrentPlaying,
-    Browsing(ContextId),
+    Context(Option<ContextId>, ContextPageType),
     Searching {
         input: String,
         current_query: String,
     },
     Recommendations(SeedItem),
+}
+
+#[derive(Clone, Debug)]
+pub enum ContextPageType {
+    CurrentPlaying,
+    Browsing(ContextId),
 }
 
 /// Window state
@@ -148,6 +153,16 @@ impl Default for UIState {
             window: WindowState::Unknown,
 
             progress_bar_rect: tui::layout::Rect::default(),
+        }
+    }
+}
+
+impl PageState {
+    /// returns the context URI of the current page (if is a context page)
+    pub fn context_uri(&self) -> Option<String> {
+        match self {
+            Self::Context(context_id, _) => context_id.map(|id| id.uri()),
+            _ => None,
         }
     }
 }

--- a/spotify_player/src/state/ui.rs
+++ b/spotify_player/src/state/ui.rs
@@ -161,7 +161,7 @@ impl PageState {
     /// returns the context URI of the current page (if is a context page)
     pub fn context_uri(&self) -> Option<String> {
         match self {
-            Self::Context(context_id, _) => context_id.map(|id| id.uri()),
+            Self::Context(context_id, _) => context_id.as_ref().map(|id| id.uri()),
             _ => None,
         }
     }

--- a/spotify_player/src/ui/window.rs
+++ b/spotify_player/src/ui/window.rs
@@ -185,10 +185,18 @@ pub fn render_context_window(
         .title(state.ui.lock().theme.block_title_with_style(title))
         .borders(Borders::ALL);
 
-    let data = state.data.read();
-    let context = state.player.read().context(&data.caches);
+    let context_uri = match state.ui.lock().current_page().context_uri() {
+        None => {
+            frame.render_widget(
+                Paragraph::new("Cannot determine the current page's context").block(block),
+                rect,
+            );
+            return;
+        }
+        Some(context_uri) => context_uri,
+    };
 
-    match context {
+    match state.data.read().caches.context.peek(&context_uri) {
         Some(context) => {
             frame.render_widget(block, rect);
 
@@ -238,14 +246,7 @@ pub fn render_context_window(
             }
         }
         None => {
-            let desc = if state.player.read().context_id.is_none() {
-                "Cannot infer the playing context from the current playback"
-            } else {
-                // context is not empty, but cannot get context data inside the player state
-                // => still loading the context data
-                "Loading..."
-            };
-            frame.render_widget(Paragraph::new(desc).block(block), rect);
+            frame.render_widget(Paragraph::new("Loading...").block(block), rect);
         }
     }
 }


### PR DESCRIPTION
## Brief description of changes

- use `PageState::Context` as a combination of `PageState::Browsing`, `PageState::CurrentPlaying`
- handle window state update logic and context data request logic in the `ui::handle_page_state_change` function