### PR TITLE
Add browse page

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ List of supported commands:
 | `LyricPage`                   | go to the lyric page of the current track (`lyric-finder` feature only) | `g L`, `l`         |
 | `LibraryPage`                 | go to the user library page                                             | `g l`              |
 | `SearchPage`                  | go to the search page                                                   | `g s`              |
+| `BrowsePage`                  | go to the browse page                                                   | `g b`              |
 | `PreviousPage`                | go to the previous page                                                 | `backspace`, `C-q` |
 | `SortTrackByTitle`            | sort the track table (if any) by track's title                          | `s t`              |
 | `SortTrackByArtists`          | sort the track table (if any) by track's artists                        | `s a`              |

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -306,12 +306,7 @@ impl Client {
             .categories_manual(None, None, Some(50), None)
             .await?;
 
-        Ok(self
-            .all_paging_items(first_page)
-            .await?
-            .into_iter()
-            .map(Category::from)
-            .collect())
+        Ok(first_page.items.into_iter().map(Category::from).collect())
     }
 
     /// Find an available device. Return the device's id if exists.

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -312,7 +312,7 @@ impl Client {
     pub async fn browse_categories(&self) -> Result<Vec<Category>> {
         let first_page = self
             .spotify
-            .categories_manual(None, None, Some(50), None)
+            .categories_manual(Some("EN"), None, Some(50), None)
             .await?;
 
         Ok(first_page.items.into_iter().map(Category::from).collect())

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -154,7 +154,6 @@ impl Client {
                         "failed to get lyric for track {} - artists {}",
                         track, artists
                     ))?;
-                    log::debug!("lyric result: {result:?}");
 
                     state.data.write().caches.lyrics.put(query, result);
                 }
@@ -924,7 +923,9 @@ impl Client {
         let mut items = first_page.items;
         let mut maybe_next = first_page.next;
         while let Some(url) = maybe_next {
-            let mut next_page = self.internal_call::<CursorBasedPage<T>>(&url).await?;
+            let mut next_page = self
+                .internal_call::<rspotify_model::CursorBasedPage<T>>(&url)
+                .await?;
             items.append(&mut next_page.items);
             maybe_next = next_page.next;
         }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -47,6 +47,7 @@ pub enum Command {
     LyricPage,
     LibraryPage,
     SearchPage,
+    BrowsePage,
     PreviousPage,
 
     SortTrackByTitle,
@@ -128,6 +129,7 @@ impl Command {
             Self::LyricPage => "go to the lyric page of the current track",
             Self::LibraryPage => "go to the user libary page",
             Self::SearchPage => "go to the search page",
+            Self::BrowsePage => "go to the browse page",
             Self::PreviousPage => "go to the previous page",
             Self::SortTrackByTitle => "sort the track table (if any) by track's title",
             Self::SortTrackByArtists => "sort the track table (if any) by track's artists",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -147,6 +147,10 @@ impl Default for KeymapConfig {
                     command: Command::SearchPage,
                 },
                 Keymap {
+                    key_sequence: "g b".into(),
+                    command: Command::BrowsePage,
+                },
+                Keymap {
                     key_sequence: "backspace".into(),
                     command: Command::PreviousPage,
                 },

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -33,6 +33,7 @@ pub enum PlayerRequest {
 pub enum ClientRequest {
     GetCurrentUser,
     GetDevices,
+    GetBrowseCategories,
     GetUserPlaylists,
     GetUserSavedAlbums,
     GetUserFollowedArtists,

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -136,6 +136,9 @@ fn handle_key_event(
             PageType::Tracks => {
                 page::handle_key_sequence_for_tracks_page(&key_sequence, client_pub, state)?
             }
+            PageType::Browse => {
+                page::handle_key_sequence_for_browse_page(&key_sequence, client_pub, state)?
+            }
             #[cfg(feature = "lyric-finder")]
             PageType::Lyric => {
                 page::handle_key_sequence_for_lyric_page(&key_sequence, client_pub, state)?
@@ -309,7 +312,7 @@ fn handle_global_command(
             ui.create_new_page(PageState::Browse {
                 state: BrowsePageUIState::new(),
             });
-            client_pub.send(ClientRequest::GetBrowseCategories);
+            client_pub.send(ClientRequest::GetBrowseCategories)?;
         }
         Command::PreviousPage => {
             if ui.history.len() > 1 {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -34,6 +34,7 @@ pub enum ClientRequest {
     GetCurrentUser,
     GetDevices,
     GetBrowseCategories,
+    GetBrowseCategoryPlaylists(Category),
     GetUserPlaylists,
     GetUserSavedAlbums,
     GetUserFollowedArtists,

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -305,6 +305,12 @@ fn handle_global_command(
                 state: SearchPageUIState::new(),
             });
         }
+        Command::BrowsePage => {
+            ui.create_new_page(PageState::Browse {
+                state: BrowsePageUIState::new(),
+            });
+            client_pub.send(ClientRequest::GetBrowseCategories);
+        }
         Command::PreviousPage => {
             if ui.history.len() > 1 {
                 ui.history.pop();

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     command::{Command, TrackAction},
     key::{Key, KeySequence},
     state::*,
-    utils::{self, new_list_state, new_table_state},
+    utils::{new_list_state, new_table_state},
 };
 
 #[cfg(feature = "lyric-finder")]
@@ -312,7 +312,7 @@ fn handle_global_command(
         Command::BrowsePage => {
             ui.create_new_page(PageState::Browse {
                 state: BrowsePageUIState::CategoryList {
-                    state: utils::new_list_state(),
+                    state: new_list_state(),
                 },
             });
             client_pub.send(ClientRequest::GetBrowseCategories)?;

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     command::{Command, TrackAction},
     key::{Key, KeySequence},
     state::*,
-    utils::{new_list_state, new_table_state},
+    utils::{self, new_list_state, new_table_state},
 };
 
 #[cfg(feature = "lyric-finder")]
@@ -310,7 +310,9 @@ fn handle_global_command(
         }
         Command::BrowsePage => {
             ui.create_new_page(PageState::Browse {
-                state: BrowsePageUIState::new(),
+                state: BrowsePageUIState::CategoryList {
+                    state: utils::new_list_state(),
+                },
             });
             client_pub.send(ClientRequest::GetBrowseCategories)?;
         }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -337,7 +337,7 @@ pub fn handle_key_sequence_for_browse_page(
                         ui.create_new_page(PageState::Browse {
                             state: BrowsePageUIState::CategoryPlaylistList {
                                 category: categories[selected].clone(),
-                                state: utils::new_list_state(),
+                                state: new_list_state(),
                             },
                         });
                     }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use rand::Rng;
 
 use super::*;
@@ -302,17 +303,67 @@ pub fn handle_key_sequence_for_browse_page(
 
     let mut ui = state.ui.lock();
     let data = state.data.read();
-    let categories = ui.search_filtered_items(&data.browse.categories);
+
+    let len = match ui.current_page() {
+        PageState::Browse { state } => match state {
+            BrowsePageUIState::CategoryList { .. } => {
+                ui.search_filtered_items(&data.browse.categories).len()
+            }
+            BrowsePageUIState::CategoryPlaylistList { category, .. } => data
+                .browse
+                .category_playlists
+                .get(&category.id)
+                .map(|v| ui.search_filtered_items(v).len())
+                .unwrap_or_default(),
+        },
+        _ => anyhow::bail!("expect a browse page state"),
+    };
 
     let page_state = ui.current_page_mut();
     let selected = page_state.selected().unwrap_or_default();
-    if selected >= categories.len() {
+    if selected >= len {
         return Ok(false);
     }
 
     match command {
+        Command::ChooseSelected => {
+            match page_state {
+                PageState::Browse { state } => match state {
+                    BrowsePageUIState::CategoryList { .. } => {
+                        let categories = ui.search_filtered_items(&data.browse.categories);
+                        client_pub.send(ClientRequest::GetBrowseCategoryPlaylists(
+                            categories[selected].clone(),
+                        ))?;
+                        ui.create_new_page(PageState::Browse {
+                            state: BrowsePageUIState::CategoryPlaylistList {
+                                category: categories[selected].clone(),
+                                state: utils::new_list_state(),
+                            },
+                        });
+                    }
+                    BrowsePageUIState::CategoryPlaylistList { category, .. } => {
+                        let playlists =
+                            data.browse
+                                .category_playlists
+                                .get(&category.id)
+                                .context(format!(
+                                    "expect to have playlists data for {category} category"
+                                ))?;
+                        let context_id = ContextId::Playlist(
+                            ui.search_filtered_items(playlists)[selected].id.clone(),
+                        );
+                        ui.create_new_page(PageState::Context {
+                            id: None,
+                            context_page_type: ContextPageType::Browsing(context_id),
+                            state: None,
+                        });
+                    }
+                },
+                _ => anyhow::bail!("expect a browse page state"),
+            };
+        }
         Command::SelectNextOrScrollDown => {
-            if selected + 1 < categories.len() {
+            if selected + 1 < len {
                 page_state.select(selected + 1);
             }
         }
@@ -322,7 +373,7 @@ pub fn handle_key_sequence_for_browse_page(
             }
         }
         Command::Search => {
-            ui.current_page_mut().select(0);
+            page_state.select(0);
             ui.popup = Some(PopupState::Search {
                 query: "".to_owned(),
             });

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -257,6 +257,9 @@ fn handle_key_sequence_for_search_popup(
         PageType::Tracks => {
             page::handle_key_sequence_for_tracks_page(key_sequence, client_pub, state)
         }
+        PageType::Browse => {
+            page::handle_key_sequence_for_browse_page(key_sequence, client_pub, state)
+        }
         #[cfg(feature = "lyric-finder")]
         PageType::Lyric => {
             page::handle_key_sequence_for_lyric_page(key_sequence, client_pub, state)

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::model::*;
 
 pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
@@ -7,6 +9,7 @@ pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
 pub struct AppData {
     pub user_data: UserData,
     pub caches: Caches,
+    pub browse: BrowseData,
 }
 
 #[derive(Default, Debug)]
@@ -29,6 +32,12 @@ pub struct Caches {
     pub lyrics: lru::LruCache<String, lyric_finder::LyricResult>,
     #[cfg(feature = "image")]
     pub images: lru::LruCache<String, image::DynamicImage>,
+}
+
+#[derive(Debug)]
+pub struct BrowseData {
+    pub categories: Vec<Category>,
+    pub category_playlists: HashMap<String, Vec<Playlist>>,
 }
 
 impl Default for Caches {

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -34,7 +34,7 @@ pub struct Caches {
     pub images: lru::LruCache<String, image::DynamicImage>,
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct BrowseData {
     pub categories: Vec<Category>,
     pub category_playlists: HashMap<String, Vec<Playlist>>,

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -137,6 +137,12 @@ pub struct Playlist {
     pub owner: (String, UserId),
 }
 
+#[derive(Clone, Debug)]
+/// A Spotify category
+pub struct Category {
+    pub id: String,
+    pub name: String,
+}
 
 impl Context {
     /// sorts tracks in the context by a sort oder
@@ -396,5 +402,14 @@ impl From<rspotify_model::FullPlaylist> for Playlist {
 impl std::fmt::Display for Playlist {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} • {}", self.name, self.owner.0)
+    }
+}
+
+impl From<rspotify_model::category::Category> for Category {
+    fn from(c: rspotify_model::category::Category) -> Self {
+        Self {
+            name: c.name,
+            id: c.id,
+        }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -1,6 +1,5 @@
 pub use rspotify::model as rspotify_model;
 pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
-use serde::{Deserialize, Serialize};
 
 use crate::utils::map_join;
 
@@ -411,5 +410,11 @@ impl From<rspotify_model::category::Category> for Category {
             name: c.name,
             id: c.id,
         }
+    }
+}
+
+impl std::fmt::Display for Category {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -137,27 +137,6 @@ pub struct Playlist {
     pub owner: (String, UserId),
 }
 
-// NOTE: the below cursor-based paging objects is a workaround to account
-// the fact that `rspotify v0.11.3` assumes `cursors` field in the response is not nullable.
-
-/// Cursor-based paging object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct CursorBasedPage<T> {
-    pub href: String,
-    pub items: Vec<T>,
-    pub limit: u32,
-    pub next: Option<String>,
-    pub cursors: Option<Cursor>,
-    /// Absent if it has read all data items. This field doesn't match what
-    /// Spotify document says
-    pub total: Option<u32>,
-}
-
-/// Cursor object
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct Cursor {
-    pub after: Option<String>,
-}
 
 impl Context {
     /// sorts tracks in the context by a sort oder

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -28,6 +28,9 @@ pub enum PageState {
         artists: String,
         scroll_offset: usize,
     },
+    Browse {
+        state: BrowsePageUIState,
+    },
 }
 
 pub enum PageType {
@@ -35,6 +38,7 @@ pub enum PageType {
     Context,
     Search,
     Tracks,
+    Browse,
     #[cfg(feature = "lyric-finder")]
     Lyric,
 }
@@ -101,6 +105,11 @@ pub enum SearchFocusState {
     Playlists,
 }
 
+#[derive(Clone, Debug)]
+pub struct BrowsePageUIState {
+    pub category_list: ListState,
+}
+
 pub enum MutableWindowState<'a> {
     Table(&'a mut TableState),
     List(&'a mut ListState),
@@ -114,6 +123,7 @@ impl PageState {
             PageState::Context { .. } => PageType::Context,
             PageState::Search { .. } => PageType::Search,
             PageState::Tracks { .. } => PageType::Tracks,
+            PageState::Browse { .. } => PageType::Browse,
             #[cfg(feature = "lyric-finder")]
             PageState::Lyric { .. } => PageType::Lyric,
         }
@@ -186,6 +196,7 @@ impl PageState {
                 },
             }),
             Self::Tracks { state, .. } => Some(MutableWindowState::Table(state)),
+            Self::Browse { state } => Some(MutableWindowState::List(&mut state.category_list)),
             #[cfg(feature = "lyric-finder")]
             Self::Lyric { .. } => None,
         }
@@ -234,6 +245,14 @@ impl ContextPageUIState {
             album_list: utils::new_list_state(),
             related_artist_list: utils::new_list_state(),
             focus: ArtistFocusState::TopTracks,
+        }
+    }
+}
+
+impl BrowsePageUIState {
+    pub fn new() -> Self {
+        Self {
+            category_list: utils::new_list_state(),
         }
     }
 }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -106,8 +106,14 @@ pub enum SearchFocusState {
 }
 
 #[derive(Clone, Debug)]
-pub struct BrowsePageUIState {
-    pub category_list: ListState,
+pub enum BrowsePageUIState {
+    CategoryList {
+        state: ListState,
+    },
+    CategoryPlaylistList {
+        category: Category,
+        state: ListState,
+    },
 }
 
 pub enum MutableWindowState<'a> {
@@ -143,7 +149,7 @@ impl PageState {
     }
 
     /// The currently focused window state of the page.
-    fn focus_window_state_mut(&mut self) -> Option<MutableWindowState> {
+    pub fn focus_window_state_mut(&mut self) -> Option<MutableWindowState> {
         match self {
             Self::Library {
                 state:
@@ -196,7 +202,12 @@ impl PageState {
                 },
             }),
             Self::Tracks { state, .. } => Some(MutableWindowState::Table(state)),
-            Self::Browse { state } => Some(MutableWindowState::List(&mut state.category_list)),
+            Self::Browse { state } => match state {
+                BrowsePageUIState::CategoryList { state } => Some(MutableWindowState::List(state)),
+                BrowsePageUIState::CategoryPlaylistList { state, .. } => {
+                    Some(MutableWindowState::List(state))
+                }
+            },
             #[cfg(feature = "lyric-finder")]
             Self::Lyric { .. } => None,
         }
@@ -245,14 +256,6 @@ impl ContextPageUIState {
             album_list: utils::new_list_state(),
             related_artist_list: utils::new_list_state(),
             focus: ArtistFocusState::TopTracks,
-        }
-    }
-}
-
-impl BrowsePageUIState {
-    pub fn new() -> Self {
-        Self {
-            category_list: utils::new_list_state(),
         }
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -101,6 +101,7 @@ fn render_main_layout(
         PageType::Search => page::render_search_page(is_active, frame, state, ui, chunks[1]),
         PageType::Context => page::render_context_page(is_active, frame, state, ui, chunks[1]),
         PageType::Tracks => page::render_tracks_page(is_active, frame, state, ui, chunks[1]),
+        PageType::Browse => page::render_browse_page(is_active, frame, state, ui, chunks[1]),
         #[cfg(feature = "lyric-finder")]
         PageType::Lyric => page::render_lyric_page(is_active, frame, state, ui, chunks[1]),
     }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -433,29 +433,31 @@ pub fn render_browse_page(
 ) -> Result<()> {
     let data = state.data.read();
 
-    let (category_list, len) = utils::construct_list_widget(
-        &ui.theme,
-        ui.search_filtered_items(&data.browse.categories)
-            .into_iter()
-            .map(|c| (c.name.clone(), false))
-            .collect(),
-        "Categories",
-        is_active,
-        None,
-    );
-
-    let page_state = match ui.current_page_mut() {
-        PageState::Browse { state } => state,
+    let (list, len) = match ui.current_page() {
+        PageState::Browse { state } => match state {
+            BrowsePageUIState::CategoryList { .. } => utils::construct_list_widget(
+                &ui.theme,
+                ui.search_filtered_items(&data.browse.categories)
+                    .into_iter()
+                    .map(|c| (c.name.clone(), false))
+                    .collect(),
+                "Categories",
+                is_active,
+                None,
+            ),
+            BrowsePageUIState::CategoryPlaylistList { category, .. } => {
+                todo!()
+            }
+        },
         s => anyhow::bail!("expect a browse page state, found {s:?}"),
     };
 
-    utils::render_list_window(
-        frame,
-        category_list,
-        rect,
-        len,
-        &mut page_state.category_list,
-    );
+    let list_state = match ui.current_page_mut().focus_window_state_mut() {
+        Some(MutableWindowState::List(list_state)) => list_state,
+        _ => anyhow::bail!("expect a list for the focused window"),
+    };
+
+    utils::render_list_window(frame, list, rect, len, list_state);
 
     Ok(())
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -446,7 +446,7 @@ pub fn render_browse_page(
                 None,
             ),
             BrowsePageUIState::CategoryPlaylistList { category, .. } => {
-                let title = format!("{} playlists", category.name);
+                let title = format!("{} Playlists", category.name);
                 let playlists = match data.browse.category_playlists.get(&category.id) {
                     Some(playlists) => playlists,
                     None => {

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -446,7 +446,24 @@ pub fn render_browse_page(
                 None,
             ),
             BrowsePageUIState::CategoryPlaylistList { category, .. } => {
-                todo!()
+                let title = format!("{} playlists", category.name);
+                let playlists = match data.browse.category_playlists.get(&category.id) {
+                    Some(playlists) => playlists,
+                    None => {
+                        utils::render_loading_window(&ui.theme, frame, rect, &title);
+                        return Ok(());
+                    }
+                };
+                utils::construct_list_widget(
+                    &ui.theme,
+                    ui.search_filtered_items(playlists)
+                        .into_iter()
+                        .map(|c| (c.name.clone(), false))
+                        .collect(),
+                    &title,
+                    is_active,
+                    None,
+                )
             }
         },
         s => anyhow::bail!("expect a browse page state, found {s:?}"),

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -424,6 +424,42 @@ pub fn render_tracks_page(
     )
 }
 
+pub fn render_browse_page(
+    is_active: bool,
+    frame: &mut Frame,
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+    rect: Rect,
+) -> Result<()> {
+    let data = state.data.read();
+
+    let (category_list, len) = utils::construct_list_widget(
+        &ui.theme,
+        ui.search_filtered_items(&data.browse.categories)
+            .into_iter()
+            .map(|c| (c.name.clone(), false))
+            .collect(),
+        "Categories",
+        is_active,
+        None,
+    );
+
+    let page_state = match ui.current_page_mut() {
+        PageState::Browse { state } => state,
+        s => anyhow::bail!("expect a browse page state, found {s:?}"),
+    };
+
+    utils::render_list_window(
+        frame,
+        category_list,
+        rect,
+        len,
+        &mut page_state.category_list,
+    );
+
+    Ok(())
+}
+
 #[cfg(feature = "lyric-finder")]
 pub fn render_lyric_page(
     _is_active: bool,

--- a/spotify_player/src/ui/utils.rs
+++ b/spotify_player/src/ui/utils.rs
@@ -73,3 +73,14 @@ pub fn render_table_window(
     adjust_table_state(state, len);
     frame.render_stateful_widget(widget, rect, state);
 }
+
+pub fn render_loading_window(theme: &config::Theme, frame: &mut Frame, rect: Rect, title: &str) {
+    frame.render_widget(
+        Paragraph::new("Loading...").block(
+            Block::default()
+                .title(theme.block_title_with_style(title))
+                .borders(Borders::ALL),
+        ),
+        rect,
+    );
+}


### PR DESCRIPTION
## Changes
- added a browse page based on Spotify's [browse APIs](https://developer.spotify.com/console/browse/)
   + added `BrowsePage` command (default binding: `g b`) and its handlers
- added `GetBrowseCategories` and `GetBrowseCategoryPlaylists` client requests along with their handlers
- cleanup legacy codes