### PR TITLE
Action on item improvements

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -266,7 +266,8 @@ impl Client {
                 }
             }
             ClientRequest::AddTrackToPlaylist(playlist_id, track_id) => {
-                self.add_track_to_playlist(&playlist_id, &track_id).await?;
+                self.add_track_to_playlist(state, &playlist_id, &track_id)
+                    .await?;
             }
             ClientRequest::SaveToLibrary(item) => {
                 self.save_to_library(state, item).await?;
@@ -594,6 +595,7 @@ impl Client {
     /// adds track to a playlist
     pub async fn add_track_to_playlist(
         &self,
+        state: &SharedState,
         playlist_id: &PlaylistId,
         track_id: &TrackId,
     ) -> Result<()> {
@@ -607,6 +609,9 @@ impl Client {
         self.spotify
             .playlist_add_items(playlist_id, vec![dyn_track_id], None)
             .await?;
+
+        // When adding a new track to a playlist, remove the cache of that playlist
+        state.data.write().caches.context.pop(&playlist_id.uri());
 
         Ok(())
     }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -269,7 +269,7 @@ impl Client {
                 self.add_track_to_playlist(state, &playlist_id, &track_id)
                     .await?;
             }
-            ClientRequest::SaveToLibrary(item) => {
+            ClientRequest::AddToLibrary(item) => {
                 self.save_to_library(state, item).await?;
             }
         };

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -631,7 +631,7 @@ impl Client {
             .playlist_add_items(playlist_id, vec![dyn_track_id], None)
             .await?;
 
-        // When adding a new track to a playlist, remove the cache of that playlist
+        // After adding a new track to a playlist, remove the cache of that playlist
         state.data.write().caches.context.pop(&playlist_id.uri());
 
         Ok(())
@@ -651,6 +651,7 @@ impl Client {
                     self.spotify
                         .current_user_saved_tracks_add(vec![&track.id])
                         .await?;
+                    // update the in-memory `user_data`
                     state.data.write().user_data.saved_tracks.insert(0, track);
                 }
             }
@@ -663,6 +664,7 @@ impl Client {
                     self.spotify
                         .current_user_saved_albums_add(vec![&album.id])
                         .await?;
+                    // update the in-memory `user_data`
                     state.data.write().user_data.saved_albums.insert(0, album);
                 }
             }
@@ -673,6 +675,7 @@ impl Client {
                     .await?;
                 if !follows[0] {
                     self.spotify.user_follow_artists(vec![&artist.id]).await?;
+                    // update the in-memory `user_data`
                     state
                         .data
                         .write()
@@ -697,6 +700,7 @@ impl Client {
                         .await?;
                     if !follows[0] {
                         self.spotify.playlist_follow(&playlist.id, None).await?;
+                        // update the in-memory `user_data`
                         state.data.write().user_data.playlists.insert(0, playlist);
                     }
                 }
@@ -705,6 +709,7 @@ impl Client {
         Ok(())
     }
 
+    // removes a Spotify item from user's library
     pub async fn remove_from_library(&self, state: &SharedState, id: ItemId) -> Result<()> {
         match id {
             ItemId::Track(id) => {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -648,6 +648,7 @@ impl Client {
                     self.spotify
                         .current_user_saved_tracks_add(vec![&track.id])
                         .await?;
+                    state.data.write().user_data.saved_tracks.insert(0, track);
                 }
             }
             Item::Album(album) => {
@@ -659,6 +660,7 @@ impl Client {
                     self.spotify
                         .current_user_saved_albums_add(vec![&album.id])
                         .await?;
+                    state.data.write().user_data.saved_albums.insert(0, album);
                 }
             }
             Item::Artist(artist) => {
@@ -668,6 +670,12 @@ impl Client {
                     .await?;
                 if !follows[0] {
                     self.spotify.user_follow_artists(vec![&artist.id]).await?;
+                    state
+                        .data
+                        .write()
+                        .user_data
+                        .followed_artists
+                        .insert(0, artist);
                 }
             }
             Item::Playlist(playlist) => {
@@ -686,6 +694,7 @@ impl Client {
                         .await?;
                     if !follows[0] {
                         self.spotify.playlist_follow(&playlist.id, None).await?;
+                        state.data.write().user_data.playlists.insert(0, playlist);
                     }
                 }
             }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -62,7 +62,6 @@ pub enum TrackAction {
     BrowseAlbum,
     BrowseRecommendations,
     AddToPlaylist,
-    RemoveFromCurrentPlaylist,
     SaveToLikedTracks,
     RemoveFromLikedTracks,
 }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -56,14 +56,35 @@ pub enum Command {
     ReverseTrackOrder,
 }
 
-/// An action on a Spotify item (track,album,artist,playlist)
-#[derive(Copy, Clone, Debug)]
-pub enum Action {
-    AddTrackToPlaylist,
-    SaveToLibrary,
+#[derive(Debug, Copy, Clone)]
+pub enum TrackAction {
     BrowseArtist,
     BrowseAlbum,
     BrowseRecommendations,
+    AddToPlaylist,
+    RemoveFromCurrentPlaylist,
+    SaveToLikedTracks,
+    RemoveFromLikedTracks,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum AlbumAction {
+    BrowseArtist,
+    AddToLibrary,
+    DeleteFromLibrary,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum ArtistAction {
+    BrowseRecommendations,
+    Follow,
+    Unfollow,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum PlaylistAction {
+    AddToLibrary,
+    DeleteFromLibrary,
 }
 
 impl Command {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    command::Command,
+    command::{Command, TrackAction},
     key::{Key, KeySequence},
     state::*,
     utils::{map_join, new_list_state, new_table_state},
@@ -39,7 +39,7 @@ pub enum ClientRequest {
     GetRecommendations(SeedItem),
     Search(String),
     AddTrackToPlaylist(PlaylistId, TrackId),
-    SaveToLibrary(Item),
+    AddToLibrary(Item),
     Player(PlayerRequest),
     #[cfg(feature = "lyric-finder")]
     GetLyric {
@@ -212,7 +212,17 @@ fn handle_global_command(
         Command::ShowActionsOnCurrentTrack => {
             if let Some(track) = state.player.read().current_playing_track() {
                 if let Some(track) = Track::try_from_full_track(track.clone()) {
-                    ui.popup = Some(PopupState::ActionList(Item::Track(track), new_list_state()));
+                    let actions = vec![
+                        TrackAction::BrowseArtist,
+                        TrackAction::BrowseAlbum,
+                        TrackAction::BrowseRecommendations,
+                        TrackAction::AddToPlaylist,
+                    ];
+                    // TODO: handle action on user's liked tracks
+                    ui.popup = Some(PopupState::ActionList(
+                        ActionListItem::Track(track, actions),
+                        new_list_state(),
+                    ));
                 }
             }
         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -282,9 +282,6 @@ fn handle_global_command(
             ui.create_new_page(PageState::Library {
                 state: LibraryPageUIState::new(),
             });
-            client_pub.send(ClientRequest::GetUserPlaylists)?;
-            client_pub.send(ClientRequest::GetUserFollowedArtists)?;
-            client_pub.send(ClientRequest::GetUserSavedAlbums)?;
         }
         Command::SearchPage => {
             ui.create_new_page(PageState::Search {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -32,6 +32,7 @@ pub enum ClientRequest {
     GetUserPlaylists,
     GetUserSavedAlbums,
     GetUserFollowedArtists,
+    GetUserSavedTracks,
     GetUserTopTracks,
     GetUserRecentlyPlayedTracks,
     GetContext(ContextId),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -213,13 +213,24 @@ fn handle_global_command(
         Command::ShowActionsOnCurrentTrack => {
             if let Some(track) = state.player.read().current_playing_track() {
                 if let Some(track) = Track::try_from_full_track(track.clone()) {
-                    let actions = vec![
+                    let mut actions = vec![
                         TrackAction::BrowseArtist,
                         TrackAction::BrowseAlbum,
                         TrackAction::BrowseRecommendations,
                         TrackAction::AddToPlaylist,
                     ];
-                    // TODO: handle action on user's liked tracks
+                    if state
+                        .data
+                        .read()
+                        .user_data
+                        .saved_tracks
+                        .iter()
+                        .any(|t| t.id == track.id)
+                    {
+                        actions.push(TrackAction::RemoveFromLikedTracks);
+                    } else {
+                        actions.push(TrackAction::SaveToLikedTracks);
+                    }
                     ui.popup = Some(PopupState::ActionList(
                         ActionListItem::Track(track, actions),
                         new_list_state(),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -275,6 +275,11 @@ fn handle_global_command(
             if ui.history.len() > 1 {
                 ui.history.pop();
                 ui.popup = None;
+                if let PageState::Context { id, .. } = ui.current_page_mut() {
+                    // Force reload the page if something has been changed compared to the last
+                    // time the page was visitted.
+                    *id = None;
+                }
             }
         }
         #[cfg(feature = "lyric-finder")]

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -41,6 +41,7 @@ pub enum ClientRequest {
     Search(String),
     AddTrackToPlaylist(PlaylistId, TrackId),
     AddToLibrary(Item),
+    DeleteFromLibrary(ItemId),
     Player(PlayerRequest),
     #[cfg(feature = "lyric-finder")]
     GetLyric {

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -33,17 +33,20 @@ pub fn handle_key_sequence_for_library_page(
                 LibraryFocusState::Playlists => window::handle_command_for_playlist_list_window(
                     command,
                     ui.search_filtered_items(&data.user_data.playlists),
+                    &data,
                     ui,
                 ),
                 LibraryFocusState::SavedAlbums => window::handle_command_for_album_list_window(
                     command,
                     ui.search_filtered_items(&data.user_data.saved_albums),
+                    &data,
                     ui,
                 ),
                 LibraryFocusState::FollowedArtists => {
                     window::handle_command_for_artist_list_window(
                         command,
                         ui.search_filtered_items(&data.user_data.followed_artists),
+                        &data,
                         ui,
                     )
                 }
@@ -114,25 +117,25 @@ pub fn handle_key_sequence_for_search_page(
             let tracks = search_results
                 .map(|s| s.tracks.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_track_list_window(command, client_pub, tracks, ui)
+            window::handle_command_for_track_list_window(command, client_pub, tracks, &data, ui)
         }
         SearchFocusState::Artists => {
             let artists = search_results
                 .map(|s| s.artists.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_artist_list_window(command, artists, ui)
+            window::handle_command_for_artist_list_window(command, artists, &data, ui)
         }
         SearchFocusState::Albums => {
             let albums = search_results
                 .map(|s| s.albums.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_album_list_window(command, albums, ui)
+            window::handle_command_for_album_list_window(command, albums, &data, ui)
         }
         SearchFocusState::Playlists => {
             let playlists = search_results
                 .map(|s| s.playlists.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_playlist_list_window(command, playlists, ui)
+            window::handle_command_for_playlist_list_window(command, playlists, &data, ui)
         }
     }
 }
@@ -280,6 +283,7 @@ pub fn handle_key_sequence_for_tracks_page(
             None,
             Some(tracks.iter().map(|t| &t.id).collect()),
             tracks,
+            &data,
             ui,
         ),
     }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -57,65 +57,54 @@ pub fn handle_key_sequence_for_popup(
                 },
             )
         }
-        PopupState::UserPlaylistList(action, _) => {
-            match action {
-                PlaylistPopupAction::Browse => {
-                    let playlist_uris = state
-                        .data
-                        .read()
-                        .user_data
-                        .playlists
-                        .iter()
-                        .map(|p| p.id.uri())
-                        .collect::<Vec<_>>();
+        PopupState::UserPlaylistList(action, _) => match action {
+            PlaylistPopupAction::Browse => {
+                let playlist_uris = state
+                    .data
+                    .read()
+                    .user_data
+                    .playlists
+                    .iter()
+                    .map(|p| p.id.uri())
+                    .collect::<Vec<_>>();
 
-                    handle_command_for_context_browsing_list_popup(
-                        command,
-                        ui,
-                        playlist_uris,
-                        rspotify_model::Type::Playlist,
-                    )
-                }
-                PlaylistPopupAction::AddTrack(track_id) => {
-                    let track_id = track_id.clone();
-                    let playlist_ids = state
-                        .data
-                        .read()
-                        .user_data
-                        .playlists_created_by_user()
-                        .into_iter()
-                        .map(|p| p.id.clone())
-                        .collect::<Vec<_>>();
-
-                    handle_command_for_list_popup(
-                        command,
-                        ui,
-                        playlist_ids.len(),
-                        |_, _| {},
-                        |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                            // when adding a new track to a playlist, we need to remove
-                            // the cache for that playlist
-                            state
-                                .data
-                                .write()
-                                .caches
-                                .context
-                                .pop(&playlist_ids[id].uri());
-
-                            client_pub.send(ClientRequest::AddTrackToPlaylist(
-                                playlist_ids[id].clone(),
-                                track_id.clone(),
-                            ))?;
-                            ui.popup = None;
-                            Ok(())
-                        },
-                        |ui: &mut UIStateGuard| {
-                            ui.popup = None;
-                        },
-                    )
-                }
+                handle_command_for_context_browsing_list_popup(
+                    command,
+                    ui,
+                    playlist_uris,
+                    rspotify_model::Type::Playlist,
+                )
             }
-        }
+            PlaylistPopupAction::AddTrack(track_id) => {
+                let track_id = track_id.clone();
+                let playlist_ids = state
+                    .data
+                    .read()
+                    .user_data
+                    .playlists_created_by_user()
+                    .into_iter()
+                    .map(|p| p.id.clone())
+                    .collect::<Vec<_>>();
+
+                handle_command_for_list_popup(
+                    command,
+                    ui,
+                    playlist_ids.len(),
+                    |_, _| {},
+                    |ui: &mut UIStateGuard, id: usize| -> Result<()> {
+                        client_pub.send(ClientRequest::AddTrackToPlaylist(
+                            playlist_ids[id].clone(),
+                            track_id.clone(),
+                        ))?;
+                        ui.popup = None;
+                        Ok(())
+                    },
+                    |ui: &mut UIStateGuard| {
+                        ui.popup = None;
+                    },
+                )
+            }
+        },
         PopupState::UserFollowedArtistList(_) => {
             let artist_uris = state
                 .data

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -437,7 +437,6 @@ fn handle_command_for_action_list_popup(
                         };
                         ui.create_new_page(new_page);
                     }
-                    TrackAction::RemoveFromCurrentPlaylist => todo!(),
                     TrackAction::RemoveFromLikedTracks => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Track(
                             track.id.clone(),

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -438,7 +438,12 @@ fn handle_command_for_action_list_popup(
                         ui.create_new_page(new_page);
                     }
                     TrackAction::RemoveFromCurrentPlaylist => todo!(),
-                    TrackAction::RemoveFromLikedTracks => todo!(),
+                    TrackAction::RemoveFromLikedTracks => {
+                        client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Track(
+                            track.id.clone(),
+                        )))?;
+                        ui.popup = None;
+                    }
                 },
                 ActionListItem::Album(album, actions) => match actions[id] {
                     AlbumAction::BrowseArtist => {
@@ -451,7 +456,12 @@ fn handle_command_for_action_list_popup(
                         client_pub.send(ClientRequest::AddToLibrary(Item::Album(album.clone())))?;
                         ui.popup = None;
                     }
-                    AlbumAction::DeleteFromLibrary => todo!(),
+                    AlbumAction::DeleteFromLibrary => {
+                        client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Album(
+                            album.id.clone(),
+                        )))?;
+                        ui.popup = None;
+                    }
                 },
                 ActionListItem::Artist(artist, actions) => match actions[id] {
                     ArtistAction::Follow => {
@@ -471,7 +481,12 @@ fn handle_command_for_action_list_popup(
                         };
                         ui.create_new_page(new_page);
                     }
-                    ArtistAction::Unfollow => todo!(),
+                    ArtistAction::Unfollow => {
+                        client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Artist(
+                            artist.id.clone(),
+                        )))?;
+                        ui.popup = None;
+                    }
                 },
                 ActionListItem::Playlist(playlist, actions) => match actions[id] {
                     PlaylistAction::AddToLibrary => {
@@ -480,7 +495,12 @@ fn handle_command_for_action_list_popup(
                         )))?;
                         ui.popup = None;
                     }
-                    PlaylistAction::DeleteFromLibrary => todo!(),
+                    PlaylistAction::DeleteFromLibrary => {
+                        client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(
+                            playlist.id.clone(),
+                        )))?;
+                        ui.popup = None;
+                    }
                 },
             }
             Ok(())

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -149,7 +149,16 @@ pub fn handle_command_for_track_table_window(
             if let Some(ContextId::Playlist(_)) = context_id {
                 actions.push(TrackAction::RemoveFromCurrentPlaylist);
             }
-            // TODO: handle action on user's liked tracks
+            if data
+                .user_data
+                .saved_tracks
+                .iter()
+                .any(|t| t.id == tracks[id].id)
+            {
+                actions.push(TrackAction::RemoveFromLikedTracks);
+            } else {
+                actions.push(TrackAction::SaveToLikedTracks);
+            }
             ui.popup = Some(PopupState::ActionList(
                 ActionListItem::Track(tracks[id].clone(), actions),
                 new_list_state(),
@@ -194,13 +203,22 @@ pub fn handle_command_for_track_list_window(
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {
-            let actions = vec![
+            let mut actions = vec![
                 TrackAction::BrowseArtist,
                 TrackAction::BrowseAlbum,
                 TrackAction::BrowseRecommendations,
                 TrackAction::AddToPlaylist,
             ];
-            // TODO: handle action on user's liked tracks
+            if data
+                .user_data
+                .saved_tracks
+                .iter()
+                .any(|t| t.id == tracks[id].id)
+            {
+                actions.push(TrackAction::RemoveFromLikedTracks);
+            } else {
+                actions.push(TrackAction::SaveToLikedTracks);
+            }
             ui.popup = Some(PopupState::ActionList(
                 ActionListItem::Track(tracks[id].clone(), actions),
                 new_list_state(),

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -146,9 +146,6 @@ pub fn handle_command_for_track_table_window(
                 TrackAction::BrowseRecommendations,
                 TrackAction::AddToPlaylist,
             ];
-            if let Some(ContextId::Playlist(_)) = context_id {
-                actions.push(TrackAction::RemoveFromCurrentPlaylist);
-            }
             if data
                 .user_data
                 .saved_tracks

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -87,11 +87,10 @@ async fn init_spotify(
 
     // request user data
     client_pub.send(event::ClientRequest::GetCurrentUser)?;
-
-    // request data needed to render the Library page (default page when starting the application)
     client_pub.send(event::ClientRequest::GetUserPlaylists)?;
     client_pub.send(event::ClientRequest::GetUserFollowedArtists)?;
     client_pub.send(event::ClientRequest::GetUserSavedAlbums)?;
+    client_pub.send(event::ClientRequest::GetUserSavedTracks)?;
 
     Ok(())
 }

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -16,6 +16,7 @@ pub struct UserData {
     pub playlists: Vec<Playlist>,
     pub followed_artists: Vec<Artist>,
     pub saved_albums: Vec<Album>,
+    pub saved_tracks: Vec<Track>,
 }
 
 #[derive(Debug)]

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,5 +1,7 @@
 use super::model::*;
 
+pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
+
 #[derive(Default, Debug)]
 /// the application's data
 pub struct AppData {

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -72,6 +72,14 @@ pub enum Item {
 }
 
 #[derive(Debug, Clone)]
+pub enum ItemId {
+    Track(TrackId),
+    Album(AlbumId),
+    Artist(ArtistId),
+    Playlist(PlaylistId),
+}
+
+#[derive(Debug, Clone)]
 /// A Spotify recommendation seed
 pub enum SeedItem {
     Track(Track),

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -2,7 +2,6 @@ pub use rspotify::model as rspotify_model;
 pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
 use serde::{Deserialize, Serialize};
 
-use crate::command;
 use crate::utils::map_join;
 
 #[derive(Clone, Debug)]
@@ -236,40 +235,6 @@ impl TrackOrder {
             Self::Album => x.album_info().cmp(&y.album_info()),
             Self::Duration => x.duration.cmp(&y.duration),
             Self::Artists => x.artists_info().cmp(&y.artists_info()),
-        }
-    }
-}
-
-impl Item {
-    /// gets the list of possible actions on the current item
-    pub fn actions(&self) -> Vec<command::Action> {
-        match self {
-            Self::Track(_) => vec![
-                command::Action::BrowseAlbum,
-                command::Action::BrowseArtist,
-                command::Action::BrowseRecommendations,
-                command::Action::AddTrackToPlaylist,
-                command::Action::SaveToLibrary,
-            ],
-            Self::Artist(_) => vec![
-                command::Action::BrowseRecommendations,
-                command::Action::SaveToLibrary,
-            ],
-            Self::Album(_) => vec![
-                command::Action::BrowseArtist,
-                command::Action::SaveToLibrary,
-            ],
-            Self::Playlist(_) => vec![command::Action::SaveToLibrary],
-        }
-    }
-
-    /// gets the name of the spotify item
-    pub fn name(&self) -> &str {
-        match self {
-            Self::Track(track) => &track.name,
-            Self::Artist(artist) => &artist.name,
-            Self::Album(album) => &album.name,
-            Self::Playlist(playlist) => &playlist.name,
         }
     }
 }

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -1,4 +1,4 @@
-use crate::state::model::*;
+use crate::{command, state::model::*};
 use tui::widgets::ListState;
 
 #[derive(Debug)]
@@ -11,10 +11,18 @@ pub enum PopupState {
     DeviceList(ListState),
     ArtistList(Vec<Artist>, ListState),
     ThemeList(Vec<crate::config::Theme>, ListState),
-    ActionList(Item, ListState),
+    ActionList(ActionListItem, ListState),
 }
 
-/// An action on a playlist popup list
+#[derive(Debug)]
+pub enum ActionListItem {
+    Track(Track, Vec<command::TrackAction>),
+    Artist(Artist, Vec<command::ArtistAction>),
+    Album(Album, Vec<command::AlbumAction>),
+    Playlist(Playlist, Vec<command::PlaylistAction>),
+}
+
+/// An action on an item in a playlist popup list
 #[derive(Debug)]
 pub enum PlaylistPopupAction {
     Browse,
@@ -63,6 +71,43 @@ impl PopupState {
         match self.list_state_mut() {
             None => {}
             Some(state) => state.select(id),
+        }
+    }
+}
+
+impl ActionListItem {
+    pub fn n_actions(&self) -> usize {
+        match self {
+            ActionListItem::Track(.., actions) => actions.len(),
+            ActionListItem::Artist(.., actions) => actions.len(),
+            ActionListItem::Album(.., actions) => actions.len(),
+            ActionListItem::Playlist(.., actions) => actions.len(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            ActionListItem::Track(track, ..) => &track.name,
+            ActionListItem::Artist(artist, ..) => &artist.name,
+            ActionListItem::Album(album, ..) => &album.name,
+            ActionListItem::Playlist(playlist, ..) => &playlist.name,
+        }
+    }
+
+    pub fn actions_desc(&self) -> Vec<String> {
+        match self {
+            ActionListItem::Track(.., actions) => {
+                actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>()
+            }
+            ActionListItem::Artist(.., actions) => {
+                actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>()
+            }
+            ActionListItem::Album(.., actions) => {
+                actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>()
+            }
+            ActionListItem::Playlist(.., actions) => {
+                actions.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>()
+            }
         }
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -112,26 +112,30 @@ pub fn construct_list_widget<'a>(
     title: &str,
     is_active: bool,
     borders: Option<Borders>,
-) -> List<'a> {
+) -> (List<'a>, usize) {
+    let n_items = items.len();
     let borders = borders.unwrap_or(Borders::ALL);
 
-    List::new(
-        items
-            .into_iter()
-            .map(|(s, is_active)| {
-                ListItem::new(s).style(if is_active {
-                    theme.current_playing()
-                } else {
-                    Style::default()
+    (
+        List::new(
+            items
+                .into_iter()
+                .map(|(s, is_active)| {
+                    ListItem::new(s).style(if is_active {
+                        theme.current_playing()
+                    } else {
+                        Style::default()
+                    })
                 })
-            })
-            .collect::<Vec<_>>(),
-    )
-    .highlight_style(theme.selection_style(is_active))
-    .block(
-        Block::default()
-            .title(theme.block_title_with_style(title))
-            .borders(borders),
+                .collect::<Vec<_>>(),
+        )
+        .highlight_style(theme.selection_style(is_active))
+        .block(
+            Block::default()
+                .title(theme.block_title_with_style(title))
+                .borders(borders),
+        ),
+        n_items,
     )
 }
 

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -51,17 +51,14 @@ pub fn render_popup(
                 (chunks[0], false)
             }
             PopupState::ActionList(item, _) => {
-                let items = item
-                    .actions()
-                    .iter()
-                    .map(|a| (format!("{:?}", a), false))
-                    .collect();
-
                 let rect = render_list_popup(
                     frame,
                     rect,
                     &format!("Actions on {}", item.name()),
-                    items,
+                    item.actions_desc()
+                        .into_iter()
+                        .map(|d| (d, false))
+                        .collect(),
                     7,
                     ui,
                 );

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -150,7 +150,7 @@ fn render_list_popup(
         .constraints([Constraint::Min(0), Constraint::Length(length)].as_ref())
         .split(rect);
 
-    let widget = construct_list_widget(&ui.theme, items, title, true, None);
+    let widget = construct_list_widget(&ui.theme, items, title, true, None).0;
 
     frame.render_stateful_widget(
         widget,


### PR DESCRIPTION
## Changes
- remove the `Action` struct in favour of more specific item-based structs, such `TrackAction`, `AlbumAction`, etc
- add `ClientRequest::{GetUserSavedTracks, RemoveFromLibrary}`, rename `ClientRequest::SaveToLibrary` to `ClientRequest::AddToLibrary`
 - update the action-on-item handlers to include "delete-from-library" action