### PR TITLE
Refactor playback rendering codes

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -29,6 +29,9 @@ All configuration files should be placed inside the application's configuration 
 | `track_table_item_max_len`           | the maximum length of a column in a track table                               | `32`                                        |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS) |
 | `default_device`                     | the default device to connect to on startup if no playing device found        | `spotify-player`                            |
+| `playback_window_width`              | the width of the playback window                                              | `6`                                         |
+| `cover_img_width`                    | the width of the cover image (`image` feature only)                           | `5`                                         |
+| `cover_img_length`                   | the length of the cover image (`image` feature only)                          | `9`                                         |
 
 The default `app.toml` can be found in the example [`app.toml`](../examples/app.toml) file
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -8,6 +8,9 @@ enable_media_control = false
 default_device = "spotify-player"
 play_icon = "⏸"
 pause_icon = "▶"
+cover_img_length = 9
+cover_img_width = 5
+playback_window_width = 6
 
 [device]
 name = "spotify-player"

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -27,7 +27,7 @@ pub struct AppConfig {
     pub proxy: Option<String>,
     pub ap_port: Option<u16>,
 
-    // referesh duration configs
+    // duration configs
     pub app_refresh_duration_in_ms: u64,
     pub playback_refresh_duration_in_ms: u64,
     #[cfg(feature = "image")]
@@ -35,9 +35,16 @@ pub struct AppConfig {
 
     pub track_table_item_max_len: usize,
 
-    // icons
+    // icon configs
     pub play_icon: String,
     pub pause_icon: String,
+
+    // layout configs
+    #[cfg(feature = "image")]
+    pub cover_img_length: usize,
+    #[cfg(feature = "image")]
+    pub cover_img_width: usize,
+    pub playback_window_width: usize,
 
     #[cfg(feature = "media-control")]
     pub enable_media_control: bool,
@@ -75,6 +82,13 @@ impl Default for AppConfig {
 
             play_icon: "⏸".to_string(),
             pause_icon: "▶".to_string(),
+
+            #[cfg(feature = "image")]
+            cover_img_length: 9,
+            #[cfg(feature = "image")]
+            cover_img_width: 5,
+
+            playback_window_width: 7,
 
             // Because of the "creating new window and stealing focus" behaviour
             // when running the media control event loop on startup,

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -88,7 +88,7 @@ impl Default for AppConfig {
             #[cfg(feature = "image")]
             cover_img_width: 5,
 
-            playback_window_width: 7,
+            playback_window_width: 6,
 
             // Because of the "creating new window and stealing focus" behaviour
             // when running the media control event loop on startup,

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -6,6 +6,7 @@ type Terminal = tui::Terminal<tui::backend::CrosstermBackend<std::io::Stdout>>;
 type Frame<'a> = tui::Frame<'a, tui::backend::CrosstermBackend<std::io::Stdout>>;
 
 mod page;
+mod playback;
 mod popup;
 mod utils;
 
@@ -91,9 +92,15 @@ fn render_main_layout(
 ) -> Result<()> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(8), Constraint::Min(0)].as_ref())
+        .constraints(
+            [
+                Constraint::Length((state.app_config.playback_window_width + 2) as u16),
+                Constraint::Min(0),
+            ]
+            .as_ref(),
+        ) // +2 for top/bot borders
         .split(rect);
-    render_playback_window(frame, state, ui, chunks[0])?;
+    playback::render_playback_window(frame, state, ui, chunks[0])?;
 
     let page_type = ui.current_page().page_type();
     match page_type {
@@ -104,171 +111,5 @@ fn render_main_layout(
         PageType::Browse => page::render_browse_page(is_active, frame, state, ui, chunks[1]),
         #[cfg(feature = "lyric-finder")]
         PageType::Lyric => page::render_lyric_page(is_active, frame, state, ui, chunks[1]),
-    }
-}
-
-/// Renders a playback window showing information about the current playback, which includes
-/// - track title, artists, album
-/// - playback metadata (playing state, repeat state, shuffle state, volume, device, etc)
-fn render_playback_window(
-    frame: &mut Frame,
-    state: &SharedState,
-    ui: &mut UIStateGuard,
-    rect: Rect,
-) -> Result<()> {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0), Constraint::Length(1)].as_ref())
-        .margin(1)
-        .split(rect);
-
-    let block = Block::default()
-        .title(ui.theme.block_title_with_style("Playback"))
-        .borders(Borders::ALL);
-    frame.render_widget(block, rect);
-
-    let player = state.player.read();
-    if let Some(ref playback) = player.playback {
-        if let Some(rspotify::model::PlayableItem::Track(ref track)) = playback.item {
-            let playback_info = vec![
-                Span::styled(
-                    format!(
-                        "{} {} • {}",
-                        if !playback.is_playing {
-                            &state.app_config.pause_icon
-                        } else {
-                            &state.app_config.play_icon
-                        },
-                        track.name,
-                        crate::utils::map_join(&track.artists, |a| &a.name, ", ")
-                    ),
-                    ui.theme.playback_track(),
-                )
-                .into(),
-                Span::styled(track.album.name.to_string(), ui.theme.playback_album()).into(),
-                Span::styled(
-                    format!(
-                        "repeat: {} | shuffle: {} | volume: {}% | device: {}",
-                        playback.repeat_state.as_ref(),
-                        playback.shuffle_state,
-                        playback.device.volume_percent.unwrap_or_default(),
-                        playback.device.name,
-                    ),
-                    ui.theme.playback_metadata(),
-                )
-                .into(),
-            ];
-
-            let playback_desc = Paragraph::new(playback_info)
-                .wrap(Wrap { trim: true })
-                .block(Block::default());
-            let progress = std::cmp::min(
-                player
-                    .playback_progress()
-                    .context("playback should exist")?,
-                track.duration,
-            );
-            let progress_bar = Gauge::default()
-                .block(Block::default())
-                .gauge_style(ui.theme.playback_progress_bar())
-                .ratio(progress.as_secs_f64() / track.duration.as_secs_f64())
-                .label(Span::styled(
-                    format!(
-                        "{}/{}",
-                        crate::utils::format_duration(progress),
-                        crate::utils::format_duration(track.duration),
-                    ),
-                    Style::default().add_modifier(Modifier::BOLD),
-                ));
-
-            let metadata_rect = {
-                #[cfg(feature = "image")]
-                {
-                    // Render the track's cover image if `image` feature is enabled
-                    let chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints(
-                            [
-                                Constraint::Length(9),
-                                Constraint::Length(1), // a margin of 1 between the cover image widget and track's metadata widget
-                                Constraint::Min(0),
-                            ]
-                            .as_ref(),
-                        )
-                        .split(chunks[0]);
-
-                    let url = crate::utils::get_track_album_image_url(track).map(String::from);
-                    if let Some(url) = url {
-                        let needs_render = match &ui.last_cover_image_render_info {
-                            Some((last_url, last_time)) => {
-                                url != *last_url
-                                    || last_time.elapsed()
-                                        > std::time::Duration::from_millis(
-                                            state.app_config.cover_image_refresh_duration_in_ms,
-                                        )
-                            }
-                            None => true,
-                        };
-
-                        if needs_render {
-                            render_track_cover_image(state, ui, chunks[0], url);
-                        }
-                    }
-
-                    chunks[2]
-                }
-
-                #[cfg(not(feature = "image"))]
-                {
-                    chunks[0]
-                }
-            };
-            let progress_bar_rect = chunks[1];
-
-            ui.playback_progress_bar_rect = progress_bar_rect;
-
-            frame.render_widget(playback_desc, metadata_rect);
-            frame.render_widget(progress_bar, progress_bar_rect);
-        }
-    } else {
-        // Previously rendered image can result in weird rendering text,
-        // clear the widget area before rendering the text.
-        #[cfg(feature = "image")]
-        if ui.last_cover_image_render_info.is_some() {
-            frame.render_widget(Clear, chunks[0]);
-            ui.last_cover_image_render_info = None;
-        }
-
-        frame.render_widget(
-            Paragraph::new(
-                "No playback found. \
-                 Please make sure there is a running Spotify client and try to connect to it using the `SwitchDevice` command."
-            )
-            .wrap(Wrap { trim: true })
-            .block(Block::default()),
-            chunks[0],
-        );
-    };
-
-    Ok(())
-}
-
-#[cfg(feature = "image")]
-fn render_track_cover_image(state: &SharedState, ui: &mut UIStateGuard, rect: Rect, url: String) {
-    let data = state.data.read();
-    if let Some(image) = data.caches.images.peek(&url) {
-        ui.last_cover_image_render_info = Some((url, std::time::Instant::now()));
-        if let Err(err) = viuer::print(
-            image,
-            &viuer::Config {
-                x: rect.x,
-                y: rect.y as i16,
-                width: Some(rect.width as u32),
-                height: Some(rect.height as u32),
-                ..Default::default()
-            },
-        ) {
-            tracing::error!("Failed to render the image: {err}",);
-        }
     }
 }

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -3,6 +3,8 @@ use super::*;
 /// Renders a playback window showing information about the current playback, which includes
 /// - track title, artists, album
 /// - playback metadata (playing state, repeat state, shuffle state, volume, device, etc)
+/// - cover image (if `image` feature is enabled)
+/// - playback progress bar
 pub fn render_playback_window(
     frame: &mut Frame,
     state: &SharedState,

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -1,0 +1,232 @@
+use super::*;
+
+/// Renders a playback window showing information about the current playback, which includes
+/// - track title, artists, album
+/// - playback metadata (playing state, repeat state, shuffle state, volume, device, etc)
+pub fn render_playback_window(
+    frame: &mut Frame,
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+    rect: Rect,
+) -> Result<()> {
+    // render borders and title
+    let block = Block::default()
+        .title(ui.theme.block_title_with_style("Playback"))
+        .borders(Borders::ALL);
+    frame.render_widget(block, rect);
+
+    let rect = {
+        // remove top/bot margins
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0)].as_ref())
+            .margin(1)
+            .split(rect)[0]
+    };
+
+    let player = state.player.read();
+    if let Some(ref playback) = player.playback {
+        if let Some(rspotify::model::PlayableItem::Track(ref track)) = playback.item {
+            let (metadata_rect, progress_bar_rect) = {
+                // allocate the progress bar rect
+                let (rect, progress_bar_rect) = {
+                    let chunks = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([Constraint::Min(0), Constraint::Length(1)].as_ref())
+                        .split(rect);
+
+                    (chunks[0], chunks[1])
+                };
+
+                let metadata_rect = {
+                    // Render the track's cover image if `image` feature is enabled
+                    #[cfg(feature = "image")]
+                    {
+                        // Split the allocated rectangle into `metadata_rect` and `cover_img_rect`
+                        let (metadata_rect, cover_img_rect) = {
+                            let hor_chunks = Layout::default()
+                                .direction(Direction::Horizontal)
+                                .constraints(
+                                    [
+                                        Constraint::Length(
+                                            state.app_config.cover_img_length as u16,
+                                        ),
+                                        Constraint::Length(1), // a margin of 1 between the cover image widget and track's metadata widget
+                                        Constraint::Min(0),    // metadata_rect
+                                    ]
+                                    .as_ref(),
+                                )
+                                .split(rect);
+                            let ver_chunks = Layout::default()
+                                .direction(Direction::Vertical)
+                                .constraints(
+                                    [
+                                        Constraint::Length(state.app_config.cover_img_width as u16), // cover_img_rect
+                                        Constraint::Min(0), // a margin of 1 between the cover image widget and track's metadata widget
+                                    ]
+                                    .as_ref(),
+                                )
+                                .split(hor_chunks[0]);
+
+                            (hor_chunks[2], ver_chunks[0])
+                        };
+
+                        let url = crate::utils::get_track_album_image_url(track).map(String::from);
+                        if let Some(url) = url {
+                            let needs_render = match &ui.last_cover_image_render_info {
+                                Some((last_url, last_time)) => {
+                                    url != *last_url
+                                        || last_time.elapsed()
+                                            > std::time::Duration::from_millis(
+                                                state.app_config.cover_image_refresh_duration_in_ms,
+                                            )
+                                }
+                                None => true,
+                            };
+
+                            if needs_render {
+                                render_playback_cover_image(state, ui, cover_img_rect, url);
+                            }
+                        }
+
+                        metadata_rect
+                    }
+
+                    #[cfg(not(feature = "image"))]
+                    {
+                        rect
+                    }
+                };
+
+                (metadata_rect, progress_bar_rect)
+            };
+
+            render_playback_metadata(frame, state, ui, metadata_rect, track, playback);
+
+            let progress = std::cmp::min(
+                player
+                    .playback_progress()
+                    .context("playback should exist")?,
+                track.duration,
+            );
+            render_playback_progress_bar(frame, ui, progress, track, progress_bar_rect);
+        } else {
+            tracing::warn!("Got a non-track playable item: {:?}", playback.item);
+        }
+    } else {
+        // Previously rendered image can result in weird rendering text,
+        // clear the widget area before rendering the text.
+        #[cfg(feature = "image")]
+        if ui.last_cover_image_render_info.is_some() {
+            frame.render_widget(Clear, rect);
+            ui.last_cover_image_render_info = None;
+        }
+
+        frame.render_widget(
+            Paragraph::new(
+                "No playback found. \
+                 Please make sure there is a running Spotify client and try to connect to it using the `SwitchDevice` command."
+            )
+            .wrap(Wrap { trim: true })
+            .block(Block::default()),
+            rect,
+        );
+    };
+
+    Ok(())
+}
+
+fn render_playback_metadata(
+    frame: &mut Frame,
+    state: &SharedState,
+    ui: &UIStateGuard,
+    rect: Rect,
+    track: &rspotify_model::FullTrack,
+    playback: &rspotify_model::CurrentPlaybackContext,
+) {
+    let playback_info = vec![
+        Span::styled(
+            format!(
+                "{} {} • {}",
+                if !playback.is_playing {
+                    &state.app_config.pause_icon
+                } else {
+                    &state.app_config.play_icon
+                },
+                track.name,
+                crate::utils::map_join(&track.artists, |a| &a.name, ", ")
+            ),
+            ui.theme.playback_track(),
+        )
+        .into(),
+        Span::styled(track.album.name.to_string(), ui.theme.playback_album()).into(),
+        Span::styled(
+            format!(
+                "repeat: {} | shuffle: {} | volume: {}% | device: {}",
+                playback.repeat_state.as_ref(),
+                playback.shuffle_state,
+                playback.device.volume_percent.unwrap_or_default(),
+                playback.device.name,
+            ),
+            ui.theme.playback_metadata(),
+        )
+        .into(),
+    ];
+
+    let playback_desc = Paragraph::new(playback_info)
+        .wrap(Wrap { trim: true })
+        .block(Block::default());
+
+    frame.render_widget(playback_desc, rect);
+}
+
+fn render_playback_progress_bar(
+    frame: &mut Frame,
+    ui: &mut UIStateGuard,
+    progress: std::time::Duration,
+    track: &rspotify_model::FullTrack,
+    rect: Rect,
+) {
+    let progress_bar = Gauge::default()
+        .block(Block::default())
+        .gauge_style(ui.theme.playback_progress_bar())
+        .ratio(progress.as_secs_f64() / track.duration.as_secs_f64())
+        .label(Span::styled(
+            format!(
+                "{}/{}",
+                crate::utils::format_duration(progress),
+                crate::utils::format_duration(track.duration),
+            ),
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+
+    // update the progress bar's position stored inside the UI state
+    ui.playback_progress_bar_rect = rect;
+
+    frame.render_widget(progress_bar, rect);
+}
+
+#[cfg(feature = "image")]
+fn render_playback_cover_image(
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+    rect: Rect,
+    url: String,
+) {
+    let data = state.data.read();
+    if let Some(image) = data.caches.images.peek(&url) {
+        ui.last_cover_image_render_info = Some((url, std::time::Instant::now()));
+        if let Err(err) = viuer::print(
+            image,
+            &viuer::Config {
+                x: rect.x,
+                y: rect.y as i16,
+                width: Some(rect.width as u32),
+                height: Some(rect.height as u32),
+                ..Default::default()
+            },
+        ) {
+            tracing::error!("Failed to render the image: {err}",);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- added new `ui::playback` module
- made the "rectangle split" code and "rendering" code more organized for different parts of the playback window
- added layout config options.  
  + Related: see https://github.com/aome510/spotify-player/issues/74#issuecomment-1225087875