### PR TITLE
Media control follow-up improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev
         if: ${{ runner.os == 'Linux' }}
       - uses: actions/checkout@v2
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,18 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  linux-test:
+  rust-ci:
     if: github.event.pull_request.draft != true
-    name: Linux (ubuntu)
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config
+        if: ${{ runner.os == 'Linux' }}
       - uses: actions/checkout@v2
       - uses: actions-rs/cargo@v1
         name: Cargo Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "config_parser2"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad40c82a0d985e7b6ddc7e4fcf86ed77bfcdaf83e3a82573787a13e07ff8c71"
+checksum = "ab0859c810793c5f89c891d5ec162cc6b14c637c8e1af0dcaa18f23e600c63dc"
 dependencies = [
  "anyhow",
  "config_parser_derive",

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ List of supported commands:
 | `SelectPreviousOrScrollUp`    | select the previous item in a list/table or scroll up                   | `k`, `C-k`, `up`   |
 | `ChooseSelected`              | choose the selected item                                                | `enter`            |
 | `RefreshPlayback`             | manually refresh the current playback                                   | `r`                |
-| `ReconnectIntegratedClient`   | reconnect the integrated librespot client (`streaming` feature only)    | `R`                |
+| `RestartIntegratedClient`     | restart the integrated librespot client (`streaming` feature only)      | `R`                |
 | `ShowActionsOnSelectedItem`   | open a popup showing actions on a selected item                         | `g a`, `C-space`   |
 | `ShowActionsOnCurrentTrack`   | open a popup showing actions on the current track                       | `a`                |
 | `FocusNextWindow`             | focus the next focusable window (if any)                                | `tab`              |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Introduction
 
-`spotify-player` is a fast, easy to use, and [configurable](https://github.com/aome510/spotify-player/blob/master/doc/config.md) terminal music player.
+`spotify-player` is a fast, easy to use, and [configurable](doc/config.md) terminal music player.
 
 ### Features
 
@@ -246,7 +246,7 @@ List of supported commands:
 | `SortTrackByAddedDate`        | sort the track table (if any) by track's added date                     | `s D`              |
 | `ReverseOrder`                | reverse the order of the track table (if any)                           | `s r`              |
 
-To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](https://github.com/aome510/spotify-player/blob/master/doc/config.md#keymaps) in the configuration documentation.
+To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](doc/config.md#keymaps) in the configuration documentation.
 
 ### Actions
 
@@ -265,7 +265,7 @@ To move the focus from the search input to the other windows such as track resul
 
 By default, `spotify-player` will look into `$HOME/.config/spotify-player` for application's configuration files. This can be changed by either specifying `-c <FOLDER_PATH>` or `--config-folder <FOLDER_PATH>` option.
 
-Please refer to [the configuration documentation](https://github.com/aome510/spotify-player/blob/master/doc/config.md) for more details on the configuration options.
+Please refer to [the configuration documentation](doc/config.md) for more details on the configuration options.
 
 ## Caches
 
@@ -279,4 +279,4 @@ The application stores logs inside the `$APP_CACHE_FOLDER/spotify-player-*.log` 
 
 ## Acknowledgement
 
-`spotify-player` is written in [Rust](https://www.rust-lang.org) and is built on top of awesome libraries such as [tui-rs](https://github.com/fdehau/tui-rs), [rspotify](https://github.com/ramsayleung/rspotify), [librespot](https://github.com/librespot-org/librespot), and [many more](https://github.com/aome510/spotify-player/blob/master/spotify_player/Cargo.toml). It's highly inspired by [spotify-tui](https://github.com/Rigellute/spotify-tui) and [ncspot](https://github.com/hrkfdn/ncspot).
+`spotify-player` is written in [Rust](https://www.rust-lang.org) and is built on top of awesome libraries such as [tui-rs](https://github.com/fdehau/tui-rs), [rspotify](https://github.com/ramsayleung/rspotify), [librespot](https://github.com/librespot-org/librespot), and [many more](spotify_player/Cargo.toml). It's highly inspired by [spotify-tui](https://github.com/Rigellute/spotify-tui) and [ncspot](https://github.com/hrkfdn/ncspot).

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Under the hood, `spotify-player` retrieves the song's lyric using [Genius.com](h
 
 To enable media control support, `spotify_player` needs to be built/installed with `media-control` feature (enabled by default) and set the `enable_media_control` config option to `true` in the [general configuration file](doc/config.md#media-control).
 
+Media control support is implemented using [MPRIS DBus](https://wiki.archlinux.org/title/MPRIS) on Linux and OS window event listener on Windows and MacOS.
+
 ### Mouse support
 
 Currently, the only supported use case for mouse is to seek to a position of the current playback by left-clicking to such position in the playback's progress bar.
@@ -247,6 +249,11 @@ List of supported commands:
 | `ReverseOrder`                | reverse the order of the track table (if any)                           | `s r`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](doc/config.md#keymaps) in the configuration documentation.
+
+**Tips**:
+
+- `RefreshPlayback` can be used to manually update the playback status.
+- `RestartIntegratedClient` is useful when user wants to switch to another audio device (headphone, earphone, etc) without restarting the application, as the integrated client will be re-initialized with the new device.
 
 ### Actions
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Under the hood, `spotify-player` retrieves the song's lyric using [Genius.com](h
 
 ### Media Control
 
-To enable media control support, `spotify_player` needs to be built/installed with `media-control` feature (enabled by default) and set `enable_media_control` config option to `true` in the [general configuration file](doc/config.md#media-control).
+To enable media control support, `spotify_player` needs to be built/installed with `media-control` feature (enabled by default) and set the `enable_media_control` config option to `true` in the [general configuration file](doc/config.md#media-control).
 
 ### Mouse support
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Spotify Connect](#spotify-connect)
   - [Streaming](#streaming)
   - [Lyric](#lyric)
+  - [Media Control](#media-control)
   - [Mouse support](#mouse-support)
 - [Commands](#commands)
 - [Configurations](#configurations)
@@ -25,16 +26,11 @@
 
 - Minimalist UI with an intuitive paging and popup system.
 - Highly configurable, allow to easily customize application's shortcuts or theme/color scheme.
-- Support a majority of Spotify features through a set of [commands](#commands).
-- Support multiple Spotify pages:
-  - User library page
-  - Artist/Album/Playlist page
-  - Search page
-  - Recommendation (radio) page
-  - and many others...
+- Feature parity with the official Spotify application.
 - Support remote control with [Spotify Connect](#spotify-connect).
 - Support [streaming](#streaming) songs directly from the terminal.
 - Support [lyric](#lyric) for most songs.
+- Support [cross-platform media control](#media-control).
 
 ## Examples
 
@@ -78,7 +74,20 @@ A demo of `spotify-player` `v0.5.0-pre-release` on [youtube](https://www.youtube
 
 A Spotify Premium account is **required**.
 
-To build and run the application, Window and MacOS users will need to install [Rust and cargo](https://www.rust-lang.org/tools/install) as the build requirements. Linux users will also need to install additional dependencies such as `openssl` and `alsa-lib` (`libasound2-dev` in Ubuntu and `alsa-lib` in Arch Linux) to build and run the application.
+#### Dependencies
+
+##### Windows and MacOS
+
+- [Rust and cargo](https://www.rust-lang.org/tools/install) as the build dependencies
+
+##### Linux
+
+- [Rust and cargo](https://www.rust-lang.org/tools/install) as the build dependencies
+- `openssl`, `alsa-lib` (`streaming` feature), `libdbus` (`media-control` feature). For example, on Debian based systems, run the below command to install application's dependencies:
+
+```shell
+sudo apt install libssl-dev libasound2-dev libdbus-1-dev
+```
 
 ### Cargo
 
@@ -130,25 +139,25 @@ docker run --rm \
 
 ### Spotify Connect
 
-To enable a full [Spotify connect](https://www.spotify.com/us/connect/) support, user will need to register a Spotify application and specify their own `client_id` in the application's general configuration file as described in the [configuration documentation](https://github.com/aome510/spotify-player/blob/master/doc/config.md#general).
+To enable a full [Spotify connect](https://www.spotify.com/us/connect/) support, user will need to register a Spotify application and specify the application's `client_id` in the general configuration file as described in the [configuration documentation](https://github.com/aome510/spotify-player/blob/master/doc/config.md#general).
 
-More details on registering a Spotify application can be found in the [official Spotify documentation](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/).
+More details about registering a Spotify application can be found in the [official Spotify documentation](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/).
 
 When `spotify_player` runs with your own `client_id`, press **D** (default shortcut for `SwitchDevice` command) to get the list of available devices, then press **enter** (default shortcut for `ChooseSelected` command) to connect to the selected device.
 
-An example of using Spotify connect to interact with Spotify's official client:
+An example of using Spotify connect to interact with the Spotify's official application:
 
 ![Spotify Connect Example](https://user-images.githubusercontent.com/40011582/140323795-8a7ed2bb-7bda-4db2-9672-6036eac6e771.gif)
 
 ### Streaming
 
-`spotify-player` supports streaming (needs to be built with `streaming` feature), e.g playing music directly from terminal without other Spotify client.
+`spotify-player` supports streaming (needs to be built with `streaming` feature), e.g playing music directly from terminal without other Spotify clients.
 
-It uses the [librespot](https://github.com/librespot-org/librespot) library to create an integrated Spotify client while running. The integrated client will register a Spotify speaker device under the `spotify-player` name and is also accessible through [Spotify connect](#spotify-connect).
+It uses the [librespot](https://github.com/librespot-org/librespot) library to create an integrated Spotify client while running. The integrated client will register a Spotify speaker device under the `spotify-player` name, which is accessible on the [Spotify connect](#spotify-connect) device list.
 
 #### Audio backend
 
-`spotify-player` uses [rodio](https://github.com/RustAudio/rodio) as the default [audio backend](https://github.com/librespot-org/librespot/wiki/Audio-Backends). List of available backends:
+`spotify-player` uses [rodio](https://github.com/RustAudio/rodio) as the default [audio backend](https://github.com/librespot-org/librespot/wiki/Audio-Backends). List of available audio backends:
 
 - `alsa-backend`
 - `pulseaudio-backend`
@@ -159,25 +168,31 @@ It uses the [librespot](https://github.com/librespot-org/librespot) library to c
 - `sdl-backend`
 - `gstreamer-backend`
 
-User can change the audio backend when building the application by specifying the `--features` option. For example, to build `spotify-player` with `pulseaudio-backend`, run
+User can change the audio backend when building/installing the application by specifying the `--features` option. For example, to install `spotify-player` with `pulseaudio-backend`, run
 
 ```shell
-cargo build --release --no-default-features --features pulseaudio-backend
+cargo install spotify_player --no-default-features --features pulseaudio-backend
 ```
 
-**Note**: user will need additional dependencies depending on the selected audio backend. More details can be found in the [Librespot documentation](https://github.com/librespot-org/librespot/wiki/Compiling#general-dependencies).
+**Note**: user will need to install additional dependencies depending on the selected audio backend. More details can be found in the [Librespot documentation](https://github.com/librespot-org/librespot/wiki/Compiling#general-dependencies).
 
-The `streaming` feature can be disabled by running (to use the application as a remote player only)
+The `streaming` feature can be also disabled upon installing by running
 
 ```shell
-cargo build --release --no-default-features
+cargo install spotify_player --no-default-features
 ```
 
 ### Lyric
 
+To enable lyric support, `spotify_player` needs to be built/installed with `lyric-finder` feature (enabled by default).
+
 User can view lyric of the currently playing track by calling the `LyricPage` command to go the lyric page. To do this, `spotify-player` needs to be built with a `lyric-finder` feature.
 
 Under the hood, `spotify-player` retrieves the song's lyric using [Genius.com](https://genius.com).
+
+### Media Control
+
+To enable media control support, `spotify_player` needs to be built/installed with `media-control` feature (enabled by default) and set `enable_media_control` config option to `true` in the [general configuration file](doc/config.md#media-control).
 
 ### Mouse support
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -64,7 +64,7 @@ The configuration options for the [Librespot](https://github.com/librespot-org/l
 | `name`        | The librespot device's name                                             | `spotify-player` |
 | `device_type` | The librespot device's type                                             | `speaker`        |
 | `volume`      | Initial volume (in percentage) of the device                            | `50`             |
-| `bitrate`     | Bitrate in kbps (`96`, `160`, `320`)                                    | `160`            |
+| `bitrate`     | Bitrate in kbps (`96`, `160`, or `320`)                                 | `160`            |
 | `audio_cache` | Enable caching audio files (store in `$APP_CACHE_FOLDER/audio/` folder) | `false`          |
 
 More details on the above configuration options can be found under the [Librespot wiki page](https://github.com/librespot-org/librespot/wiki/Options).

--- a/doc/config.md
+++ b/doc/config.md
@@ -3,6 +3,8 @@
 ## Table of Contents
 
 - [General](#general)
+  - [Notes](#notes)
+  - [Device configurations](#device-configurations)
 - [Themes](#themes)
   - [Use script to add theme](#use-script-to-add-theme)
   - [Palette](#palette)
@@ -15,17 +17,18 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify-player` uses `app.toml` to configure general application configurations:
 
-| Option                            | Description                                                        | Default                            |
-| --------------------------------- | ------------------------------------------------------------------ | ---------------------------------- |
-| `client_id`                       | the Spotify client's ID                                            | `65b708073fc0480ea92a077233ca87bd` |
-| `theme`                           | the application's theme                                            | `dracula`                          |
-| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes | `32`                               |
-| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes    | `0`                                |
-| `track_table_item_max_len`        | the maximum length of a column in a track table                    | `32`                               |
+| Option                            | Description                                                        | Default                                     |
+| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------- |
+| `client_id`                       | the Spotify client's ID                                            | `65b708073fc0480ea92a077233ca87bd`          |
+| `theme`                           | the application's theme                                            | `dracula`                                   |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes | `32`                                        |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes    | `0`                                         |
+| `track_table_item_max_len`        | the maximum length of a column in a track table                    | `32`                                        |
+| `enable_media_control`            | enable application media control support                           | `true` (Linux), `false` (Windows and MacOS) |
 
 The default `app.toml` can be found in the example [`app.toml`](https://github.com/aome510/spotify-player/blob/master/examples/app.toml) file
 
-**Note**:
+### Notes
 
 - By default, `spotify-player` uses the official Spotify Web app's client (`client_id = 65b708073fc0480ea92a077233ca87bd`)
 - It's recommended to specify [your own Client ID](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to avoid possible rate limits and to allow a full [Spotify connect](https://www.spotify.com/us/connect/) support.
@@ -45,6 +48,12 @@ The default `app.toml` can be found in the example [`app.toml`](https://github.c
   **Note**: the above list might not be up-to-date.
 
 - An example of event that triggers a playback update is the one happening when the current track ends.
+
+#### Media control
+
+Media control support (`enable_media_control` option) is enabled by default on Linux but disabled by default on MacOS and Windows.
+
+MacOS and Windows require **an open window** to listen to OS media event. As a result, `spotify_player` needs to spawn an invisible window on startup, which may steal focus from the running terminal. To interact with the `spotify-player`, which is run on the terminal, user will need to re-focus the terminal. Because of this extra re-focus step, the media control support is disabled by default on MacOS and Windows to avoid possible confusion for first-time users.
 
 ### Device configurations
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -26,7 +26,7 @@ All configuration files should be placed inside the application's configuration 
 | `track_table_item_max_len`        | the maximum length of a column in a track table                    | `32`                                        |
 | `enable_media_control`            | enable application media control support                           | `true` (Linux), `false` (Windows and MacOS) |
 
-The default `app.toml` can be found in the example [`app.toml`](https://github.com/aome510/spotify-player/blob/master/examples/app.toml) file
+The default `app.toml` can be found in the example [`app.toml`](examples/app.toml) file
 
 ### Notes
 
@@ -77,7 +77,7 @@ The new theme can then be used by setting the `theme` option in the [`app.toml`]
 
 A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of predefined style for application's components). `name` and `palette` are required when defining a new theme. If `component_style` is not specified, a default value will be used.
 
-An example of user-defined themes can be found in the example [`theme.toml`](https://github.com/aome510/spotify-player/blob/master/examples/theme.toml) file
+An example of user-defined themes can be found in the example [`theme.toml`](examples/theme.toml) file
 
 ### Use script to add theme
 
@@ -148,7 +148,7 @@ table_header = { fg = "Blue" }
 
 ## Keymaps
 
-`spotify-player` uses `keymap.toml` to add or override new key mappings in additional to [the default key mappings](https://github.com/aome510/spotify-player#commands). To define a new key mapping, simply add a `keymaps` entry. For example,
+`spotify-player` uses `keymap.toml` to add or override new key mappings in additional to [the default key mappings](../README.md#commands). To define a new key mapping, simply add a `keymaps` entry. For example,
 
 ```toml
 [[keymaps]]

--- a/doc/config.md
+++ b/doc/config.md
@@ -53,7 +53,7 @@ The default `app.toml` can be found in the example [`app.toml`](examples/app.tom
 
 Media control support (`enable_media_control` option) is enabled by default on Linux but disabled by default on MacOS and Windows.
 
-MacOS and Windows require **an open window** to listen to OS media event. As a result, `spotify_player` needs to spawn an invisible window on startup, which may steal focus from the running terminal. To interact with the `spotify-player`, which is run on the terminal, user will need to re-focus the terminal. Because of this extra re-focus step, the media control support is disabled by default on MacOS and Windows to avoid possible confusion for first-time users.
+MacOS and Windows require **an open window** to listen to OS media event. As a result, `spotify_player` needs to spawn an invisible window on startup, which may steal focus from the running terminal. To interact with `spotify-player`, which is run on the terminal, user will need to re-focus the terminal. Because of this extra re-focus step, the media control support is disabled by default on MacOS and Windows to avoid possible confusion for first-time users.
 
 ### Device configurations
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -3,6 +3,7 @@ client_id = "65b708073fc0480ea92a077233ca87bd"
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 track_table_item_max_len = 32
+enable_media_control = false
 
 [device]
 name = "spotify-player"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1.0.57"
 clap = "3.1.18"
-config_parser2 = "0.1.2"
+config_parser2 = "0.1.3"
 crossterm = "0.23.2"
 dirs-next = "2.0.0"
 librespot-connect = { version = "0.3.1", optional = true }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -23,7 +23,7 @@ pub enum Command {
     RefreshPlayback,
 
     #[cfg(feature = "streaming")]
-    ReconnectIntegratedClient,
+    RestartIntegratedClient,
 
     FocusNextWindow,
     FocusPreviousWindow,
@@ -81,7 +81,7 @@ impl Command {
             Self::OpenCommandHelp => "open a command help popup",
             Self::ClosePopup => "close a popup",
             #[cfg(feature = "streaming")]
-            Self::ReconnectIntegratedClient => "reconnect the integrated librespot client",
+            Self::RestartIntegratedClient => "restart the integrated librespot client",
             Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down",
             Self::SelectPreviousOrScrollUp => {
                 "select the previous item in a list/table or scroll up"

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -82,7 +82,7 @@ impl Default for KeymapConfig {
                 #[cfg(feature = "streaming")]
                 Keymap {
                     key_sequence: "R".into(),
-                    command: Command::ReconnectIntegratedClient,
+                    command: Command::RestartIntegratedClient,
                 },
                 Keymap {
                     key_sequence: "tab".into(),

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -23,6 +23,8 @@ pub struct AppConfig {
     pub app_refresh_duration_in_ms: u64,
     pub playback_refresh_duration_in_ms: u64,
     pub track_table_item_max_len: usize,
+    #[cfg(feature = "media-control")]
+    pub enable_media_control: bool,
 
     pub device: DeviceConfig,
 }
@@ -46,6 +48,17 @@ impl Default for AppConfig {
             app_refresh_duration_in_ms: 32,
             playback_refresh_duration_in_ms: 0,
             track_table_item_max_len: 32,
+
+            // Because of the creating new window and stealing focus behaviour
+            // when running the media control event loop on startup,
+            // `media_control` support is disabled by default for Windows and MacOS.
+            // Users will need to explicitly enable this option in their configuration files.
+            #[cfg(feature = "media-control")]
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            enable_media_control: false,
+            #[cfg(feature = "media-control")]
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            enable_media_control: true,
 
             device: DeviceConfig::default(),
         }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -49,15 +49,15 @@ impl Default for AppConfig {
             playback_refresh_duration_in_ms: 0,
             track_table_item_max_len: 32,
 
-            // Because of the creating new window and stealing focus behaviour
+            // Because of the "creating new window and stealing focus" behaviour
             // when running the media control event loop on startup,
-            // `media_control` support is disabled by default for Windows and MacOS.
+            // media control support is disabled by default for Windows and MacOS.
             // Users will need to explicitly enable this option in their configuration files.
             #[cfg(feature = "media-control")]
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             enable_media_control: false,
             #[cfg(feature = "media-control")]
-            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            #[cfg(target_os = "linux")]
             enable_media_control: true,
 
             device: DeviceConfig::default(),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     command::Command,
     key::{Key, KeySequence},
     state::*,
-    utils::{new_list_state, new_table_state},
+    utils::{map_join, new_list_state, new_table_state},
 };
 use anyhow::Result;
 use tokio::sync::mpsc;
@@ -284,17 +284,7 @@ fn handle_global_command(
         #[cfg(feature = "lyric-finder")]
         Command::LyricPage => {
             if let Some(track) = state.player.read().current_playing_track() {
-                let artists = track
-                    .artists
-                    .iter()
-                    .map(|a| &a.name)
-                    .fold(String::new(), |x, y| {
-                        if x.is_empty() {
-                            x + y
-                        } else {
-                            x + ", " + y
-                        }
-                    });
+                let artists = map_join(&track.artists, |a| &a.name, ", ");
                 ui.create_new_page(PageState::Lyric {
                     track: track.name.clone(),
                     artists: artists.clone(),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -323,7 +323,7 @@ fn handle_global_command(
             ui.popup = Some(PopupState::ThemeList(themes, new_list_state()));
         }
         #[cfg(feature = "streaming")]
-        Command::ReconnectIntegratedClient => {
+        Command::RestartIntegratedClient => {
             client_pub.blocking_send(ClientRequest::NewStreamingConnection)?;
         }
         Command::FocusNextWindow => {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -212,7 +212,7 @@ async fn main() -> Result<()> {
     });
 
     #[cfg(feature = "media-control")]
-    {
+    if state.app_config.enable_media_control {
         // media control task
         tokio::task::spawn_blocking({
             let state = state.clone();

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -20,6 +20,7 @@ fn update_control_metadata(
     state: &SharedState,
     controls: &mut MediaControls,
     prev_track_info: &mut String,
+    prev_is_playing: &mut Option<bool>,
 ) -> Result<(), souvlaki::Error> {
     let player = state.player.read();
 
@@ -27,13 +28,35 @@ fn update_control_metadata(
         None => {}
         Some(track) => {
             if let Some(ref playback) = player.playback {
-                let progress = player.playback_progress().map(MediaPosition);
+                #[cfg(target_os = "linux")]
+                {
+                    // For linux, the `souvlaki` crate doesn't support updating the playback's current position
+                    // and internally it only handles at most one DBus event every one second [1].
+                    // To avoid possible event congestion, which can happen when the call frequency of
+                    // `update_control_metadata` is higher than 1Hz (`refresh_duration < 1s`, see `start_event_watcher`),
+                    // only update the media playback when the playback status (determined by `is_playing` variable below) is changed.
+                    // [1]: https://github.com/Sinono3/souvlaki/blob/b4d47bb2797ffdd625c17192df640510466762e1/src/platform/linux/mod.rs#L450
 
-                if playback.is_playing {
-                    controls.set_playback(MediaPlayback::Playing { progress })?;
-                } else {
-                    controls.set_playback(MediaPlayback::Paused { progress })?;
+                    if prev_is_playing != Some(playback.is_playing) {
+                        if playback.is_playing {
+                            controls.set_playback(MediaPlayback::Playing { progress: None })?;
+                        } else {
+                            controls.set_playback(MediaPlayback::Paused { progress: None })?;
+                        }
+                    }
                 }
+
+                #[cfg(any(target_os = "macos", target_os = "windows"))]
+                {
+                    let progress = player.playback_progress().map(MediaPosition);
+                    if playback.is_playing {
+                        controls.set_playback(MediaPlayback::Playing { progress })?;
+                    } else {
+                        controls.set_playback(MediaPlayback::Paused { progress })?;
+                    }
+                }
+
+                *prev_is_playing = Some(playback.is_playing);
             }
 
             // only update metadata when the track information is changed
@@ -81,6 +104,7 @@ pub fn start_event_watcher(
 
     let refresh_duration = std::time::Duration::from_millis(200);
     let mut track_info = String::new();
+    let mut is_playing = None;
     loop {
         if let Ok(event) = rx.try_recv() {
             tracing::info!("Got a media control event: {event:?}");
@@ -104,7 +128,7 @@ pub fn start_event_watcher(
             }
         }
 
-        update_control_metadata(&state, &mut controls, &mut track_info)?;
+        update_control_metadata(&state, &mut controls, &mut track_info, &mut is_playing)?;
         std::thread::sleep(refresh_duration);
     }
 }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -68,8 +68,8 @@ pub fn start_event_watcher(
 
     let hwnd = None;
     let config = PlatformConfig {
-        display_name: "spotify_player",
-        dbus_name: "Spotify Player",
+        dbus_name: "spotify_player",
+        display_name: "Spotify Player",
         hwnd,
     };
     let mut controls = MediaControls::new(config)?;

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -1,6 +1,6 @@
-use souvlaki::{
-    MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
-};
+#![allow(unused_imports)]
+use souvlaki::MediaPosition;
+use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 
 use crate::{
     event::{ClientRequest, PlayerRequest},

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -37,7 +37,7 @@ fn update_control_metadata(
                     // only update the media playback when the playback status (determined by `is_playing` variable below) is changed.
                     // [1]: https://github.com/Sinono3/souvlaki/blob/b4d47bb2797ffdd625c17192df640510466762e1/src/platform/linux/mod.rs#L450
 
-                    if prev_is_playing != Some(playback.is_playing) {
+                    if *prev_is_playing != Some(playback.is_playing) {
                         if playback.is_playing {
                             controls.set_playback(MediaPlayback::Playing { progress: None })?;
                         } else {

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -3,6 +3,7 @@ pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
 use serde::{Deserialize, Serialize};
 
 use crate::command;
+use crate::utils::map_join;
 
 #[derive(Clone, Debug)]
 /// A Spotify context (playlist, album, artist)
@@ -296,16 +297,7 @@ impl Device {
 impl Track {
     /// gets the track's artists information
     pub fn artists_info(&self) -> String {
-        self.artists
-            .iter()
-            .map(|a| &a.name)
-            .fold(String::new(), |x, y| {
-                if x.is_empty() {
-                    x + y
-                } else {
-                    x + ", " + y
-                }
-            })
+        map_join(&self.artists, |a| &a.name, ", ")
     }
 
     /// gets the track's album information

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -44,3 +44,16 @@ pub fn new_table_state() -> TableState {
     state.select(Some(0));
     state
 }
+
+pub fn map_join<T, F>(v: &[T], f: F, sep: &str) -> String
+where
+    F: Fn(&T) -> &str,
+{
+    v.iter().map(f).fold(String::new(), |x, y| {
+        if x.is_empty() {
+            x + y
+        } else {
+            x + sep + y
+        }
+    })
+}


### PR DESCRIPTION
## Changes
- added `enable_media_control` config option
- fixed media control issues when running on Linux
- updated github CI to include more macOS and windows in addition to ubuntu as running OSes
- updated documents
  + added information about new `media-control` feature
  + cleaned up documents, updated wordings, etc

## Breaking changes
- renamed `ReconnectIntegratedClient` to `RestartIntegratedClient`