### PR TITLE
Refactor IPC codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,44 +151,44 @@ To open a shortcut help popup, press `?` or `C-h` (default shortcuts for `OpenCo
 
 List of supported commands:
 
-| Command                     | Description                                                 | Default shortcuts  |
-| --------------------------- | ----------------------------------------------------------- | ------------------ |
-| `NextTrack`                 | next track                                                  | `n`                |
-| `PreviousTrack`             | previous track                                              | `p`                |
-| `ResumePause`               | resume/pause based on the current playback                  | `space`            |
-| `PlayRandom`                | play a random track in the current context                  | `.`                |
-| `Repeat`                    | cycle the repeat mode                                       | `C-r`              |
-| `Shuffle`                   | toggle the shuffle mode                                     | `C-s`              |
-| `VolumeUp`                  | increase playback volume by 5%                              | `+`                |
-| `VolumeDown`                | decrease playback volume by 5%                              | `-`                |
-| `Quit`                      | quit the application                                        | `C-c`, `q`         |
-| `OpenCommandHelp`           | open a command help popup                                   | `?`, `C-h`         |
-| `ClosePopup`                | close a popup                                               | `esc`              |
-| `SelectNextOrScrollDown`    | select the next item in a list/table or scroll down         | `j`, `C-j`, `down` |
-| `SelectPreviousOrScrollUp`  | select the previous item in a list/table or scroll up       | `k`, `C-k`, `up`   |
-| `ChooseSelected`            | choose the selected item                                    | `enter`            |
-| `RefreshPlayback`           | manually refresh the current playback                       | `r`                |
-| `ReconnectIntegratedClient` | reconnect the integrated librespot client                   | `R`                |
-| `ShowActionsOnSelectedItem` | open a popup showing actions on a selected item             | `g a`, `C-space`   |
-| `ShowActionsOnCurrentTrack` | open a popup showing actions on the currently playing track | `a`                |
-| `FocusNextWindow`           | focus the next focusable window (if any)                    | `tab`              |
-| `FocusPreviousWindow`       | focus the previous focusable window (if any)                | `backtab`          |
-| `SwitchTheme`               | open a popup for switching theme                            | `T`                |
-| `SwitchDevice`              | open a popup for switching device                           | `D`                |
-| `Search`                    | open a popup for searching in the current page              | `/`                |
-| `BrowseUserPlaylists`       | open a popup for browsing user's playlists                  | `u p`              |
-| `BrowseUserFollowedArtists` | open a popup for browsing user's followed artists           | `u a`              |
-| `BrowseUserSavedAlbums`     | open a popup for browsing user's saved albums               | `u A`              |
-| `BrowsePlayingContext`      | browse the current playing context                          | `g space`          |
-| `LibraryPage`               | go to the user library page                                 | `g l`              |
-| `SearchPage`                | go to the search page                                       | `g s`              |
-| `PreviousPage`              | go to the previous page                                     | `backspace`, `C-p` |
-| `SortTrackByTitle`          | sort the track table (if any) by track's title              | `s t`              |
-| `SortTrackByArtists`        | sort the track table (if any) by track's artists            | `s a`              |
-| `SortTrackByAlbum`          | sort the track table (if any) by track's album              | `s A`              |
-| `SortTrackByDuration`       | sort the track table (if any) by track's duration           | `s d`              |
-| `SortTrackByAddedDate`      | sort the track table (if any) by track's added date         | `s D`              |
-| `ReverseOrder`              | reverse the order of the track table (if any)               | `s r`              |
+| Command                     | Description                                                        | Default shortcuts  |
+| --------------------------- | ------------------------------------------------------------------ | ------------------ |
+| `NextTrack`                 | next track                                                         | `n`                |
+| `PreviousTrack`             | previous track                                                     | `p`                |
+| `ResumePause`               | resume/pause based on the current playback                         | `space`            |
+| `PlayRandom`                | play a random track in the current context                         | `.`                |
+| `Repeat`                    | cycle the repeat mode                                              | `C-r`              |
+| `Shuffle`                   | toggle the shuffle mode                                            | `C-s`              |
+| `VolumeUp`                  | increase playback volume by 5%                                     | `+`                |
+| `VolumeDown`                | decrease playback volume by 5%                                     | `-`                |
+| `Quit`                      | quit the application                                               | `C-c`, `q`         |
+| `OpenCommandHelp`           | open a command help popup                                          | `?`, `C-h`         |
+| `ClosePopup`                | close a popup                                                      | `esc`              |
+| `SelectNextOrScrollDown`    | select the next item in a list/table or scroll down                | `j`, `C-j`, `down` |
+| `SelectPreviousOrScrollUp`  | select the previous item in a list/table or scroll up              | `k`, `C-k`, `up`   |
+| `ChooseSelected`            | choose the selected item                                           | `enter`            |
+| `RefreshPlayback`           | manually refresh the current playback                              | `r`                |
+| `ReconnectIntegratedClient` | reconnect the integrated librespot client (streaming feature only) | `R`                |
+| `ShowActionsOnSelectedItem` | open a popup showing actions on a selected item                    | `g a`, `C-space`   |
+| `ShowActionsOnCurrentTrack` | open a popup showing actions on the currently playing track        | `a`                |
+| `FocusNextWindow`           | focus the next focusable window (if any)                           | `tab`              |
+| `FocusPreviousWindow`       | focus the previous focusable window (if any)                       | `backtab`          |
+| `SwitchTheme`               | open a popup for switching theme                                   | `T`                |
+| `SwitchDevice`              | open a popup for switching device                                  | `D`                |
+| `Search`                    | open a popup for searching in the current page                     | `/`                |
+| `BrowseUserPlaylists`       | open a popup for browsing user's playlists                         | `u p`              |
+| `BrowseUserFollowedArtists` | open a popup for browsing user's followed artists                  | `u a`              |
+| `BrowseUserSavedAlbums`     | open a popup for browsing user's saved albums                      | `u A`              |
+| `BrowsePlayingContext`      | browse the current playing context                                 | `g space`          |
+| `LibraryPage`               | go to the user library page                                        | `g l`              |
+| `SearchPage`                | go to the search page                                              | `g s`              |
+| `PreviousPage`              | go to the previous page                                            | `backspace`, `C-p` |
+| `SortTrackByTitle`          | sort the track table (if any) by track's title                     | `s t`              |
+| `SortTrackByArtists`        | sort the track table (if any) by track's artists                   | `s a`              |
+| `SortTrackByAlbum`          | sort the track table (if any) by track's album                     | `s A`              |
+| `SortTrackByDuration`       | sort the track table (if any) by track's duration                  | `s d`              |
+| `SortTrackByAddedDate`      | sort the track table (if any) by track's added date                | `s D`              |
+| `ReverseOrder`              | reverse the order of the track table (if any)                      | `s r`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](https://github.com/aome510/spotify-player/blob/master/doc/config.md#keymaps) in the configuration documentation.
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ List of supported commands:
 | `SelectPreviousOrScrollUp`  | select the previous item in a list/table or scroll up       | `k`, `C-k`, `up`   |
 | `ChooseSelected`            | choose the selected item                                    | `enter`            |
 | `RefreshPlayback`           | manually refresh the current playback                       | `r`                |
+| `ReconnectIntegratedClient` | reconnect the integrated librespot client                   | `R`                |
 | `ShowActionsOnSelectedItem` | open a popup showing actions on a selected item             | `g a`, `C-space`   |
 | `ShowActionsOnCurrentTrack` | open a popup showing actions on the currently playing track | `a`                |
 | `FocusNextWindow`           | focus the next focusable window (if any)                    | `tab`              |

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -20,7 +20,7 @@ pub fn start_client_handler(
     while let Ok(request) = client_sub.recv() {
         match request {
             #[cfg(feature = "streaming")]
-            ClientRequest::NewConnection => {
+            ClientRequest::NewSpircConnection => {
                 // send a notification to current spirc subcribers to shutdown all running spirc connections
                 spirc_pub.send(()).unwrap_or_default();
                 client.new_spirc_connection(spirc_pub.subscribe(), client_pub.clone());

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -19,7 +19,10 @@ pub async fn start_client_handler(
 ) {
     while let Ok(request) = client_sub.recv() {
         match request {
+            #[cfg(feature = "streaming")]
             ClientRequest::NewConnection => {
+                // send a notification to current spirc subcribers to shutdown all running spirc connections
+                spirc_pub.send(()).unwrap_or_default();
                 client.new_spirc_connection(spirc_pub.subscribe(), client_pub.clone());
             }
             _ => {

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -8,12 +8,11 @@ use crate::{
 use super::Client;
 
 /// starts the client's request handler
-#[tokio::main]
 pub async fn start_client_handler(
     state: SharedState,
     client: Client,
     client_pub: mpsc::Sender<ClientRequest>,
-    client_sub: mpsc::Receiver<ClientRequest>,
+    mut client_sub: mpsc::Receiver<ClientRequest>,
     spirc_pub: broadcast::Sender<()>,
 ) {
     while let Some(request) = client_sub.recv().await {
@@ -40,7 +39,6 @@ pub async fn start_client_handler(
 /// starts multiple event watchers listening
 /// to player events and notifying the client
 /// to make additional update requests if needed
-#[tokio::main]
 pub async fn start_player_event_watchers(
     state: SharedState,
     client_pub: mpsc::Sender<ClientRequest>,

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 use crate::{
     config,
@@ -14,6 +14,7 @@ mod handlers;
 mod spotify;
 
 pub use handlers::*;
+use tokio::sync::{broadcast, mpsc};
 
 /// The application's client
 #[derive(Clone)]
@@ -34,7 +35,7 @@ impl Client {
     /// creates a new Librespot's spirc connection
     pub fn new_spirc_connection(
         &self,
-        spirc_sub: tokio::sync::broadcast::Receiver<()>,
+        spirc_sub: broadcast::Receiver<()>,
         client_pub: mpsc::Sender<ClientRequest>,
     ) {
         let session = match self.spotify.session {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 use crate::{
     config,
@@ -14,7 +14,7 @@ mod handlers;
 mod spotify;
 
 pub use handlers::*;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 
 /// The application's client
 #[derive(Clone)]
@@ -43,7 +43,7 @@ impl Client {
             Some(ref session) => session.clone(),
         };
         let device = self.spotify.device.clone();
-        tokio::spawn(async move {
+        tokio::task::spawn(async move {
             spirc::new_connection(session, device, client_pub, spirc_sub).await;
         });
     }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
+#[cfg(feature = "streaming")]
+use crate::spirc;
 use crate::{
     config,
     event::{ClientRequest, PlayerRequest},
-    spirc,
     state::*,
 };
 use anyhow::{anyhow, Result};
@@ -33,6 +34,7 @@ impl Client {
     }
 
     /// creates a new Librespot's spirc connection
+    #[cfg(feature = "streaming")]
     pub fn new_spirc_connection(
         &self,
         spirc_sub: broadcast::Receiver<()>,

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -168,6 +168,7 @@ impl Client {
         tracing::info!("handle client request {:?}", request);
 
         match request {
+            #[cfg(feature = "streaming")]
             ClientRequest::NewConnection => {
                 unreachable!("request should be already handled by the caller function");
             }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 
 use crate::{
     config,
@@ -14,7 +14,7 @@ mod handlers;
 mod spotify;
 
 pub use handlers::*;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 
 /// The application's client
 #[derive(Clone)]

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -170,7 +170,7 @@ impl Client {
 
         match request {
             #[cfg(feature = "streaming")]
-            ClientRequest::NewConnection => {
+            ClientRequest::NewSpircConnection => {
                 unreachable!("request should be already handled by the caller function");
             }
             ClientRequest::GetCurrentUser => {

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -6,57 +6,37 @@ use rspotify::{
     http::HttpClient,
     ClientResult, Config, Credentials, OAuth, Token,
 };
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use crate::token;
 
-/// A wrapper struct for `librespot::Session` that implements
-/// `Debug` and `Default` traits.
-/// These above traits are required to implement
-/// `rspotify::BaseClient` and `rspotify::OauthClient` traits.
 #[derive(Clone, Default)]
-pub struct SessionWrapper {
-    session: Option<Session>,
-}
-
-impl std::fmt::Debug for SessionWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("{ session: ... }")
-    }
-}
-
-impl SessionWrapper {
-    fn new(session: Session) -> Self {
-        Self {
-            session: Some(session),
-        }
-    }
-
-    /// gets the librespot session stored inside the wrapper struct.
-    /// It returns an eror if there is no such session.
-    pub fn session(&self) -> Result<&Session> {
-        match self.session {
-            Some(ref session) => Ok(session),
-            None => Err(anyhow!("failed to get the wrapped librespot session.")),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
 /// A Spotify client to interact with Spotify API server
 pub struct Spotify {
     pub creds: Credentials,
     pub oauth: OAuth,
     pub config: Config,
     pub token: Arc<Mutex<Option<Token>>>,
-    pub http: HttpClient,
-    pub session: SessionWrapper,
     pub client_id: String,
+    pub http: HttpClient,
+    pub session: Option<Arc<Session>>,
+}
+
+impl fmt::Debug for Spotify {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Spotify")
+            .field("creds", &self.creds)
+            .field("oauth", &self.oauth)
+            .field("config", &self.config)
+            .field("token", &self.token)
+            .field("client_id", &self.client_id)
+            .finish()
+    }
 }
 
 impl Spotify {
     /// creates a new Spotify client
-    pub fn new(session: Session, client_id: String) -> Spotify {
+    pub fn new(session: Arc<Session>, client_id: String) -> Spotify {
         Self {
             creds: Credentials::default(),
             oauth: OAuth::default(),
@@ -66,7 +46,7 @@ impl Spotify {
             },
             token: Arc::new(Mutex::new(None)),
             http: HttpClient::default(),
-            session: SessionWrapper::new(session),
+            session: Some(session),
             client_id,
         }
     }
@@ -89,11 +69,6 @@ impl Spotify {
                 "failed to get the authorization token stored inside the client."
             )),
         }
-    }
-
-    /// retrieves an authorization token
-    pub async fn retrieve_token(&self) -> Result<Token> {
-        Ok(token::get_token(self.session.session()?, &self.client_id).await?)
     }
 }
 
@@ -119,7 +94,14 @@ impl BaseClient for Spotify {
     }
 
     async fn refetch_token(&self) -> ClientResult<Option<Token>> {
-        match self.retrieve_token().await {
+        let session = match self.session {
+            None => {
+                tracing::warn!("there is no session inside the spotify client");
+                return Ok(None);
+            }
+            Some(session) => session,
+        };
+        match token::get_token(session.as_ref(), &self.client_id).await {
             Ok(token) => Ok(Some(token)),
             Err(err) => {
                 tracing::warn!("{}", err);

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -22,6 +22,8 @@ pub enum Command {
 
     RefreshPlayback,
 
+    ReconnectIntegratedClient,
+
     FocusNextWindow,
     FocusPreviousWindow,
 
@@ -74,6 +76,7 @@ impl Command {
             Self::Quit => "quit the application",
             Self::OpenCommandHelp => "open a command help popup",
             Self::ClosePopup => "close a popup",
+            Self::ReconnectIntegratedClient => "reconnect the integrated librespot client",
             Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down",
             Self::SelectPreviousOrScrollUp => {
                 "select the previous item in a list/table or scroll up"

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -80,6 +80,10 @@ impl Default for KeymapConfig {
                     command: Command::ShowActionsOnCurrentTrack,
                 },
                 Keymap {
+                    key_sequence: "R".into(),
+                    command: Command::ReconnectIntegratedClient,
+                },
+                Keymap {
                     key_sequence: "tab".into(),
                     command: Command::FocusNextWindow,
                 },

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use crate::{
     command::Command,
     key::{Key, KeySequence},
@@ -7,7 +9,6 @@ use crate::{
 use anyhow::Result;
 use crossterm::event::*;
 use rand::Rng;
-use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 
 mod popup;
@@ -89,9 +90,7 @@ async fn handle_mouse_event(
             if let Some(track) = track {
                 let position_ms = (track.duration.as_millis() as u32) * (event.column as u32)
                     / (ui.progress_bar_rect.width as u32);
-                client_pub
-                    .send(ClientRequest::Player(PlayerRequest::SeekTrack(position_ms)))
-                    .await?;
+                client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(position_ms)))?;
             }
         }
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -179,15 +179,12 @@ fn handle_global_command(
             ui.is_running = false;
         }
         Command::NextTrack => {
-            tracing::info!("sent client request...");
             client_pub.blocking_send(ClientRequest::Player(PlayerRequest::NextTrack))?;
         }
         Command::PreviousTrack => {
-            tracing::info!("sent client request...");
             client_pub.blocking_send(ClientRequest::Player(PlayerRequest::PreviousTrack))?;
         }
         Command::ResumePause => {
-            tracing::info!("sent client request...");
             client_pub.blocking_send(ClientRequest::Player(PlayerRequest::ResumePause))?;
         }
         Command::Repeat => {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -43,6 +43,7 @@ pub enum ClientRequest {
     AddTrackToPlaylist(PlaylistId, TrackId),
     SaveToLibrary(Item),
     Player(PlayerRequest),
+    #[cfg(feature = "streaming")]
     NewConnection,
 }
 

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -282,6 +282,7 @@ fn handle_global_command(
             ui.popup = Some(PopupState::ThemeList(themes, new_list_state()));
         }
         Command::ReconnectIntegratedClient => {
+            #[cfg(feature = "streaming")]
             client_pub.blocking_send(ClientRequest::NewSpircConnection)?;
         }
         _ => return Ok(false),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -47,7 +47,6 @@ pub enum ClientRequest {
     NewConnection,
 }
 
-#[tokio::main]
 /// starts a terminal event handler (key pressed, mouse clicked, etc)
 pub async fn start_event_handler(send: mpsc::Sender<ClientRequest>, state: SharedState) {
     let mut event_stream = EventStream::new();

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -43,6 +43,7 @@ pub enum ClientRequest {
     AddTrackToPlaylist(PlaylistId, TrackId),
     SaveToLibrary(Item),
     Player(PlayerRequest),
+    NewConnection,
 }
 
 #[tokio::main]

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -150,7 +150,7 @@ async fn handle_key_event(
         }
         Some(_) => {
             drop(ui);
-            popup::handle_key_sequence_for_popup(&key_sequence, client_pub, state)?
+            popup::handle_key_sequence_for_popup(&key_sequence, client_pub, state).await?
         }
     };
 

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -13,7 +13,7 @@ pub async fn handle_key_sequence_for_popup(
     match ui.popup.as_ref().unwrap() {
         PopupState::Search { .. } => {
             drop(ui);
-            handle_key_sequence_for_search_popup(key_sequence, client_pub, state)
+            handle_key_sequence_for_search_popup(key_sequence, client_pub, state).await
         }
         PopupState::ArtistList(artists, _) => {
             let n_items = artists.len();
@@ -201,7 +201,7 @@ pub async fn handle_key_sequence_for_popup(
 }
 
 /// handles a key sequence for a context search popup
-fn handle_key_sequence_for_search_popup(
+async fn handle_key_sequence_for_search_popup(
     key_sequence: &KeySequence,
     client_pub: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
@@ -256,10 +256,12 @@ fn handle_key_sequence_for_search_popup(
                         client_pub,
                         state,
                     )
+                    .await
                 }
                 PageState::Context(..) => {
                     drop(ui);
                     window::handle_key_sequence_for_context_window(key_sequence, client_pub, state)
+                        .await
                 }
                 PageState::Searching { .. } => Ok(false),
             },

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -3,9 +3,9 @@ use crate::command::Action;
 use super::*;
 
 /// handles a key sequence for a popup
-pub fn handle_key_sequence_for_popup(
+pub async fn handle_key_sequence_for_popup(
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<ClientRequest>,
+    client_pub: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let ui = state.ui.lock();
@@ -13,7 +13,7 @@ pub fn handle_key_sequence_for_popup(
     match ui.popup.as_ref().unwrap() {
         PopupState::Search { .. } => {
             drop(ui);
-            handle_key_sequence_for_search_popup(key_sequence, send, state)
+            handle_key_sequence_for_search_popup(key_sequence, client_pub, state)
         }
         PopupState::ArtistList(artists, _) => {
             let n_items = artists.len();
@@ -90,7 +90,7 @@ pub fn handle_key_sequence_for_popup(
                                 .context
                                 .pop(&playlist_ids[id].uri());
 
-                            send.send(ClientRequest::AddTrackToPlaylist(
+                            client_pub.blocking_send(ClientRequest::AddTrackToPlaylist(
                                 playlist_ids[id].clone(),
                                 track_id.clone(),
                             ))?;
@@ -177,10 +177,9 @@ pub fn handle_key_sequence_for_popup(
                 player.devices.len(),
                 |_, _| {},
                 |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                    send.send(ClientRequest::Player(PlayerRequest::TransferPlayback(
-                        player.devices[id].id.clone(),
-                        true,
-                    )))?;
+                    client_pub.blocking_send(ClientRequest::Player(
+                        PlayerRequest::TransferPlayback(player.devices[id].id.clone(), true),
+                    ))?;
                     ui.popup = None;
                     Ok(())
                 },
@@ -196,7 +195,7 @@ pub fn handle_key_sequence_for_popup(
         PopupState::ActionList(item, ..) => {
             let actions = item.actions();
             drop(ui);
-            handle_key_sequence_for_action_list_popup(actions, key_sequence, send, state)
+            handle_key_sequence_for_action_list_popup(actions, key_sequence, client_pub, state)
         }
     }
 }
@@ -204,7 +203,7 @@ pub fn handle_key_sequence_for_popup(
 /// handles a key sequence for a context search popup
 fn handle_key_sequence_for_search_popup(
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<ClientRequest>,
+    client_pub: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let mut ui = state.ui.lock();
@@ -252,11 +251,15 @@ fn handle_key_sequence_for_search_popup(
                 }
                 PageState::Recommendations(..) => {
                     drop(ui);
-                    window::handle_key_sequence_for_recommendation_window(key_sequence, send, state)
+                    window::handle_key_sequence_for_recommendation_window(
+                        key_sequence,
+                        client_pub,
+                        state,
+                    )
                 }
                 PageState::Context(..) => {
                     drop(ui);
-                    window::handle_key_sequence_for_context_window(key_sequence, send, state)
+                    window::handle_key_sequence_for_context_window(key_sequence, client_pub, state)
                 }
                 PageState::Searching { .. } => Ok(false),
             },
@@ -404,7 +407,7 @@ fn handle_key_sequence_for_command_help_popup(
 fn handle_key_sequence_for_action_list_popup(
     actions: Vec<Action>,
     key_sequence: &KeySequence,
-    send: &mpsc::Sender<ClientRequest>,
+    client_pub: &mpsc::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     handle_key_sequence_for_list_popup(
@@ -437,19 +440,20 @@ fn handle_key_sequence_for_action_list_popup(
                         ));
                     }
                     Action::AddTrackToPlaylist => {
-                        send.send(ClientRequest::GetUserPlaylists)?;
+                        client_pub.blocking_send(ClientRequest::GetUserPlaylists)?;
                         ui.popup = Some(PopupState::UserPlaylistList(
                             PlaylistPopupAction::AddTrack(track.id.clone()),
                             new_list_state(),
                         ));
                     }
                     Action::SaveToLibrary => {
-                        send.send(ClientRequest::SaveToLibrary(item.clone()))?;
+                        client_pub.blocking_send(ClientRequest::SaveToLibrary(item.clone()))?;
                         ui.popup = None;
                     }
                     Action::BrowseRecommendations => {
                         let seed = SeedItem::Track(track.clone());
-                        send.send(ClientRequest::GetRecommendations(seed.clone()))?;
+                        client_pub
+                            .blocking_send(ClientRequest::GetRecommendations(seed.clone()))?;
                         ui.create_new_page(PageState::Recommendations(seed));
                     }
                 },
@@ -461,26 +465,27 @@ fn handle_key_sequence_for_action_list_popup(
                         ));
                     }
                     Action::SaveToLibrary => {
-                        send.send(ClientRequest::SaveToLibrary(item.clone()))?;
+                        client_pub.blocking_send(ClientRequest::SaveToLibrary(item.clone()))?;
                         ui.popup = None;
                     }
                     _ => {}
                 },
                 Item::Artist(artist) => match actions[id] {
                     Action::SaveToLibrary => {
-                        send.send(ClientRequest::SaveToLibrary(item.clone()))?;
+                        client_pub.blocking_send(ClientRequest::SaveToLibrary(item.clone()))?;
                         ui.popup = None;
                     }
                     Action::BrowseRecommendations => {
                         let seed = SeedItem::Artist(artist.clone());
-                        send.send(ClientRequest::GetRecommendations(seed.clone()))?;
+                        client_pub
+                            .blocking_send(ClientRequest::GetRecommendations(seed.clone()))?;
                         ui.create_new_page(PageState::Recommendations(seed));
                     }
                     _ => {}
                 },
                 Item::Playlist(_) => {
                     if let Action::SaveToLibrary = actions[id] {
-                        send.send(ClientRequest::SaveToLibrary(item.clone()))?;
+                        client_pub.blocking_send(ClientRequest::SaveToLibrary(item.clone()))?;
                         ui.popup = None;
                     }
                 }

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -53,9 +53,9 @@ pub fn handle_key_sequence_for_context_window(
                         _ => return Ok(false),
                     };
 
-                    client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                        Playback::Context(context_id, offset),
-                    )))?;
+                    client_pub.blocking_send(ClientRequest::Player(
+                        PlayerRequest::StartPlayback(Playback::Context(context_id, offset)),
+                    ))?;
                 }
             }
         }
@@ -200,7 +200,7 @@ pub fn handle_key_sequence_for_recommendation_window(
                 let id = rand::thread_rng().gen_range(0..tracks.len());
                 Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()))
             };
-            client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+            client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(tracks.iter().map(|t| t.id.clone()).collect(), offset),
             )))?;
 
@@ -245,20 +245,20 @@ pub fn handle_key_sequence_for_search_window(
         if key_sequence.keys.len() == 1 {
             if let Key::None(c) = key_sequence.keys[0] {
                 match c {
-                    KeyCode::Char(c) => {
+                    crossterm::event::KeyCode::Char(c) => {
                         input.push(c);
                         return Ok(true);
                     }
-                    KeyCode::Backspace => {
+                    crossterm::event::KeyCode::Backspace => {
                         if !input.is_empty() {
                             input.pop().unwrap();
                         }
                         return Ok(true);
                     }
-                    KeyCode::Enter => {
+                    crossterm::event::KeyCode::Enter => {
                         if !input.is_empty() {
                             *current_query = input.clone();
-                            client_pub.send(ClientRequest::Search(input.clone()))?;
+                            client_pub.blocking_send(ClientRequest::Search(input.clone()))?;
                         }
                         return Ok(true);
                     }
@@ -436,12 +436,12 @@ fn handle_command_for_track_table_subwindow(
             let offset = Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()));
             if track_ids.is_some() {
                 // play a track from a list of tracks
-                client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
                     Playback::URIs(track_ids.unwrap().into_iter().cloned().collect(), offset),
                 )))?;
             } else if context_id.is_some() {
                 // play a track from a context
-                client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
                     Playback::Context(context_id.unwrap(), offset),
                 )))?;
             }
@@ -486,7 +486,7 @@ fn handle_command_for_track_list_subwindow(
             // It's different for the track table, in which
             // `ChooseSelected` on a track will start a `URIs` playback
             // containing all the tracks in the table.
-            client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+            client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(vec![tracks[id].id.clone()], None),
             )))?;
         }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> anyhow::Result<()> {
     let (send, recv) = std::sync::mpsc::channel::<event::ClientRequest>();
 
     // get some prior information
+    #[cfg(feature = "streaming")]
     send.send(event::ClientRequest::NewConnection)?;
     send.send(event::ClientRequest::GetCurrentUser)?;
     send.send(event::ClientRequest::GetCurrentPlayback)?;

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
         let client_pub = client_pub.clone();
         client.init_token().await?;
         async move {
-            client::start_client_handler(state, client, client_pub, client_sub, spirc_pub);
+            client::start_client_handler(state, client, client_pub, client_sub, spirc_pub).await;
         }
     });
 
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
         let client_pub = client_pub.clone();
         let state = state.clone();
         async move {
-            event::start_event_handler(state, client_pub);
+            event::start_event_handler(state, client_pub).await;
         }
     });
 
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
         let client_pub = client_pub.clone();
         let state = state.clone();
         async move {
-            client::start_player_event_watchers(state, client_pub);
+            client::start_player_event_watchers(state, client_pub).await;
         }
     });
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -134,5 +134,5 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // application's UI as the main thread
-    ui::start_ui(state, client_pub)
+    ui::start_ui(state, client_pub).await
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -116,19 +116,19 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // terminal event handler thread
-    std::thread::spawn({
+    tokio::task::spawn({
         let client_pub = client_pub.clone();
         let state = state.clone();
-        move || {
+        async move {
             event::start_event_handler(client_pub, state);
         }
     });
 
     // player event watcher thread(s)
-    std::thread::spawn({
+    tokio::task::spawn({
         let client_pub = client_pub.clone();
         let state = state.clone();
-        move || {
+        async move {
             client::start_player_event_watchers(state, client_pub);
         }
     });

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -90,9 +90,9 @@ async fn main() -> anyhow::Result<()> {
 
     // get some prior information
     #[cfg(feature = "streaming")]
-    client_pub.send(event::ClientRequest::NewConnection);
-    client_pub.send(event::ClientRequest::GetCurrentUser);
-    client_pub.send(event::ClientRequest::GetCurrentPlayback);
+    client_pub.send(event::ClientRequest::NewSpircConnection)?;
+    client_pub.send(event::ClientRequest::GetCurrentUser)?;
+    client_pub.send(event::ClientRequest::GetCurrentPlayback)?;
 
     // client event handler task
     tokio::task::spawn_blocking({
@@ -110,11 +110,11 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // terminal event handler task
-    tokio::task::spawn_blocking({
+    tokio::task::spawn({
         let client_pub = client_pub.clone();
         let state = state.clone();
-        move || {
-            event::start_event_handler(state, client_pub);
+        async move {
+            event::start_event_handler(state, client_pub).await;
         }
     });
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
         .send(event::ClientRequest::GetCurrentPlayback)
         .await?;
 
-    // client event handler thread
+    // client event handler task
     tokio::task::spawn({
         let state = state.clone();
         let client = client::Client::new(
@@ -115,16 +115,16 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    // terminal event handler thread
+    // terminal event handler task
     tokio::task::spawn({
         let client_pub = client_pub.clone();
         let state = state.clone();
         async move {
-            event::start_event_handler(client_pub, state);
+            event::start_event_handler(state, client_pub);
         }
     });
 
-    // player event watcher thread(s)
+    // player event watcher task
     tokio::task::spawn({
         let client_pub = client_pub.clone();
         let state = state.clone();
@@ -133,6 +133,6 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    // application's UI as the main thread
+    // application's UI as the main task
     ui::start_ui(state, client_pub).await
 }

--- a/spotify_player/src/spirc.rs
+++ b/spotify_player/src/spirc.rs
@@ -19,7 +19,7 @@ pub async fn new_connection(
     session: Session,
     device: config::DeviceConfig,
     send: mpsc::Sender<ClientRequest>,
-    mut reconnect_recv: tokio::sync::broadcast::Receiver<()>,
+    mut spirc_sub: tokio::sync::broadcast::Receiver<()>,
 ) {
     // librespot volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
@@ -75,7 +75,7 @@ pub async fn new_connection(
     let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer);
     tokio::select! {
         _ = spirc_task => {}
-        _ = reconnect_recv.recv() => {
+        _ = spirc_sub.recv() => {
             tracing::info!("got reconnect request, shutdown the current connection to create a new spirc connection...");
             spirc.shutdown();
         }


### PR DESCRIPTION
## Brief description of changes

- use `tokio::sync::mpsc` instead of `std::sync::mpsc`. Rename `send, recv` as channel variable to `client_pub, client_sub`
- add `ClientRequest::NewSpircConnection` and `Command::ReconnectIntegratedClient` that restarts a spirc connection
- cleanup the `client::spotify` code