### PR TITLE
Improve device connect logic on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ An example of using Spotify connect to interact with the Spotify's official appl
 
 ### Streaming
 
-`spotify-player` supports streaming (needs to be built with `streaming` feature), e.g playing music directly from terminal without other Spotify clients.
+`spotify-player` supports streaming (needs to be built/installed with `streaming` feature, enabled by default), which allows to the application to play music directly from terminal without other Spotify clients.
 
 It uses the [librespot](https://github.com/librespot-org/librespot) library to create an integrated Spotify client while running. The integrated client will register a Spotify speaker device under the `spotify-player` name, which is accessible on the [Spotify connect](#spotify-connect) device list.
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -17,14 +17,15 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify-player` uses `app.toml` to configure general application configurations:
 
-| Option                            | Description                                                        | Default                                     |
-| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------- |
-| `client_id`                       | the Spotify client's ID                                            | `65b708073fc0480ea92a077233ca87bd`          |
-| `theme`                           | the application's theme                                            | `dracula`                                   |
-| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes | `32`                                        |
-| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes    | `0`                                         |
-| `track_table_item_max_len`        | the maximum length of a column in a track table                    | `32`                                        |
-| `enable_media_control`            | enable application media control support                           | `true` (Linux), `false` (Windows and MacOS) |
+| Option                            | Description                                                            | Default                                     |
+| --------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------- |
+| `client_id`                       | the Spotify client's ID                                                | `65b708073fc0480ea92a077233ca87bd`          |
+| `theme`                           | the application's theme                                                | `dracula`                                   |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes     | `32`                                        |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes        | `0`                                         |
+| `track_table_item_max_len`        | the maximum length of a column in a track table                        | `32`                                        |
+| `enable_media_control`            | enable application media control support                               | `true` (Linux), `false` (Windows and MacOS) |
+| `default_device`                  | the default device to connect to on startup if no playing device found | `spotify-player`                            |
 
 The default `app.toml` can be found in the example [`app.toml`](examples/app.toml) file
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -27,7 +27,7 @@ All configuration files should be placed inside the application's configuration 
 | `enable_media_control`            | enable application media control support                               | `true` (Linux), `false` (Windows and MacOS) |
 | `default_device`                  | the default device to connect to on startup if no playing device found | `spotify-player`                            |
 
-The default `app.toml` can be found in the example [`app.toml`](examples/app.toml) file
+The default `app.toml` can be found in the example [`app.toml`](../examples/app.toml) file
 
 ### Notes
 
@@ -74,11 +74,11 @@ More details on the above configuration options can be found under the [Librespo
 
 `spotify-player` uses `theme.toml` to define additional themes in addition to the default themes (`dracula`, `ayu_light`, `gruvbox_dark`, `solarized_light`).
 
-The new theme can then be used by setting the `theme` option in the [`app.toml`](#general) file or specifying the `-t <THEME>` (`--theme <THEME>`) option when running the player.
+The new theme can then be used by setting the `theme` option in the [general configuration](#general) file or specifying the `-t <THEME>` (`--theme <THEME>`) option when running the player.
 
 A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of predefined style for application's components). `name` and `palette` are required when defining a new theme. If `component_style` is not specified, a default value will be used.
 
-An example of user-defined themes can be found in the example [`theme.toml`](examples/theme.toml) file
+An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file
 
 ### Use script to add theme
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -4,6 +4,7 @@ app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 track_table_item_max_len = 32
 enable_media_control = false
+default_device = "spotify-player"
 
 [device]
 name = "spotify-player"

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -26,6 +26,8 @@ pub struct AppConfig {
     #[cfg(feature = "media-control")]
     pub enable_media_control: bool,
 
+    pub default_device: String,
+
     pub device: DeviceConfig,
 }
 
@@ -59,6 +61,8 @@ impl Default for AppConfig {
             #[cfg(feature = "media-control")]
             #[cfg(target_os = "linux")]
             enable_media_control: true,
+
+            default_device: "spotify-player".to_string(),
 
             device: DeviceConfig::default(),
         }


### PR DESCRIPTION
## Changes
- improved the device connect logic on startup, so that the transfer playback change is shown up in the player
- added `default_device` general config option representing the preferred device to connect to on startup if no playing device found