### PR TITLE
Change client/device reconnect logic

### DIFF
--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -19,6 +19,7 @@ pub async fn start_client_handler(
                 // send a notification to current spirc subcribers to shutdown all running spirc connections
                 spirc_pub.send(()).unwrap_or_default();
                 client.new_spirc_connection(spirc_pub.subscribe(), client_pub.clone());
+                // TODO: handle no playback when reconnect integrated spotify
             }
             _ => {
                 let state = state.clone();

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -18,8 +18,15 @@ pub async fn start_client_handler(
             ClientRequest::NewSpircConnection => {
                 // send a notification to current spirc subcribers to shutdown all running spirc connections
                 spirc_pub.send(()).unwrap_or_default();
-                client.new_spirc_connection(spirc_pub.subscribe(), client_pub.clone());
-                // TODO: handle no playback when reconnect integrated spotify
+                if let Err(err) = client
+                    .new_spirc_connection(spirc_pub.subscribe(), client_pub.clone(), true)
+                    .await
+                {
+                    tracing::warn!(
+                        "encounter error when creating new spirc connection: {}",
+                        err
+                    );
+                }
             }
             _ => {
                 let state = state.clone();

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -1,9 +1,6 @@
 use tokio::sync::{broadcast, mpsc};
 
-use crate::{
-    event::{ClientRequest, PlayerRequest},
-    state::*,
-};
+use crate::{event::ClientRequest, state::*};
 
 use super::Client;
 
@@ -77,13 +74,6 @@ pub fn start_player_event_watchers(state: SharedState, client_pub: mpsc::Sender<
                     .blocking_send(ClientRequest::GetCurrentPlayback)
                     .unwrap_or_default();
             }
-        }
-
-        // try to reconnect if there is no playback
-        if player.playback.is_none() {
-            client_pub
-                .blocking_send(ClientRequest::Player(PlayerRequest::Reconnect))
-                .unwrap_or_default();
         }
 
         // update the context state and request new data when moving to a new context page

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -45,9 +45,7 @@ impl Client {
             Some(ref session) => session.clone(),
         };
         let device = self.spotify.device.clone();
-        tokio::task::spawn(async move {
-            spirc::new_connection(session, device, client_pub, spirc_sub).await;
-        });
+        spirc::new_connection(session, device, client_pub, spirc_sub);
     }
 
     /// initializes the authorization token inside the Spotify client

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -21,7 +21,6 @@ pub enum PlayerRequest {
     Repeat,
     Shuffle,
     Volume(u8),
-    Reconnect,
     TransferPlayback(String, bool),
     StartPlayback(Playback),
 }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -181,8 +181,13 @@ pub fn handle_key_sequence_for_popup(
                 player.devices.len(),
                 |_, _| {},
                 |ui: &mut UIStateGuard, id: usize| -> Result<()> {
+                    let is_playing = player
+                        .playback
+                        .as_ref()
+                        .map(|p| p.is_playing)
+                        .unwrap_or(false);
                     client_pub.blocking_send(ClientRequest::Player(
-                        PlayerRequest::TransferPlayback(player.devices[id].id.clone(), true),
+                        PlayerRequest::TransferPlayback(player.devices[id].id.clone(), is_playing),
                     ))?;
                     ui.popup = None;
                     Ok(())

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -91,13 +91,13 @@ async fn main() -> anyhow::Result<()> {
     // get some prior information
     #[cfg(feature = "streaming")]
     client_pub
+        .send(event::ClientRequest::GetCurrentPlayback)
+        .await?;
+    client_pub
         .send(event::ClientRequest::NewSpircConnection)
         .await?;
     client_pub
         .send(event::ClientRequest::GetCurrentUser)
-        .await?;
-    client_pub
-        .send(event::ClientRequest::GetCurrentPlayback)
         .await?;
     client_pub
         .send(event::ClientRequest::GetUserPlaylists)

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -53,7 +53,9 @@ async fn init_spotify(
 
     // if `streaming` feature is enabled, create new Spirc connection
     #[cfg(feature = "streaming")]
-    client.new_spirc_connection(spirc_pub.subscribe(), client_pub.clone());
+    client
+        .new_spirc_connection(spirc_pub.subscribe(), client_pub.clone(), false)
+        .await?;
 
     if state.player.read().playback.is_none() {
         tracing::info!(

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -192,5 +192,15 @@ fn render_playback_window(frame: &mut Frame, state: &SharedState, rect: Rect) {
             frame.render_widget(playback_desc, chunks[0]);
             frame.render_widget(progress_bar, chunks[1]);
         }
+    } else {
+        frame.render_widget(
+            Paragraph::new(
+                "No playback found. \
+                 Please make sure there is a running Spotify client and try to connect to it using the `SwitchDevice` command."
+            )
+            .wrap(Wrap { trim: true })
+            .block(Block::default()),
+            chunks[0],
+        );
     };
 }


### PR DESCRIPTION
## Brief description of changes

- removed `PlayerRequest::Reconnect` and made the reconnect flow explicit, e.g require users to manually reconnect instead of automatically making a reconnect request if no playback found.
- updated the logic for handling no playback
- updated the application initialization code on startup