### PR TITLE
Add session configs

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -20,6 +20,8 @@ All configuration files should be placed inside the application's configuration 
 | Option                               | Description                                                                   | Default                                     |
 | ------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------- |
 | `client_id`                          | the Spotify client's ID                                                       | `65b708073fc0480ea92a077233ca87bd`          |
+| `ap_port`                            | the application's Spotify session connection port                             | `None`                                      |
+| `proxy`                              | the application's Spotify session connection proxy                            | `None`                                      |
 | `theme`                              | the application's theme                                                       | `dracula`                                   |
 | `app_refresh_duration_in_ms`         | the duration (in ms) between two consecutive application refreshes            | `32`                                        |
 | `playback_refresh_duration_in_ms`    | the duration (in ms) between two consecutive playback refreshes               | `0`                                         |
@@ -34,6 +36,7 @@ The default `app.toml` can be found in the example [`app.toml`](../examples/app.
 
 - By default, `spotify-player` uses the official Spotify Web app's client (`client_id = 65b708073fc0480ea92a077233ca87bd`)
 - It's recommended to specify [your own Client ID](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to avoid possible rate limits and to allow a full [Spotify connect](https://www.spotify.com/us/connect/) support.
+- `ap_port` and `proxy` are [Librespot's session configurations](https://github.com/librespot-org/librespot/wiki/Behind-web-proxy). By default, `spotify-player` doesn't set those values, which means the Librespot library will fallback to use its default options.
 - Positive-value `app_refresh_duration_in_ms` is used to refresh the playback periodically. This can result in hitting a Spotify rate limit if the application is running for a long time.
 - To prevent the rate limit, `spotify-player` sets `playback_refresh_duration_in_ms=0` by default and makes additional API calls when there is an event or a command triggering a playback update.
 - List of commands that triggers a playback update:

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -161,7 +161,12 @@ async fn main() -> Result<()> {
     };
 
     // create a librespot session
-    let session = auth::new_session(&cache_folder, state.app_config.device.audio_cache).await?;
+    let session = auth::new_session(
+        &cache_folder,
+        state.app_config.device.audio_cache,
+        &state.app_config,
+    )
+    .await?;
 
     // create a spotify API client
     let client = client::Client::new(


### PR DESCRIPTION
Fixes #59

## Changes
- added `ap_port` and `proxy` configs that allow to configure [Librespot session](https://github.com/librespot-org/librespot/wiki/Behind-web-proxy)