### PR TITLE
Tweak application tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1ceeb589a3157cac0ab8cc585feb749bd2cea5cb55a6ee802ad72d9fd38303da"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3563,6 +3563,7 @@ dependencies = [
  "config_parser2",
  "crossterm",
  "dirs-next",
+ "flume",
  "image",
  "librespot-connect",
  "librespot-core",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -41,6 +41,7 @@ souvlaki = { version = "0.5.1", optional = true }
 winit = { version = "0.26.1", optional = true }
 viuer = { version = "0.6.1", optional = true }
 image = { version= "0.24", optional = true }
+flume = "0.10.13"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -47,19 +47,25 @@ pub async fn start_client_handler(
 
 /// Starts multiple event watchers listening to events and
 /// notifying the client to make update requests if needed
-pub fn start_player_event_watchers(state: SharedState, client_pub: mpsc::Sender<ClientRequest>) {
+pub async fn start_player_event_watchers(
+    state: SharedState,
+    client_pub: mpsc::Sender<ClientRequest>,
+) {
     // Start a watcher task that updates the playback every `playback_refresh_duration_in_ms` ms.
     // A positive value of `playback_refresh_duration_in_ms` is required to start the watcher.
     if state.app_config.playback_refresh_duration_in_ms > 0 {
-        tokio::task::spawn_blocking({
+        tokio::task::spawn({
             let client_pub = client_pub.clone();
             let playback_refresh_duration =
                 std::time::Duration::from_millis(state.app_config.playback_refresh_duration_in_ms);
-            move || loop {
-                client_pub
-                    .blocking_send(ClientRequest::GetCurrentPlayback)
-                    .unwrap_or_default();
-                std::thread::sleep(playback_refresh_duration);
+            async move {
+                loop {
+                    client_pub
+                        .send(ClientRequest::GetCurrentPlayback)
+                        .await
+                        .unwrap_or_default();
+                    tokio::time::sleep(playback_refresh_duration).await;
+                }
             }
         });
     }
@@ -67,58 +73,72 @@ pub fn start_player_event_watchers(state: SharedState, client_pub: mpsc::Sender<
     // Main watcher task
     let refresh_duration = std::time::Duration::from_millis(200);
     loop {
-        std::thread::sleep(refresh_duration);
-
-        let mut ui = state.ui.lock();
-        let player = state.player.read();
+        tokio::time::sleep(refresh_duration).await;
 
         // update the playback when the current track ends
-        let progress_ms = player.playback_progress();
-        let duration_ms = player.current_playing_track().map(|t| t.duration);
-        let is_playing = match player.playback {
-            Some(ref playback) => playback.is_playing,
-            None => false,
+        let (progress_ms, duration_ms, is_playing) = {
+            let player = state.player.read();
+
+            (
+                player.playback_progress(),
+                player.current_playing_track().map(|t| t.duration),
+                player
+                    .playback
+                    .as_ref()
+                    .map(|p| p.is_playing)
+                    .unwrap_or_default(),
+            )
         };
         if let (Some(progress_ms), Some(duration_ms)) = (progress_ms, duration_ms) {
             if progress_ms >= duration_ms && is_playing {
                 client_pub
-                    .blocking_send(ClientRequest::GetCurrentPlayback)
+                    .send(ClientRequest::GetCurrentPlayback)
+                    .await
                     .unwrap_or_default();
             }
         }
 
         // update the context state and request new data when moving to a new context page
+        let mut new_context_id: Option<ContextId> = None;
         if let PageState::Context {
             id,
             context_page_type,
-            state,
-        } = ui.current_page_mut()
+            state: page_state,
+        } = state.ui.lock().current_page_mut()
         {
             let expected_id = match context_page_type {
                 ContextPageType::Browsing(context_id) => Some(context_id.clone()),
-                ContextPageType::CurrentPlaying => player.playing_context_id(),
+                ContextPageType::CurrentPlaying => state.player.read().playing_context_id(),
             };
 
             if *id != expected_id {
                 tracing::info!("Current context ID ({:?}) is different from the expected ID ({:?}), update the context state", id, expected_id);
 
-                *id = expected_id.clone();
-                match expected_id {
+                *id = expected_id;
+
+                match id {
                     Some(id) => {
-                        client_pub
-                            .blocking_send(ClientRequest::GetContext(id.clone()))
-                            .unwrap_or_default();
-                        *state = Some(match id {
+                        *page_state = Some(match id {
                             ContextId::Album(_) => ContextPageUIState::new_album(),
                             ContextId::Artist(_) => ContextPageUIState::new_artist(),
                             ContextId::Playlist(_) => ContextPageUIState::new_playlist(),
                         });
+                        new_context_id = Some(id.clone());
                     }
                     None => {
-                        *state = None;
+                        *page_state = None;
                     }
                 }
             }
+        }
+
+        // Found a new context ID compared to the previous one,
+        // make a `GetContext` request to get context data.
+        if let Some(id) = new_context_id {
+            client_pub
+                .send(ClientRequest::GetContext(id))
+                .await
+                .unwrap_or_default();
         }
     }
 }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -15,7 +15,6 @@ mod handlers;
 mod spotify;
 
 pub use handlers::*;
-use tokio::sync::{broadcast, mpsc};
 use tracing::Instrument;
 
 /// The application's client
@@ -38,8 +37,8 @@ impl Client {
     #[cfg(feature = "streaming")]
     pub async fn new_streaming_connection(
         &self,
-        streaming_sub: broadcast::Receiver<()>,
-        client_pub: mpsc::Sender<ClientRequest>,
+        streaming_sub: flume::Receiver<()>,
+        client_pub: flume::Sender<ClientRequest>,
         should_connect: bool,
     ) -> Result<()> {
         let session = match self.spotify.session {

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -54,7 +54,7 @@ pub fn handle_key_sequence_for_library_page(
 
 pub fn handle_key_sequence_for_search_page(
     key_sequence: &KeySequence,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let mut ui = state.ui.lock();
@@ -86,7 +86,7 @@ pub fn handle_key_sequence_for_search_page(
                     crossterm::event::KeyCode::Enter => {
                         if !input.is_empty() {
                             *current_query = input.clone();
-                            client_pub.blocking_send(ClientRequest::Search(input.clone()))?;
+                            client_pub.send(ClientRequest::Search(input.clone()))?;
                         }
                         return Ok(true);
                     }
@@ -139,7 +139,7 @@ pub fn handle_key_sequence_for_search_page(
 
 pub fn handle_key_sequence_for_context_page(
     key_sequence: &KeySequence,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let command = match state
@@ -183,9 +183,9 @@ pub fn handle_key_sequence_for_context_page(
                         }
                     };
 
-                    client_pub.blocking_send(ClientRequest::Player(
-                        PlayerRequest::StartPlayback(Playback::Context(context_id, offset)),
-                    ))?;
+                    client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                        Playback::Context(context_id, offset),
+                    )))?;
                 }
             }
         }
@@ -228,7 +228,7 @@ pub fn handle_key_sequence_for_context_page(
 
 pub fn handle_key_sequence_for_tracks_page(
     key_sequence: &KeySequence,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let command = match state
@@ -268,7 +268,7 @@ pub fn handle_key_sequence_for_tracks_page(
                 let id = rand::thread_rng().gen_range(0..tracks.len());
                 Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()))
             };
-            client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
+            client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(tracks.iter().map(|t| t.id.clone()).collect(), offset),
             )))?;
 
@@ -288,7 +288,7 @@ pub fn handle_key_sequence_for_tracks_page(
 #[cfg(feature = "lyric-finder")]
 pub fn handle_key_sequence_for_lyric_page(
     key_sequence: &KeySequence,
-    _client_pub: &mpsc::Sender<ClientRequest>,
+    _client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let command = match state

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -190,9 +190,10 @@ pub fn handle_key_sequence_for_popup(
                         .as_ref()
                         .map(|p| p.is_playing)
                         .unwrap_or(false);
-                    client_pub.send(ClientRequest::Player(
-                        PlayerRequest::TransferPlayback(player.devices[id].id.clone(), is_playing),
-                    ))?;
+                    client_pub.send(ClientRequest::Player(PlayerRequest::TransferPlayback(
+                        player.devices[id].id.clone(),
+                        is_playing,
+                    )))?;
                     ui.popup = None;
                     Ok(())
                 },
@@ -434,9 +435,9 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     Action::BrowseRecommendations => {
-                        client_pub.send(ClientRequest::GetRecommendations(
-                            SeedItem::Track(track.clone()),
-                        ))?;
+                        client_pub.send(ClientRequest::GetRecommendations(SeedItem::Track(
+                            track.clone(),
+                        )))?;
                         let new_page = PageState::Tracks {
                             id: format!("recommendations::{}", track.id.uri()),
                             title: "Recommendations".to_string(),
@@ -465,9 +466,9 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     Action::BrowseRecommendations => {
-                        client_pub.send(ClientRequest::GetRecommendations(
-                            SeedItem::Artist(artist.clone()),
-                        ))?;
+                        client_pub.send(ClientRequest::GetRecommendations(SeedItem::Artist(
+                            artist.clone(),
+                        )))?;
                         let new_page = PageState::Tracks {
                             id: format!("recommendations::{}", artist.id.uri()),
                             title: "Recommendations".to_string(),

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -7,7 +7,7 @@ use crate::state::UIStateGuard;
 /// assign the handling job to such window's command handler
 pub fn handle_command_for_focused_context_window(
     command: Command,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<bool> {
     let ui = state.ui.lock();
@@ -93,7 +93,7 @@ pub fn handle_command_for_focused_context_window(
 /// The above case is used for the track table of a playlist or an album.
 pub fn handle_command_for_track_table_window(
     command: Command,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     context_id: Option<ContextId>,
     track_ids: Option<Vec<&TrackId>>,
     tracks: Vec<&Track>,
@@ -119,12 +119,12 @@ pub fn handle_command_for_track_table_window(
             let offset = Some(rspotify_model::Offset::for_uri(&tracks[id].id.uri()));
             if track_ids.is_some() {
                 // play a track from a list of tracks
-                client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                     Playback::URIs(track_ids.unwrap().into_iter().cloned().collect(), offset),
                 )))?;
             } else if context_id.is_some() {
                 // play a track from a context
-                client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                     Playback::Context(context_id.unwrap(), offset),
                 )))?;
             }
@@ -142,7 +142,7 @@ pub fn handle_command_for_track_table_window(
 
 pub fn handle_command_for_track_list_window(
     command: Command,
-    client_pub: &mpsc::Sender<ClientRequest>,
+    client_pub: &flume::Sender<ClientRequest>,
     tracks: Vec<&Track>,
     mut ui: UIStateGuard,
 ) -> Result<bool> {
@@ -168,7 +168,7 @@ pub fn handle_command_for_track_list_window(
             // It's different for the track table, in which
             // `ChooseSelected` on a track will start a `URIs` playback
             // containing all the tracks in the table.
-            client_pub.blocking_send(ClientRequest::Player(PlayerRequest::StartPlayback(
+            client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(vec![tracks[id].id.clone()], None),
             )))?;
         }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -77,33 +77,21 @@ async fn init_spotify(
             .find_available_device(&state.app_config.default_device)
             .await?
         {
-            client_pub
-                .send_async(event::ClientRequest::Player(
-                    event::PlayerRequest::TransferPlayback(device_id, false),
-                ))
-                .await?;
+            client_pub.send(event::ClientRequest::Player(
+                event::PlayerRequest::TransferPlayback(device_id, false),
+            ))?;
         }
     }
 
-    client_pub
-        .send_async(event::ClientRequest::GetCurrentPlayback)
-        .await?;
+    client_pub.send(event::ClientRequest::GetCurrentPlayback)?;
 
     // request user data
-    client_pub
-        .send_async(event::ClientRequest::GetCurrentUser)
-        .await?;
+    client_pub.send(event::ClientRequest::GetCurrentUser)?;
 
     // request data needed to render the Library page (default page when starting the application)
-    client_pub
-        .send_async(event::ClientRequest::GetUserPlaylists)
-        .await?;
-    client_pub
-        .send_async(event::ClientRequest::GetUserFollowedArtists)
-        .await?;
-    client_pub
-        .send_async(event::ClientRequest::GetUserSavedAlbums)
-        .await?;
+    client_pub.send(event::ClientRequest::GetUserPlaylists)?;
+    client_pub.send(event::ClientRequest::GetUserFollowedArtists)?;
+    client_pub.send(event::ClientRequest::GetUserSavedAlbums)?;
 
     Ok(())
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -211,17 +211,17 @@ async fn main() -> Result<()> {
     });
 
     // player event watcher task
-    tokio::task::spawn_blocking({
+    tokio::task::spawn({
         let state = state.clone();
         let client_pub = client_pub.clone();
-        move || {
-            client::start_player_event_watchers(state, client_pub);
+        async move {
+            client::start_player_event_watchers(state, client_pub).await;
         }
     });
 
     // application UI task
     #[allow(unused_variables)]
-    let task = tokio::task::spawn_blocking({
+    let ui_task = tokio::task::spawn_blocking({
         let state = state.clone();
         move || ui::run(state)
     });
@@ -255,7 +255,7 @@ async fn main() -> Result<()> {
     }
     #[allow(unreachable_code)]
     {
-        task.await??;
+        ui_task.await??;
         Ok(())
     }
 }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -74,7 +74,7 @@ fn update_control_metadata(
 /// Start the application's media control event watcher
 pub fn start_event_watcher(
     state: SharedState,
-    client_pub: tokio::sync::mpsc::Sender<ClientRequest>,
+    client_pub: flume::Sender<ClientRequest>,
 ) -> Result<(), souvlaki::Error> {
     tracing::info!("Initializing application's media control event watcher...");
 
@@ -86,7 +86,7 @@ pub fn start_event_watcher(
     };
     let mut controls = MediaControls::new(config)?;
 
-    let (tx, rx) = std::sync::mpsc::sync_channel(16);
+    let (tx, rx) = flume::unbounded();
 
     controls.attach(move |e| {
         tx.send(e).unwrap_or_default();
@@ -104,17 +104,17 @@ pub fn start_event_watcher(
             match event {
                 MediaControlEvent::Play | MediaControlEvent::Pause | MediaControlEvent::Toggle => {
                     client_pub
-                        .blocking_send(ClientRequest::Player(PlayerRequest::ResumePause))
+                        .send(ClientRequest::Player(PlayerRequest::ResumePause))
                         .unwrap_or_default();
                 }
                 MediaControlEvent::Next => {
                     client_pub
-                        .blocking_send(ClientRequest::Player(PlayerRequest::NextTrack))
+                        .send(ClientRequest::Player(PlayerRequest::NextTrack))
                         .unwrap_or_default();
                 }
                 MediaControlEvent::Previous => {
                     client_pub
-                        .blocking_send(ClientRequest::Player(PlayerRequest::PreviousTrack))
+                        .send(ClientRequest::Player(PlayerRequest::PreviousTrack))
                         .unwrap_or_default();
                 }
                 _ => {}


### PR DESCRIPTION
## Changes
- use `flume` channels to replace `tokio::sync` channels
- make `client::start_player_event_watchers` async