### PR TITLE
Add cross-platform media control support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libasound2-dev
+        run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config
       - uses: actions/checkout@v2
       - uses: actions-rs/cargo@v1
         name: Cargo Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +368,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +446,31 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -520,6 +582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +620,26 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0a745c25b32caa56b82a3950f5fec7893a960f4c10ca3b02060b0c38d8c2ce"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-crossroads"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d83c4b78f7c7d0dec4859d286665a06858a607ba406c91a36316ff36918141"
+dependencies = [
+ "dbus",
 ]
 
 [[package]]
@@ -593,6 +681,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "either"
@@ -1347,6 +1441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c185b5b7ad900923ef3a8ff594083d4d9b5aea80bb4f32b8342363138c0d456b"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1754,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -1974,6 +2086,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2458,6 +2579,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
+dependencies = [
+ "libc",
+ "raw-window-handle 0.4.3",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
+dependencies = [
+ "cty",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +3050,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "souvlaki"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007734f0cdbd156d0e1819f8cb1161749fa1ff8070f466509c2514b142e48feb"
+dependencies = [
+ "block",
+ "cocoa",
+ "core-graphics",
+ "dbus",
+ "dbus-crossroads",
+ "dispatch",
+ "objc",
+ "raw-window-handle 0.3.4",
+ "windows",
+]
+
+[[package]]
 name = "spotify_player"
 version = "0.7.0"
 dependencies = [
@@ -2934,6 +3091,7 @@ dependencies = [
  "rpassword",
  "rspotify",
  "serde",
+ "souvlaki",
  "tokio",
  "toml",
  "tracing",
@@ -3599,17 +3757,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+dependencies = [
+ "windows_aarch64_msvc 0.29.0",
+ "windows_i686_gnu 0.29.0",
+ "windows_i686_msvc 0.29.0",
+ "windows_x86_64_gnu 0.29.0",
+ "windows_x86_64_msvc 0.29.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3619,9 +3796,21 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3631,9 +3820,21 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "calloop"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
+dependencies = [
+ "log",
+ "nix 0.22.3",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,8 +386,8 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation",
- "core-graphics",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
  "foreign-types",
  "libc",
  "objc",
@@ -391,7 +401,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -433,13 +443,29 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -449,12 +475,24 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.7.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -467,9 +505,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
+]
+
+[[package]]
+name = "core-video-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+dependencies = [
+ "cfg-if 0.1.10",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "libc",
+ "objc",
 ]
 
 [[package]]
@@ -498,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74117836a5124f3629e4b474eed03e479abaf98988b4bb317e29f08cfe0e4116"
 dependencies = [
  "alsa 0.6.0",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "coreaudio-rs",
  "jack 0.8.4",
  "jni",
@@ -506,8 +557,8 @@ dependencies = [
  "lazy_static",
  "libc",
  "mach",
- "ndk",
- "ndk-glue",
+ "ndk 0.6.0",
+ "ndk-glue 0.6.2",
  "nix 0.23.1",
  "oboe",
  "parking_lot 0.11.2",
@@ -534,7 +585,6 @@ checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "futures-core",
  "libc",
  "mio",
  "parking_lot 0.12.0",
@@ -687,6 +737,21 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+dependencies = [
+ "libloading 0.7.3",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "either"
@@ -1312,6 +1377,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1832,6 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,13 +1985,26 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys 0.2.2",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
  "bitflags",
  "jni-sys",
- "ndk-sys",
+ "ndk-sys 0.3.0",
  "num_enum",
  "thiserror",
 ]
@@ -1927,6 +2017,21 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk 0.5.0",
+ "ndk-context",
+ "ndk-macro",
+ "ndk-sys 0.2.2",
+]
+
+[[package]]
+name = "ndk-glue"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
@@ -1934,10 +2039,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk",
+ "ndk 0.6.0",
  "ndk-context",
  "ndk-macro",
- "ndk-sys",
+ "ndk-sys 0.3.0",
 ]
 
 [[package]]
@@ -1952,6 +2057,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ndk-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
 
 [[package]]
 name = "ndk-sys"
@@ -1978,6 +2089,19 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2113,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27f63c358b4fa0fbcfefd7c8be5cfc39c08ce2389f5325687e7762a48d30a5c1"
 dependencies = [
  "jni",
- "ndk",
+ "ndk 0.6.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -2826,6 +2950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,8 +2991,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
 ]
@@ -2873,7 +3003,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -3040,6 +3170,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
+dependencies = [
+ "bitflags",
+ "calloop",
+ "dlib",
+ "lazy_static",
+ "log",
+ "memmap2",
+ "nix 0.22.3",
+ "pkg-config",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,7 +3206,7 @@ checksum = "007734f0cdbd156d0e1819f8cb1161749fa1ff8070f466509c2514b142e48feb"
 dependencies = [
  "block",
  "cocoa",
- "core-graphics",
+ "core-graphics 0.22.3",
  "dbus",
  "dbus-crossroads",
  "dispatch",
@@ -3098,6 +3247,7 @@ dependencies = [
  "tracing-subscriber",
  "tui",
  "unicode-width",
+ "winit",
 ]
 
 [[package]]
@@ -3716,6 +3866,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
+name = "wayland-client"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91223460e73257f697d9e23d401279123d36039a3f7a449e983f123292d4458f"
+dependencies = [
+ "bitflags",
+ "downcast-rs",
+ "libc",
+ "nix 0.22.3",
+ "scoped-tls",
+ "wayland-commons",
+ "wayland-scanner",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-commons"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6e5e340d7c13490eca867898c4cec5af56c27a5ffe5c80c6fc4708e22d33e"
+dependencies = [
+ "nix 0.22.3",
+ "once_cell",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52758f13d5e7861fc83d942d3d99bf270c83269575e52ac29e5b73cb956a6bd"
+dependencies = [
+ "nix 0.22.3",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60147ae23303402e41fe034f74fb2c35ad0780ee88a1c40ac09a3be1e7465741"
+dependencies = [
+ "bitflags",
+ "wayland-client",
+ "wayland-commons",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a1ed3143f7a143187156a2ab52742e89dac33245ba505c17224df48939f9e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "xml-rs",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9341df79a8975679188e37dab3889bfa57c44ac2cb6da166f519a81cbe452d4"
+dependencies = [
+ "dlib",
+ "lazy_static",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +4066,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
+name = "winit"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
+dependencies = [
+ "bitflags",
+ "cocoa",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
+ "core-video-sys",
+ "dispatch",
+ "instant",
+ "lazy_static",
+ "libc",
+ "log",
+ "mio",
+ "ndk 0.5.0",
+ "ndk-glue 0.5.2",
+ "ndk-sys 0.2.2",
+ "objc",
+ "parking_lot 0.11.2",
+ "percent-encoding",
+ "raw-window-handle 0.4.3",
+ "smithay-client-toolkit",
+ "wasm-bindgen",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "winapi",
+ "x11-dl",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +4106,32 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "x11-dl"
+version = "2.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "xcursor"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xml5ever"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 lyric_finder = { version = "0.1.2", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.65"
-souvlaki = "0.5.1"
+souvlaki = {  version = "0.5.1", optional = true }
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]
@@ -50,5 +50,6 @@ sdl-backend = ["streaming", "librespot-playback/sdl-backend"]
 gstreamer-backend = ["streaming", "librespot-playback/gstreamer-backend"]
 streaming = ["librespot-playback", "librespot-connect"]
 lyric-finder = ["lyric_finder"]
+media-control = ["souvlaki"]
 
-default = ["rodio-backend", "lyric-finder"]
+default = ["rodio-backend", "lyric-finder", "media-control"]

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -37,6 +37,7 @@ tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 lyric_finder = { version = "0.1.2", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.65"
+souvlaki = "0.5.1"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 anyhow = "1.0.57"
 clap = "3.1.18"
 config_parser2 = "0.1.2"
-crossterm = { version = "0.23.2", features = ["event-stream"] }
+crossterm = "0.23.2"
 dirs-next = "2.0.0"
 librespot-connect = { version = "0.3.1", optional = true }
 librespot-playback = { version = "0.3.1", optional = true }
@@ -38,6 +38,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 lyric_finder = { version = "0.1.2", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.65"
 souvlaki = {  version = "0.5.1", optional = true }
+winit = { version = "0.26.1", optional = true }
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]
@@ -50,6 +51,6 @@ sdl-backend = ["streaming", "librespot-playback/sdl-backend"]
 gstreamer-backend = ["streaming", "librespot-playback/gstreamer-backend"]
 streaming = ["librespot-playback", "librespot-connect"]
 lyric-finder = ["lyric_finder"]
-media-control = ["souvlaki"]
+media-control = ["souvlaki", "winit"]
 
 default = ["rodio-backend", "lyric-finder", "media-control"]

--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -26,7 +26,7 @@ fn read_user_auth_details(user: Option<String>) -> Result<(String, String)> {
 }
 
 async fn new_session_with_new_creds(cache: &Cache) -> Result<Session> {
-    tracing::info!("creating a new session with new authentication credentials");
+    tracing::info!("Creating a new session with new authentication credentials");
 
     println!("Authentication token not found or invalid, please reauthenticate.");
 
@@ -48,7 +48,7 @@ async fn new_session_with_new_creds(cache: &Cache) -> Result<Session> {
             }
             Err(err) => {
                 println!("Failed to authenticate, {} tries left", 2 - i);
-                tracing::warn!("failed to authenticate: {err:#}")
+                tracing::warn!("Failed to authenticate: {err:#}")
             }
         }
     }
@@ -76,12 +76,12 @@ pub async fn new_session(cache_folder: &std::path::Path, audio_cache: bool) -> R
         Some(creds) => {
             match Session::connect(SessionConfig::default(), creds, Some(cache.clone())).await {
                 Ok(session) => {
-                    tracing::info!("use the cached credentials");
+                    tracing::info!("Use the cached credentials");
                     Ok(session)
                 }
                 Err(err) => match err {
                     SessionError::AuthenticationError(err) => {
-                        tracing::warn!("failed to authenticate: {err:#}");
+                        tracing::warn!("Failed to authenticate: {err:#}");
                         new_session_with_new_creds(&cache).await
                     }
                     SessionError::IoError(err) => Err(anyhow!(format!(

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -53,7 +53,7 @@ impl Spotify {
         }
     }
 
-    /// gets a Spotify access token for authorization.
+    /// gets a Spotify access token.
     /// The function may retrieve a new token and update the current token
     /// stored inside the client if the old one is expired.
     pub async fn access_token(&self) -> Result<String> {
@@ -68,7 +68,7 @@ impl Spotify {
         match self.token.lock().await.unwrap().as_ref() {
             Some(token) => Ok(token.access_token.clone()),
             None => Err(anyhow!(
-                "failed to get the authorization token stored inside the client."
+                "failed to get the authentication token stored inside the client."
             )),
         }
     }
@@ -98,7 +98,7 @@ impl BaseClient for Spotify {
     async fn refetch_token(&self) -> ClientResult<Option<Token>> {
         let session = match self.session {
             None => {
-                tracing::warn!("there is no session inside the spotify client");
+                tracing::warn!("There is no session inside the spotify client");
                 return Ok(None);
             }
             Some(ref session) => session,
@@ -106,7 +106,7 @@ impl BaseClient for Spotify {
         match token::get_token(session, &self.client_id).await {
             Ok(token) => Ok(Some(token)),
             Err(err) => {
-                tracing::error!("failed to get access token: {err:#}");
+                tracing::error!("Failed to get access token: {err:#}");
                 Ok(None)
             }
         }

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -231,7 +231,7 @@ impl KeymapConfig {
         match std::fs::read_to_string(&file_path) {
             Err(err) => {
                 tracing::warn!(
-                    "failed to open the keymap config file (path={file_path:?}): {err:#}. Use the default configurations instead",
+                    "Failed to open the keymap config file (path={file_path:?}): {err:#}. Use the default configurations instead",
                 );
             }
             Ok(content) => {

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -72,7 +72,7 @@ impl AppConfig {
         match std::fs::read_to_string(&file_path) {
             Err(err) => {
                 tracing::warn!(
-                    "failed to open the application config file (path={file_path:?}): {err:#}. Use the default configurations instead",
+                    "Failed to open the application config file (path={file_path:?}): {err:#}. Use the default configurations instead",
                 );
             }
             Ok(content) => {

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -127,7 +127,7 @@ impl ThemeConfig {
         match std::fs::read_to_string(&file_path) {
             Err(err) => {
                 tracing::warn!(
-                    "failed to open the theme config file (path={file_path:?}): {err:#}. Use the default configurations instead",
+                    "Failed to open the theme config file (path={file_path:?}): {err:#}. Use the default configurations instead",
                 );
             }
             Ok(content) => {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -48,19 +48,19 @@ pub enum ClientRequest {
         artists: String,
     },
     #[cfg(feature = "streaming")]
-    NewSpircConnection,
+    NewStreamingConnection,
 }
 
 /// starts a terminal event handler (key pressed, mouse clicked, etc)
 pub fn start_event_handler(state: SharedState, client_pub: mpsc::Sender<ClientRequest>) {
     while let Ok(event) = crossterm::event::read() {
-        let _enter = tracing::info_span!("terminal_event", event = ?event).entered();
+        let _enter = tracing::info_span!("Terminal_event", event = ?event).entered();
         if let Err(err) = match event {
             crossterm::event::Event::Mouse(event) => handle_mouse_event(event, &client_pub, &state),
             crossterm::event::Event::Key(event) => handle_key_event(event, &client_pub, &state),
             _ => Ok(()),
         } {
-            tracing::error!("failed to handle event: {err:#}");
+            tracing::error!("Failed to handle event: {err:#}");
         }
     }
 }
@@ -75,7 +75,7 @@ fn handle_mouse_event(
     // a left click event
     if let crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) = event.kind
     {
-        tracing::debug!("handling mouse event: {event:?}");
+        tracing::debug!("Handling mouse event: {event:?}");
         if event.row == ui.progress_bar_rect.y {
             // calculate the seek position (in ms) based on the clicked position,
             // the pro gress bar's width and the track's duration (in ms)
@@ -112,7 +112,7 @@ fn handle_key_event(
         key_sequence = KeySequence { keys: vec![key] };
     }
 
-    tracing::debug!("handling key event: {event:?}, current key sequence: {key_sequence:?}");
+    tracing::debug!("Handling key event: {event:?}, current key sequence: {key_sequence:?}");
 
     let handled = if state.ui.lock().popup.is_none() {
         // no popup
@@ -324,7 +324,7 @@ fn handle_global_command(
         }
         #[cfg(feature = "streaming")]
         Command::ReconnectIntegratedClient => {
-            client_pub.blocking_send(ClientRequest::NewSpircConnection)?;
+            client_pub.blocking_send(ClientRequest::NewStreamingConnection)?;
         }
         Command::FocusNextWindow => {
             if !ui.has_focused_popup() {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -241,10 +241,8 @@ async fn main() -> Result<()> {
         // control events. The below code will create an invisible window on startup
         // to listen to such events.
         let event_loop = winit::event_loop::EventLoop::new();
-        event_loop.run(move |event, _, control_flow| {
+        event_loop.run(move |_, _, control_flow| {
             *control_flow = winit::event_loop::ControlFlow::Wait;
-
-            tracing::info!("got event: {event:?}");
         });
     }
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -4,9 +4,9 @@ mod command;
 mod config;
 mod event;
 mod key;
-#[cfg(feature = "streaming")]
-mod spirc;
 mod state;
+#[cfg(feature = "streaming")]
+mod streaming;
 mod token;
 mod ui;
 mod utils;
@@ -47,23 +47,23 @@ fn init_app_cli_arguments() -> clap::ArgMatches {
 
 async fn init_spotify(
     client_pub: &tokio::sync::mpsc::Sender<event::ClientRequest>,
-    spirc_pub: &tokio::sync::broadcast::Sender<()>,
+    streaming_pub: &tokio::sync::broadcast::Sender<()>,
     client: &client::Client,
     state: &state::SharedState,
 ) -> Result<()> {
     client.init_token().await?;
     client.update_current_playback_state(state).await?;
 
-    // if `streaming` feature is enabled, create a new Spirc connection
+    // if `streaming` feature is enabled, create a new streaming connection
     #[cfg(feature = "streaming")]
     client
-        .new_spirc_connection(spirc_pub.subscribe(), client_pub.clone(), false)
+        .new_streaming_connection(streaming_pub.subscribe(), client_pub.clone(), false)
         .await
-        .context("failed to create a new spirc connection")?;
+        .context("failed to create a new streaming connection")?;
 
     if state.player.read().playback.is_none() {
         tracing::info!(
-            "no playback found on startup, trying to connect to the first available device"
+            "No playback found on startup, trying to connect to the first available device"
         );
         client.connect_to_first_available_device().await?;
     }
@@ -164,10 +164,11 @@ async fn main() -> Result<()> {
 
     // create application's channels
     let (client_pub, client_sub) = tokio::sync::mpsc::channel::<event::ClientRequest>(16);
-    let (spirc_pub, _) = tokio::sync::broadcast::channel::<()>(16);
+    // broadcast channels used to shutdown running streaming connections upon creating a new one
+    let (streaming_pub, _) = tokio::sync::broadcast::channel::<()>(16);
 
     // initialize Spotify-related stuff
-    init_spotify(&client_pub, &spirc_pub, &client, &state)
+    init_spotify(&client_pub, &streaming_pub, &client, &state)
         .await
         .context("failed to initialize the spotify client")?;
 
@@ -178,7 +179,8 @@ async fn main() -> Result<()> {
         let state = state.clone();
         let client_pub = client_pub.clone();
         async move {
-            client::start_client_handler(state, client, client_pub, client_sub, spirc_pub).await;
+            client::start_client_handler(state, client, client_pub, client_sub, streaming_pub)
+                .await;
         }
     });
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -241,8 +241,10 @@ async fn main() -> Result<()> {
         // control events. The below code will create an invisible window on startup
         // to listen to such events.
         let event_loop = winit::event_loop::EventLoop::new();
-        event_loop.run(move |_, _, control_flow| {
+        event_loop.run(move |event, _, control_flow| {
             *control_flow = winit::event_loop::ControlFlow::Wait;
+
+            tracing::info!("got event: {event:?}");
         });
     }
 }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -1,0 +1,31 @@
+use souvlaki::{MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
+
+/// Start the application's media control event watcher
+pub fn start_event_watcher() -> Result<(), souvlaki::Error> {
+    tracing::info!("Initializing application's media control event watcher...");
+
+    let hwnd = None;
+    let config = PlatformConfig {
+        display_name: "spotify_player",
+        dbus_name: "Spotify Player",
+        hwnd,
+    };
+    let mut controls = MediaControls::new(config)?;
+
+    controls.attach(|e| {
+        tracing::info!("Got media event: {e:?}");
+    })?;
+    controls.set_playback(MediaPlayback::Playing { progress: None })?;
+    controls
+        .set_metadata(MediaMetadata {
+            title: Some("When The Sun Hits"),
+            album: Some("Souvlaki"),
+            artist: Some("Slowdive"),
+            duration: Some(std::time::Duration::from_secs_f64(4.0 * 60.0 + 50.0)),
+            cover_url: Some("https://c.pxhere.com/photos/34/c1/souvlaki_authentic_greek_greek_food_mezes-497780.jpg!d"),
+        })?;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+}

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -83,9 +83,10 @@ pub fn start_event_watcher(
     // for the track metadata to be shown up on MacOS media bar.
     controls.set_playback(MediaPlayback::Playing { progress: None })?;
 
+    let refresh_duration = std::time::Duration::from_millis(100);
     loop {
         if let Ok(event) = rx.try_recv() {
-            tracing::info!("got a media control event: {event:?}");
+            tracing::info!("Got a media control event: {event:?}");
             match event {
                 MediaControlEvent::Play | MediaControlEvent::Pause | MediaControlEvent::Toggle => {
                     client_pub
@@ -107,6 +108,6 @@ pub fn start_event_watcher(
         }
 
         update_control_metadata(&state, &mut controls)?;
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(refresh_duration);
     }
 }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -7,6 +7,14 @@ use crate::{
     state::SharedState,
 };
 
+fn get_track_album_image_url(track: &rspotify::model::FullTrack) -> Option<&str> {
+    if track.album.images.is_empty() {
+        None
+    } else {
+        Some(&track.album.images[0].url)
+    }
+}
+
 fn update_control_metadata(
     state: &SharedState,
     controls: &mut MediaControls,
@@ -43,7 +51,7 @@ fn update_control_metadata(
                         }),
                 ),
                 duration: Some(track.duration),
-                cover_url: None,
+                cover_url: get_track_album_image_url(track),
             })?;
         }
     }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -80,9 +80,12 @@ pub fn start_event_watcher(
         tx.send(e).unwrap_or_default();
     })?;
     // Somehow, on startup, media playback needs to be initialized with `Playing`
-    // for the track metadata to be shown up on MacOS media bar.
+    // for the track metadata to be shown up on the MacOS media status bar.
     controls.set_playback(MediaPlayback::Playing { progress: None })?;
 
+    // `100ms` is a "good enough" duration for the track metadata to be updated consistently.
+    // Setting this to be higher (e.g, `200ms`) would result in incorrect metadata
+    // shown up in the media status bar occasionally.
     let refresh_duration = std::time::Duration::from_millis(100);
     loop {
         if let Ok(event) = rx.try_recv() {

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -39,13 +39,13 @@ impl State {
         if let Some(theme) = theme {
             self.app_config.theme = theme.to_owned();
         };
-        tracing::info!("general configurations: {:?}", self.app_config);
+        tracing::info!("General configurations: {:?}", self.app_config);
 
         self.theme_config.parse_config_file(config_folder)?;
-        tracing::info!("theme configurations: {:?}", self.theme_config);
+        tracing::info!("Theme configurations: {:?}", self.theme_config);
 
         self.keymap_config.parse_config_file(config_folder)?;
-        tracing::info!("keymap configurations: {:?}", self.keymap_config);
+        tracing::info!("Keymap configurations: {:?}", self.keymap_config);
 
         if let Some(theme) = self.theme_config.find_theme(&self.app_config.theme) {
             // update the UI theme based on the `theme` config option

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -36,14 +36,15 @@ impl PlayerState {
         match self.playback {
             None => None,
             Some(ref playback) => {
-                let progress_ms = playback.progress.unwrap()
+                let progress = playback.progress.unwrap()
                     + if playback.is_playing {
                         std::time::Instant::now()
                             .saturating_duration_since(self.playback_last_updated.unwrap())
                     } else {
+                        // zero duration
                         std::time::Duration::default()
                     };
-                Some(progress_ms)
+                Some(progress)
             }
         }
     }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -26,10 +26,10 @@ pub fn run(state: SharedState) -> Result<()> {
             frame.render_widget(block, frame.size());
 
             if let Err(err) = render_application(frame, &state, frame.size()) {
-                tracing::error!("failed to render the application: {err:#}");
+                tracing::error!("Failed to render the application: {err:#}");
             }
         }) {
-            tracing::error!("failed to draw the application: {err:#}");
+            tracing::error!("Failed to draw the application: {err:#}");
         }
 
         std::thread::sleep(ui_refresh_duration);

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -17,7 +17,7 @@ pub fn run(state: SharedState) -> Result<()> {
     loop {
         if !state.ui.lock().is_running {
             clean_up(terminal).context("failed to clean up the application's UI resources")?;
-            return Ok(());
+            std::process::exit(0);
         }
 
         if let Err(err) = terminal.draw(|frame| {


### PR DESCRIPTION
## Changes
- added cross-platform media control support
  - added `media_control` module
  - added `souvlaki` and `winit` crates (under `media-control` feature) 
- capitalized the first character of a log message
- renamed `spric` to `streaming`