### PR TITLE
Cleanup compilation warnings

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(any(feature = "lyric-finder", feature = "image"))]
-use anyhow::Context as AnyHowContext;
+use anyhow::Context as _;
 use anyhow::Result;
 use librespot_core::session::Session;
 use rspotify::prelude::*;

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     event::{ClientRequest, PlayerRequest},
     state::*,
 };
-use anyhow::{Context as AnyhowContext, Result};
+use anyhow::Result;
 use librespot_core::session::Session;
 use rspotify::prelude::*;
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -7,6 +7,9 @@ use crate::{
     event::{ClientRequest, PlayerRequest},
     state::*,
 };
+
+#[cfg(any(feature = "lyric-finder", feature = "image"))]
+use anyhow::Context as AnyHowContext;
 use anyhow::Result;
 use librespot_core::session::Session;
 use rspotify::prelude::*;

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,8 +2,12 @@ use crate::{
     command::{Command, TrackAction},
     key::{Key, KeySequence},
     state::*,
-    utils::{map_join, new_list_state, new_table_state},
+    utils::{new_list_state, new_table_state},
 };
+
+#[cfg(feature = "lyric-finder")]
+use crate::utils::map_join;
+
 use anyhow::Result;
 
 mod page;

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "image")]
 use crate::utils;
 
 use super::model::*;
@@ -33,6 +34,7 @@ impl PlayerState {
         }
     }
 
+    #[cfg(feature = "image")]
     /// gets the current playing track's album cover URL
     pub fn current_playing_track_album_cover_url(&self) -> Option<&str> {
         self.current_playing_track()


### PR DESCRIPTION
Cleaning up some compilation warnings for new features code not being under corresponding CFG flag, and an unused  `use` I saw while testing the package.


PD: 0.9 is published in AUR ;)