### PR TITLE
Add various improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +177,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -769,6 +799,12 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glib"
@@ -1699,6 +1735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2000,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2588,6 +2642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +2931,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backtrace",
  "chrono",
  "clap",
  "config_parser2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,7 +2951,6 @@ dependencies = [
  "rspotify",
  "serde",
  "tokio",
- "tokio-stream",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/doc/config.md
+++ b/doc/config.md
@@ -15,24 +15,24 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify-player` uses `app.toml` to configure general application configurations:
 
-| Option                                     | Description                                                      | Default                            |
-| ------------------------------------------ | ---------------------------------------------------------------- | ---------------------------------- |
-| `client_id`                                | the application's client ID that interacts with Spotify APIs     | `65b708073fc0480ea92a077233ca87bd` |
-| `theme`                                    | the application's theme                                          | `dracula`                          |
-| `n_refreshes_each_playback_update`         | number of refresh requests in each playback update               | `5`                                |
-| `refresh_delay_in_ms_each_playback_update` | delay in ms between two refresh requests in each playback update | `500`                              |
-| `app_refresh_duration_in_ms`               | duration in ms for re-rendering the application's UI             | `32`                               |
-| `playback_refresh_duration_in_ms`          | duration in ms for refreshing the playback periodically          | `0`                                |
-| `track_table_item_max_len`                 | maximum length of a column in a track table                      | `32`                               |
+| Option                            | Description                                                        | Default                            |
+| --------------------------------- | ------------------------------------------------------------------ | ---------------------------------- |
+| `client_id`                       | the Spotify client's ID                                            | `65b708073fc0480ea92a077233ca87bd` |
+| `theme`                           | the application's theme                                            | `dracula`                          |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes | `32`                               |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes    | `0`                                |
+| `track_table_item_max_len`        | the maximum length of a column in a track table                    | `32`                               |
 
 The default `app.toml` can be found in the example [`app.toml`](https://github.com/aome510/spotify-player/blob/master/examples/app.toml) file
 
 **Note**:
 
-- By default, the application uses the official Spotify Web app's client ID (`65b708073fc0480ea92a077233ca87bd`). It's recommended to specify [your own Client ID](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to avoid possible rate limit and to allow a full [Spotify connect](https://www.spotify.com/us/connect/) support.
-- Positive-value `app_refresh_duration_in_ms` is used to refresh the current playback (making a Spotify API call) every `app_refresh_duration_in_ms` ms. This can result in hitting Spotify rate limit if the player is running for a long time.
-- To prevent the rate limit, `spotify-player` sets `playback_refresh_duration_in_ms=0` and uses `n_refreshes_each_playback_update` and `refresh_delay_in_ms_each_playback_update` to update the playback each time a command or event triggers a playback update.
+- By default, `spotify-player` uses the official Spotify Web app's client (`client_id = 65b708073fc0480ea92a077233ca87bd`)
+- It's recommended to specify [your own Client ID](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to avoid possible rate limits and to allow a full [Spotify connect](https://www.spotify.com/us/connect/) support.
+- Positive-value `app_refresh_duration_in_ms` is used to refresh the playback periodically. This can result in hitting a Spotify rate limit if the application is running for a long time.
+- To prevent the rate limit, `spotify-player` sets `playback_refresh_duration_in_ms=0` by default and makes additional API calls when there is an event or a command triggering a playback update.
 - List of commands that triggers a playback update:
+
   - `NextTrack`
   - `PreviousTrack`
   - `ResumePause`
@@ -41,7 +41,10 @@ The default `app.toml` can be found in the example [`app.toml`](https://github.c
   - `Shuffle`
   - `SeekTrack` (left-clicking the playback's progress bar)
   - `ChooseSelected` (for a track, a device, etc)
-- The playback is also updated when the current track ends (using a timer based on the track's duration).
+
+  **Note**: the above list might not be up-to-date.
+
+- An example of event that triggers a playback update is the one happenning when the current track ends.
 
 ### Device configurations
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -1,7 +1,5 @@
 theme = "dracula"
 client_id = "65b708073fc0480ea92a077233ca87bd"
-n_refreshes_each_playback_update = 5
-refresh_delay_in_ms_each_playback_update = 500
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 track_table_item_max_len = 32

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -25,7 +25,7 @@ reqwest = { version = "0.11.9", features = ["json"] }
 rpassword = "5.0.1"
 rspotify = "0.11.3"
 serde = { version = "1.0.136", features = ["derive"] }
-tokio = { version = "1.17.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.17.0", features = ["rt", "rt-multi-thread", "macros", "time"] }
 tokio-stream = "0.1.8"
 toml = "0.5.8"
 tui = "0.17.0"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.12.0"
 tracing = "0.1.31"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 lyric_finder = { version = "0.1.2", path = "../lyric_finder" , optional = true }
+backtrace = "0.3.65"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -26,7 +26,6 @@ rpassword = "5.0.1"
 rspotify = "0.11.3"
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.17.0", features = ["rt", "rt-multi-thread", "macros", "time"] }
-tokio-stream = "0.1.8"
 toml = "0.5.8"
 tui = "0.17.0"
 unicode-width = "0.1.9"

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -65,8 +65,7 @@ pub fn start_player_event_watchers(state: SharedState, client_pub: mpsc::Sender<
     }
 
     // Main watcher task
-    // TODO: make the below `refresh_duration` configurable
-    let refresh_duration = std::time::Duration::from_millis(100);
+    let refresh_duration = std::time::Duration::from_millis(200);
     loop {
         std::thread::sleep(refresh_duration);
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -48,7 +48,7 @@ impl Client {
         };
         let device = self.spotify.device.clone();
         let device_id = session.device_id().to_string();
-        spirc::new_connection(session, device, client_pub, spirc_sub);
+        spirc::new_connection(session, device, client_pub, spirc_sub)?;
 
         // whether should we connect to the new spirc client upon its creation
         if should_connect {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     event::{ClientRequest, PlayerRequest},
     state::*,
 };
-use anyhow::{anyhow, Context as AnyhowContext, Result};
+use anyhow::{Context as AnyhowContext, Result};
 use librespot_core::session::Session;
 use rspotify::prelude::*;
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -131,7 +131,9 @@ impl Client {
                     .shuffle(playback.shuffle_state, device_id)
                     .await?
             }
-            PlayerRequest::TransferPlayback(..) => unreachable!(),
+            PlayerRequest::TransferPlayback(..) => {
+                anyhow::bail!("`TransferPlayback` should be handled ealier")
+            }
         };
 
         Ok(())
@@ -159,7 +161,7 @@ impl Client {
             }
             #[cfg(feature = "streaming")]
             ClientRequest::NewSpircConnection => {
-                unreachable!("request should be already handled by the caller function");
+                anyhow::bail!("request should be already handled by the caller function");
             }
             ClientRequest::GetCurrentUser => {
                 let user = self.spotify.current_user().await?;
@@ -528,13 +530,13 @@ impl Client {
                     .into_iter()
                     .filter_map(Track::try_from_full_track)
                     .collect(),
-                _ => unreachable!(),
+                _ => anyhow::bail!("expect a track search result"),
             },
             match artist_result {
                 rspotify_model::SearchResult::Artists(p) => {
                     p.items.into_iter().map(|a| a.into()).collect()
                 }
-                _ => unreachable!(),
+                _ => anyhow::bail!("expect an artist search result"),
             },
             match album_result {
                 rspotify_model::SearchResult::Albums(p) => p
@@ -542,13 +544,13 @@ impl Client {
                     .into_iter()
                     .filter_map(Album::try_from_simplified_album)
                     .collect(),
-                _ => unreachable!(),
+                _ => anyhow::bail!("expect an album search result"),
             },
             match playlist_result {
                 rspotify_model::SearchResult::Playlists(p) => {
                     p.items.into_iter().map(|i| i.into()).collect()
                 }
-                _ => unreachable!(),
+                _ => anyhow::bail!("expect a playlist search result"),
             },
         );
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -184,7 +184,7 @@ impl Client {
                 let state = state.clone();
                 tokio::task::spawn(
                     async move {
-                        let delay_duration = std::time::Duration::from_millis(200);
+                        let delay_duration = std::time::Duration::from_millis(500);
                         for _ in 1..5 {
                             if let Err(err) = client.update_current_playback_state(&state).await {
                                 tracing::error!("failed to refresh the player's playback: {err:?}");

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -20,8 +20,6 @@ pub use theme::*;
 pub struct AppConfig {
     pub theme: String,
     pub client_id: String,
-    pub n_refreshes_each_playback_update: usize,
-    pub refresh_delay_in_ms_each_playback_update: u64,
     pub app_refresh_duration_in_ms: u64,
     pub playback_refresh_duration_in_ms: u64,
     pub track_table_item_max_len: usize,
@@ -45,8 +43,6 @@ impl Default for AppConfig {
             theme: "dracula".to_owned(),
             // official spotify web app's client id
             client_id: "65b708073fc0480ea92a077233ca87bd".to_string(),
-            n_refreshes_each_playback_update: 5,
-            refresh_delay_in_ms_each_playback_update: 500,
             app_refresh_duration_in_ms: 32,
             playback_refresh_duration_in_ms: 0,
             track_table_item_max_len: 32,

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -27,7 +27,7 @@ pub fn handle_key_sequence_for_library_page(
             let data = state.data.read();
             let focus_state = match ui.current_page() {
                 PageState::Library { state } => state.focus,
-                _ => unreachable!("expect a library page state"),
+                _ => anyhow::bail!("expect a library page state"),
             };
             match focus_state {
                 LibraryFocusState::Playlists => window::handle_command_for_playlist_list_window(
@@ -65,7 +65,7 @@ pub fn handle_key_sequence_for_search_page(
             input,
             current_query,
         } => (state.focus, input, current_query),
-        _ => unreachable!("expect a search page"),
+        _ => anyhow::bail!("expect a search page"),
     };
 
     // handle user's input
@@ -109,7 +109,7 @@ pub fn handle_key_sequence_for_search_page(
     let search_results = data.caches.search.peek(current_query);
 
     match focus_state {
-        SearchFocusState::Input => unreachable!("user's search input should be handled before"),
+        SearchFocusState::Input => anyhow::bail!("user's search input should be handled before"),
         SearchFocusState::Tracks => {
             let tracks = search_results
                 .map(|s| s.tracks.iter().collect())
@@ -152,7 +152,7 @@ pub fn handle_key_sequence_for_context_page(
 
     let context_id = match state.ui.lock().current_page() {
         PageState::Context { id, .. } => id.clone(),
-        _ => unreachable!("expect a context page"),
+        _ => anyhow::bail!("expect a context page"),
     };
 
     match command {
@@ -244,7 +244,7 @@ pub fn handle_key_sequence_for_tracks_page(
 
     let id = match ui.current_page() {
         PageState::Tracks { id, .. } => id,
-        _ => unreachable!("expect a tracks page"),
+        _ => anyhow::bail!("expect a tracks page"),
     };
 
     let tracks = data
@@ -305,7 +305,7 @@ pub fn handle_key_sequence_for_lyric_page(
             ref mut scroll_offset,
             ..
         } => scroll_offset,
-        _ => unreachable!("expect a lyric page"),
+        _ => anyhow::bail!("expect a lyric page"),
     };
 
     match command {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -8,7 +8,10 @@ pub fn handle_key_sequence_for_popup(
     state: &SharedState,
 ) -> Result<bool> {
     let ui = state.ui.lock();
-    let popup = ui.popup.as_ref().unwrap();
+    let popup = ui
+        .popup
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("expect to exist a popup"))?;
 
     if let PopupState::Search { .. } = popup {
         drop(ui);
@@ -23,7 +26,7 @@ pub fn handle_key_sequence_for_popup(
         None => return Ok(false),
     };
 
-    match ui.popup.as_ref().unwrap() {
+    match popup {
         PopupState::Search { .. } => anyhow::bail!("should be handled before"),
         PopupState::ArtistList(artists, _) => {
             let n_items = artists.len();
@@ -324,7 +327,7 @@ fn handle_command_for_list_popup(
     on_choose_func: impl Fn(&mut UIStateGuard, usize) -> Result<()>,
     on_close_func: impl Fn(&mut UIStateGuard),
 ) -> Result<bool> {
-    let popup = ui.popup.as_mut().unwrap();
+    let popup = ui.popup.as_mut().context("expect to exist a popup")?;
     let current_id = popup.list_selected().unwrap_or_default();
 
     match command {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -24,7 +24,7 @@ pub fn handle_key_sequence_for_popup(
     };
 
     match ui.popup.as_ref().unwrap() {
-        PopupState::Search { .. } => unreachable!("should be handled before"),
+        PopupState::Search { .. } => anyhow::bail!("should be handled before"),
         PopupState::ArtistList(artists, _) => {
             let n_items = artists.len();
 

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{command::Action, utils::new_table_state};
+use anyhow::Context;
 
 /// handles a key sequence for a popup
 pub fn handle_key_sequence_for_popup(
@@ -11,7 +12,7 @@ pub fn handle_key_sequence_for_popup(
     let popup = ui
         .popup
         .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("expect to exist a popup"))?;
+        .with_context(|| format!("expect to exist a popup"))?;
 
     if let PopupState::Search { .. } = popup {
         drop(ui);
@@ -327,7 +328,10 @@ fn handle_command_for_list_popup(
     on_choose_func: impl Fn(&mut UIStateGuard, usize) -> Result<()>,
     on_close_func: impl Fn(&mut UIStateGuard),
 ) -> Result<bool> {
-    let popup = ui.popup.as_mut().context("expect to exist a popup")?;
+    let popup = ui
+        .popup
+        .as_mut()
+        .with_context(|| "expect to exist a popup")?;
     let current_id = popup.list_selected().unwrap_or_default();
 
     match command {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -12,7 +12,7 @@ pub fn handle_key_sequence_for_popup(
     let popup = ui
         .popup
         .as_ref()
-        .with_context(|| format!("expect to exist a popup"))?;
+        .with_context(|| "expect to exist a popup".to_string())?;
 
     if let PopupState::Search { .. } = popup {
         drop(ui);

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -16,7 +16,7 @@ pub fn handle_command_for_focused_context_window(
             None => return Ok(false),
             Some(id) => id.uri(),
         },
-        _ => unreachable!("expect a context page"),
+        _ => anyhow::bail!("expect a context page"),
     };
 
     match state.data.read().caches.context.peek(&context_uri) {
@@ -32,7 +32,7 @@ pub fn handle_command_for_focused_context_window(
                         state: Some(ContextPageUIState::Artist { focus, .. }),
                         ..
                     } => focus,
-                    _ => unreachable!("expect an arist context page with a state"),
+                    _ => anyhow::bail!("expect an arist context page with a state"),
                 };
 
                 match focus_state {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -114,7 +114,7 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
         if let Some(s) = info.payload().downcast_ref::<&str>() {
             let backtrace = backtrace::Backtrace::new();
             let mut file = backtrace_file.lock().unwrap();
-            writeln!(&mut file, "got a panic: {}\n", s).unwrap();
+            writeln!(&mut file, "Got a panic: {}\n", s).unwrap();
             writeln!(&mut file, "Stack backtrace:\n{:?}", backtrace).unwrap();
         }
     }));

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -58,7 +58,8 @@ async fn init_spotify(
     #[cfg(feature = "streaming")]
     client
         .new_spirc_connection(spirc_pub.subscribe(), client_pub.clone(), false)
-        .await?;
+        .await
+        .context("failed to create a new spirc connection")?;
 
     if state.player.read().playback.is_none() {
         tracing::info!(
@@ -107,8 +108,7 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
     // initialize the application's panic backtrace
     let backtrace_file =
         std::fs::File::create(cache_folder.join(format!("{log_prefix}.backtrace")))
-            .context("failed to create backtrace file")
-            .unwrap();
+            .context("failed to create backtrace file")?;
     let backtrace_file = std::sync::Mutex::new(backtrace_file);
     std::panic::set_hook(Box::new(move |info| {
         if let Some(s) = info.payload().downcast_ref::<&str>() {

--- a/spotify_player/src/spirc.rs
+++ b/spotify_player/src/spirc.rs
@@ -1,4 +1,5 @@
 use crate::{config, event::ClientRequest};
+use anyhow::{Context, Result};
 use librespot_connect::spirc::Spirc;
 use librespot_core::{
     config::{ConnectConfig, DeviceType},
@@ -19,7 +20,7 @@ pub fn new_connection(
     device: config::DeviceConfig,
     client_pub: mpsc::Sender<ClientRequest>,
     mut spirc_sub: broadcast::Receiver<()>,
-) {
+) -> Result<()> {
     // librespot volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
     // So we need to convert from one format to another
@@ -42,7 +43,8 @@ pub fn new_connection(
         Box::new(mixer::softmixer::SoftMixer::open(MixerConfig::default())) as Box<dyn Mixer>;
     mixer.set_volume(volume);
 
-    let backend = audio_backend::find(None).unwrap();
+    let backend =
+        audio_backend::find(None).context(|| format!("unable to find an audio backend"))?;
     let player_config = PlayerConfig {
         bitrate: device
             .bitrate
@@ -85,4 +87,6 @@ pub fn new_connection(
             }
         }
     });
+
+    Ok(())
 }

--- a/spotify_player/src/spirc.rs
+++ b/spotify_player/src/spirc.rs
@@ -44,7 +44,7 @@ pub fn new_connection(
     mixer.set_volume(volume);
 
     let backend =
-        audio_backend::find(None).context(|| format!("unable to find an audio backend"))?;
+        audio_backend::find(None).with_context(|| format!("unable to find an audio backend"))?;
     let player_config = PlayerConfig {
         bitrate: device
             .bitrate

--- a/spotify_player/src/spirc.rs
+++ b/spotify_player/src/spirc.rs
@@ -44,7 +44,7 @@ pub fn new_connection(
     mixer.set_volume(volume);
 
     let backend =
-        audio_backend::find(None).with_context(|| format!("unable to find an audio backend"))?;
+        audio_backend::find(None).with_context(|| "unable to find an audio backend".to_string())?;
     let player_config = PlayerConfig {
         bitrate: device
             .bitrate

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -286,9 +286,8 @@ impl SeedItem {
 impl Device {
     /// tries to convert from a `rspotify_model::Device` into `Device`
     pub fn try_from_device(device: rspotify_model::Device) -> Option<Self> {
-        device.id.as_ref()?;
         Some(Self {
-            id: device.id.unwrap(),
+            id: device.id?,
             name: device.name,
         })
     }
@@ -329,9 +328,8 @@ impl Track {
 
     /// tries to convert from a `rspotify_model::SimplifiedTrack` into `Track`
     pub fn try_from_simplified_track(track: rspotify_model::SimplifiedTrack) -> Option<Self> {
-        track.id.as_ref()?;
         Some(Self {
-            id: track.id.unwrap(),
+            id: track.id?,
             name: track.name,
             artists: from_simplified_artists_to_artists(track.artists),
             album: None,
@@ -342,9 +340,8 @@ impl Track {
 
     /// tries to convert from a `rspotify_model::FullTrack` into `Track`
     pub fn try_from_full_track(track: rspotify_model::FullTrack) -> Option<Self> {
-        track.id.as_ref()?;
         Some(Self {
-            id: track.id.unwrap(),
+            id: track.id?,
             name: track.name,
             artists: from_simplified_artists_to_artists(track.artists),
             album: Album::try_from_simplified_album(track.album),
@@ -363,9 +360,8 @@ impl std::fmt::Display for Track {
 impl Album {
     /// tries to convert from a `rspotify_model::SimplifiedAlbum` into `Album`
     pub fn try_from_simplified_album(album: rspotify_model::SimplifiedAlbum) -> Option<Self> {
-        album.id.as_ref()?;
         Some(Self {
-            id: album.id.unwrap(),
+            id: album.id?,
             name: album.name,
             release_date: album.release_date.unwrap_or_default(),
             artists: from_simplified_artists_to_artists(album.artists),
@@ -393,9 +389,8 @@ impl std::fmt::Display for Album {
 impl Artist {
     /// tries to convert from a `rspotify_model::SimplifiedArtist` into `Artist`
     pub fn try_from_simplified_artist(artist: rspotify_model::SimplifiedArtist) -> Option<Self> {
-        artist.id.as_ref()?;
         Some(Self {
-            id: artist.id.unwrap(),
+            id: artist.id?,
             name: artist.name,
         })
     }


### PR DESCRIPTION
## Brief description of changes
- added backtrace file to log the application's panic stacktrace
- improved error handling
   + reduce the panic codes (`unwrap`, `unreachable`, etc)
   + add more context to propagated errors
- code cleanup

## Breaking changes
- removed `refresh_delay_in_ms_each_playback_update` and `n_refreshes_each_playback_update` config options
   + the playback update logic is now fixed