### PR TITLE
Remove `user:{user}` part when parsing URIs

### DIFF
--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -282,7 +282,7 @@ fn handle_command_for_context_browsing_list_popup(
         uris.len(),
         |_, _| {},
         |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-            let uri = uris[id].clone();
+            let uri = crate::utils::parse_uri(&uris[id]);
             let context_id = match context_type {
                 rspotify_model::Type::Playlist => ContextId::Playlist(PlaylistId::from_uri(&uri)?),
                 rspotify_model::Type::Artist => ContextId::Artist(ArtistId::from_uri(&uri)?),
@@ -400,7 +400,9 @@ fn handle_command_for_action_list_popup(
                     TrackAction::BrowseAlbum => {
                         if let Some(ref album) = track.album {
                             let uri = album.id.uri();
-                            let context_id = ContextId::Album(AlbumId::from_uri(&uri)?);
+                            let context_id = ContextId::Album(AlbumId::from_uri(
+                                &crate::utils::parse_uri(&uri),
+                            )?);
                             ui.create_new_page(PageState::Context {
                                 id: None,
                                 context_page_type: ContextPageType::Browsing(context_id),

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -62,18 +62,21 @@ impl PlayerState {
     pub fn playing_context_id(&self) -> Option<ContextId> {
         match self.playback {
             Some(ref playback) => match playback.context {
-                Some(ref context) => match context._type {
-                    rspotify_model::Type::Playlist => Some(ContextId::Playlist(
-                        PlaylistId::from_uri(&context.uri).expect("invalid playing context URI"),
-                    )),
-                    rspotify_model::Type::Album => Some(ContextId::Album(
-                        AlbumId::from_uri(&context.uri).expect("invalid playing context URI"),
-                    )),
-                    rspotify_model::Type::Artist => Some(ContextId::Artist(
-                        ArtistId::from_uri(&context.uri).expect("invalid playing context URI"),
-                    )),
-                    _ => None,
-                },
+                Some(ref context) => {
+                    let uri = crate::utils::parse_uri(&context.uri);
+                    match context._type {
+                        rspotify_model::Type::Playlist => {
+                            Some(ContextId::Playlist(PlaylistId::from_uri(&uri).ok()?))
+                        }
+                        rspotify_model::Type::Album => {
+                            Some(ContextId::Album(AlbumId::from_uri(&uri).ok()?))
+                        }
+                        rspotify_model::Type::Artist => {
+                            Some(ContextId::Artist(ArtistId::from_uri(&uri).ok()?))
+                        }
+                        _ => None,
+                    }
+                }
                 None => None,
             },
             None => None,

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use tui::widgets::*;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -63,5 +65,18 @@ pub fn get_track_album_image_url(track: &rspotify::model::FullTrack) -> Option<&
         None
     } else {
         Some(&track.album.images[0].url)
+    }
+}
+
+pub fn parse_uri(uri: &str) -> Cow<str> {
+    let parts = uri.split(':').collect::<Vec<_>>();
+    // The below URI probably has a format of `spotify:user:{user_id}:{type}:{id}`,
+    // but `rspotify` library expects to receive an URI of format `spotify:{type}:{id}`.
+    // We have to modify the URI to a corresponding format.
+    // See: https://github.com/aome510/spotify-player/issues/57#issuecomment-1160868626
+    if parts.len() == 5 {
+        Cow::Owned([parts[0], parts[3], parts[4]].join(":"))
+    } else {
+        Cow::Borrowed(uri)
     }
 }


### PR DESCRIPTION
Fixes #57.

## Context

rspotify` library expects to receive an URI of format `spotify:{type}:{id}` but URI returned from Spotify API can also have a format of `spotify:user:{user}:{type}:{id}`, which cause the panic happened in the original issue. This PR fixes this issue by removing the `user:{user}` part.