### PR TITLE
Improve radio feature UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -3918,6 +3918,7 @@ dependencies = [
  "rpassword",
  "rspotify",
  "serde",
+ "serde_json",
  "souvlaki",
  "tokio",
  "toml",

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ To add new shortcuts or modify the default shortcuts, please refer to the [keyma
 ### Actions
 
 A list of actions is available for each type of Spotify item (track, album, artist, or playlist).
-For example, the list of available actions on a track is `[BrowseAlbum, BrowseArtist, BrowseRecommendations, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
+For example, the list of available actions on a track is `[GoToAlbum, GoToArtist, GoToTrackRadio, GoToArtistRadio, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
 
 To get the list of actions on an item, call the `ShowActionsOnCurrentTrack` command or `ShowActionsOnSelectedItem` command, then press enter (default binding for `ChooseSelected` command) to initiate the selected action.
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ To add new shortcuts or modify the default shortcuts, please refer to the [keyma
 ### Actions
 
 A list of actions is available for each type of Spotify item (track, album, artist, or playlist).
-For example, the list of available actions on a track is `[BrowseAlbum, BrowseArtist, BrowseRecommandations, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
+For example, the list of available actions on a track is `[BrowseAlbum, BrowseArtist, BrowseRecommendations, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
 
 To get the list of actions on an item, call the `ShowActionsOnCurrentTrack` command or `ShowActionsOnSelectedItem` command, then press enter (default binding for `ChooseSelected` command) to initiate the selected action.
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ To add new shortcuts or modify the default shortcuts, please refer to the [keyma
 ### Actions
 
 A list of actions is available for each type of Spotify item (track, album, artist, or playlist).
-For example, the list of available actions on a track is `[GoToAlbum, GoToArtist, GoToTrackRadio, GoToArtistRadio, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
+For example, the list of available actions on a track is `[GoToAlbum, GoToArtist, GoToTrackRadio, GoToArtistRadio, GoToAlbumRadio, AddToPlaylist, DeleteFromCurrentPlaylist, AddToLikedTracks, DeleteFromLikedTracks]`.
 
 To get the list of actions on an item, call the `ShowActionsOnCurrentTrack` command or `ShowActionsOnSelectedItem` command, then press enter (default binding for `ChooseSelected` command) to initiate the selected action.
 

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -42,6 +42,7 @@ winit = { version = "0.27.5", optional = true }
 viuer = { version = "0.6.2", optional = true }
 image = { version = "0.24.5", optional = true }
 flume = "0.10.14"
+serde_json = "1.0.91"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -54,6 +54,12 @@ impl Spotify {
         }
     }
 
+    pub fn session(&self) -> Result<&Session> {
+        self.session
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Client has no Spotify session"))
+    }
+
     /// gets a Spotify access token.
     /// The function may retrieve a new token and update the current token
     /// stored inside the client if the old one is expired.

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -63,9 +63,9 @@ pub enum Command {
 
 #[derive(Debug, Copy, Clone)]
 pub enum TrackAction {
-    BrowseArtist,
-    BrowseAlbum,
-    BrowseRecommendations,
+    GoToArtist,
+    GoToAlbum,
+    GoToTrackRadio,
     AddToQueue,
     AddToPlaylist,
     DeleteFromCurrentPlaylist,
@@ -75,14 +75,14 @@ pub enum TrackAction {
 
 #[derive(Debug, Copy, Clone)]
 pub enum AlbumAction {
-    BrowseArtist,
+    GoToArtist,
     AddToLibrary,
     DeleteFromLibrary,
 }
 
 #[derive(Debug, Copy, Clone)]
 pub enum ArtistAction {
-    BrowseRecommendations,
+    GoToArtistRadio,
     Follow,
     Unfollow,
 }
@@ -96,17 +96,20 @@ pub enum PlaylistAction {
 /// constructs a default list of actions on a track
 pub fn construct_track_actions(track: &Track, data: &DataReadGuard) -> Vec<TrackAction> {
     let mut actions = vec![
-        TrackAction::BrowseArtist,
-        TrackAction::BrowseAlbum,
-        TrackAction::BrowseRecommendations,
+        TrackAction::GoToArtist,
+        TrackAction::GoToAlbum,
+        TrackAction::GoToTrackRadio,
         TrackAction::AddToPlaylist,
         TrackAction::AddToQueue,
     ];
+
+    // check if the track is a liked track
     if data.user_data.saved_tracks.iter().any(|t| t.id == track.id) {
         actions.push(TrackAction::DeleteFromLikedTracks);
     } else {
         actions.push(TrackAction::AddToLikedTracks);
     }
+
     actions
 }
 

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -67,6 +67,7 @@ pub enum TrackAction {
     GoToAlbum,
     GoToTrackRadio,
     GoToArtistRadio,
+    GoToAlbumRadio,
     AddToQueue,
     AddToPlaylist,
     DeleteFromCurrentPlaylist,
@@ -77,6 +78,8 @@ pub enum TrackAction {
 #[derive(Debug, Copy, Clone)]
 pub enum AlbumAction {
     GoToArtist,
+    GoToArtistRadio,
+    GoToAlbumRadio,
     AddToLibrary,
     DeleteFromLibrary,
 }
@@ -90,6 +93,7 @@ pub enum ArtistAction {
 
 #[derive(Debug, Copy, Clone)]
 pub enum PlaylistAction {
+    GoToPlaylistRadio,
     AddToLibrary,
     DeleteFromLibrary,
 }
@@ -101,6 +105,7 @@ pub fn construct_track_actions(track: &Track, data: &DataReadGuard) -> Vec<Track
         TrackAction::GoToAlbum,
         TrackAction::GoToTrackRadio,
         TrackAction::GoToArtistRadio,
+        TrackAction::GoToAlbumRadio,
         TrackAction::AddToPlaylist,
         TrackAction::AddToQueue,
     ];

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -66,6 +66,7 @@ pub enum TrackAction {
     GoToArtist,
     GoToAlbum,
     GoToTrackRadio,
+    GoToArtistRadio,
     AddToQueue,
     AddToPlaylist,
     DeleteFromCurrentPlaylist,
@@ -99,6 +100,7 @@ pub fn construct_track_actions(track: &Track, data: &DataReadGuard) -> Vec<Track
         TrackAction::GoToArtist,
         TrackAction::GoToAlbum,
         TrackAction::GoToTrackRadio,
+        TrackAction::GoToArtistRadio,
         TrackAction::AddToPlaylist,
         TrackAction::AddToQueue,
     ];

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -43,7 +43,7 @@ pub enum ClientRequest {
     GetUserRecentlyPlayedTracks,
     GetContext(ContextId),
     GetCurrentPlayback,
-    GetRecommendations(SeedItem),
+    GetRadioTracks(String),
     Search(String),
     AddTrackToQueue(TrackId<'static>),
     AddTrackToPlaylist(PlaylistId<'static>, TrackId<'static>),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -204,6 +204,7 @@ pub fn handle_key_sequence_for_context_page(
                 _ => None,
             };
 
+            // TODO: handle sort commands for non-context pages
             if let Some(order) = order {
                 if let Some(context_id) = context_id {
                     let mut data = state.data.write();

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -32,9 +32,8 @@ pub fn handle_key_sequence_for_popup(
 
     match popup {
         PopupState::Search { .. } => anyhow::bail!("should be handled before"),
-        PopupState::ArtistList(action, artists, _) => {
+        PopupState::ArtistList(_, artists, _) => {
             let n_items = artists.len();
-            let action = *action;
 
             handle_command_for_list_popup(
                 command,
@@ -42,8 +41,8 @@ pub fn handle_key_sequence_for_popup(
                 n_items,
                 |_, _| {},
                 |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                    let artists = match ui.popup {
-                        Some(PopupState::ArtistList(_, ref artists, _)) => artists,
+                    let (action, artists) = match ui.popup {
+                        Some(PopupState::ArtistList(action, ref artists, _)) => (action, artists),
                         _ => return Ok(()),
                     };
 

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -56,16 +56,17 @@ pub fn handle_key_sequence_for_popup(
                             });
                         }
                         ArtistPopupAction::GoToRadio => {
-                            client_pub.send(ClientRequest::GetRecommendations(
-                                SeedItem::Artist(artists[id].clone()),
-                            ))?;
+                            let uri = artists[id].id.uri();
+
                             let new_page = PageState::Tracks {
-                                id: format!("recommendations::{}", artists[id].id.uri()),
+                                id: format!("radio::{uri}"),
                                 title: "Recommendations".to_string(),
                                 desc: format!("{} Radio", artists[id].name),
                                 state: new_table_state(),
                             };
                             ui.create_new_page(new_page);
+
+                            client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                         }
                     }
 
@@ -455,16 +456,17 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     TrackAction::GoToTrackRadio => {
-                        client_pub.send(ClientRequest::GetRecommendations(SeedItem::Track(
-                            track.clone(),
-                        )))?;
+                        let uri = track.id.uri();
+
                         let new_page = PageState::Tracks {
-                            id: format!("recommendations::{}", track.id.uri()),
+                            id: format!("radio::{uri}"),
                             title: "Recommendations".to_string(),
                             desc: format!("{} Radio", track.name),
                             state: new_table_state(),
                         };
                         ui.create_new_page(new_page);
+
+                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     TrackAction::GoToArtistRadio => {
                         ui.popup = Some(PopupState::ArtistList(
@@ -519,16 +521,17 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     ArtistAction::GoToArtistRadio => {
-                        client_pub.send(ClientRequest::GetRecommendations(SeedItem::Artist(
-                            artist.clone(),
-                        )))?;
+                        let uri = artist.id.uri();
+
                         let new_page = PageState::Tracks {
-                            id: format!("recommendations::{}", artist.id.uri()),
+                            id: format!("radio::{uri}"),
                             title: "Recommendations".to_string(),
                             desc: format!("{} Radio", artist.name),
                             state: new_table_state(),
                         };
                         ui.create_new_page(new_page);
+
+                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     ArtistAction::Unfollow => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Artist(

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -406,7 +406,7 @@ fn handle_command_for_action_list_popup(
 
             match item {
                 ActionListItem::Track(track, actions) => match actions[id] {
-                    TrackAction::BrowseAlbum => {
+                    TrackAction::GoToAlbum => {
                         if let Some(ref album) = track.album {
                             let uri = album.id.uri();
                             let context_id = ContextId::Album(
@@ -419,7 +419,7 @@ fn handle_command_for_action_list_popup(
                             });
                         }
                     }
-                    TrackAction::BrowseArtist => {
+                    TrackAction::GoToArtist => {
                         ui.popup = Some(PopupState::ArtistList(
                             track.artists.clone(),
                             new_list_state(),
@@ -440,7 +440,7 @@ fn handle_command_for_action_list_popup(
                         client_pub.send(ClientRequest::AddToLibrary(Item::Track(track.clone())))?;
                         ui.popup = None;
                     }
-                    TrackAction::BrowseRecommendations => {
+                    TrackAction::GoToTrackRadio => {
                         client_pub.send(ClientRequest::GetRecommendations(SeedItem::Track(
                             track.clone(),
                         )))?;
@@ -473,7 +473,7 @@ fn handle_command_for_action_list_popup(
                     }
                 },
                 ActionListItem::Album(album, actions) => match actions[id] {
-                    AlbumAction::BrowseArtist => {
+                    AlbumAction::GoToArtist => {
                         ui.popup = Some(PopupState::ArtistList(
                             album.artists.clone(),
                             new_list_state(),
@@ -496,7 +496,7 @@ fn handle_command_for_action_list_popup(
                             .send(ClientRequest::AddToLibrary(Item::Artist(artist.clone())))?;
                         ui.popup = None;
                     }
-                    ArtistAction::BrowseRecommendations => {
+                    ArtistAction::GoToArtistRadio => {
                         client_pub.send(ClientRequest::GetRecommendations(SeedItem::Artist(
                             artist.clone(),
                         )))?;

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    command::{AlbumAction, ArtistAction, PlaylistAction, TrackAction},
-    utils::new_table_state,
-};
+use crate::command::{AlbumAction, ArtistAction, PlaylistAction, TrackAction};
 use anyhow::Context;
 
 /// handles a key sequence for a popup
@@ -461,6 +458,14 @@ fn handle_command_for_action_list_popup(
                             new_list_state(),
                         ));
                     }
+                    TrackAction::GoToAlbumRadio => {
+                        if let Some(ref album) = track.album {
+                            let uri = album.id.uri();
+                            let desc = format!("{} Radio", album.name);
+                            ui.create_new_radio_page(&uri, desc);
+                            client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                        }
+                    }
                     TrackAction::DeleteFromLikedTracks => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Track(
                             track.id.clone(),
@@ -485,6 +490,19 @@ fn handle_command_for_action_list_popup(
                     AlbumAction::GoToArtist => {
                         ui.popup = Some(PopupState::ArtistList(
                             ArtistPopupAction::Browse,
+                            album.artists.clone(),
+                            new_list_state(),
+                        ));
+                    }
+                    AlbumAction::GoToAlbumRadio => {
+                        let uri = album.id.uri();
+                        let desc = format!("{} Radio", album.name);
+                        ui.create_new_radio_page(&uri, desc);
+                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                    }
+                    AlbumAction::GoToArtistRadio => {
+                        ui.popup = Some(PopupState::ArtistList(
+                            ArtistPopupAction::GoToRadio,
                             album.artists.clone(),
                             new_list_state(),
                         ));
@@ -525,6 +543,12 @@ fn handle_command_for_action_list_popup(
                             playlist.clone(),
                         )))?;
                         ui.popup = None;
+                    }
+                    PlaylistAction::GoToPlaylistRadio => {
+                        let uri = playlist.id.uri();
+                        let desc = format!("{} Radio", playlist.name);
+                        ui.create_new_radio_page(&uri, desc);
+                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     PlaylistAction::DeleteFromLibrary => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -57,15 +57,8 @@ pub fn handle_key_sequence_for_popup(
                         }
                         ArtistPopupAction::GoToRadio => {
                             let uri = artists[id].id.uri();
-
-                            let new_page = PageState::Tracks {
-                                id: format!("radio::{uri}"),
-                                title: "Recommendations".to_string(),
-                                desc: format!("{} Radio", artists[id].name),
-                                state: new_table_state(),
-                            };
-                            ui.create_new_page(new_page);
-
+                            let desc = format!("{} Radio", artists[id].name);
+                            ui.create_new_radio_page(&uri, desc);
                             client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                         }
                     }
@@ -457,15 +450,8 @@ fn handle_command_for_action_list_popup(
                     }
                     TrackAction::GoToTrackRadio => {
                         let uri = track.id.uri();
-
-                        let new_page = PageState::Tracks {
-                            id: format!("radio::{uri}"),
-                            title: "Recommendations".to_string(),
-                            desc: format!("{} Radio", track.name),
-                            state: new_table_state(),
-                        };
-                        ui.create_new_page(new_page);
-
+                        let desc = format!("{} Radio", track.name);
+                        ui.create_new_radio_page(&uri, desc);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     TrackAction::GoToArtistRadio => {
@@ -522,15 +508,8 @@ fn handle_command_for_action_list_popup(
                     }
                     ArtistAction::GoToArtistRadio => {
                         let uri = artist.id.uri();
-
-                        let new_page = PageState::Tracks {
-                            id: format!("radio::{uri}"),
-                            title: "Recommendations".to_string(),
-                            desc: format!("{} Radio", artist.name),
-                            state: new_table_state(),
-                        };
-                        ui.create_new_page(new_page);
-
+                        let desc = format!("{} Radio", artist.name);
+                        ui.create_new_radio_page(&uri, desc);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     ArtistAction::Unfollow => {

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -289,7 +289,11 @@ pub fn handle_command_for_album_list_window(
             });
         }
         Command::ShowActionsOnSelectedItem => {
-            let mut actions = vec![AlbumAction::GoToArtist];
+            let mut actions = vec![
+                AlbumAction::GoToArtist,
+                AlbumAction::GoToAlbumRadio,
+                AlbumAction::GoToArtistRadio,
+            ];
             if data
                 .user_data
                 .saved_albums
@@ -341,7 +345,7 @@ pub fn handle_command_for_playlist_list_window(
             });
         }
         Command::ShowActionsOnSelectedItem => {
-            let mut actions = vec![];
+            let mut actions = vec![PlaylistAction::GoToPlaylistRadio];
             if data
                 .user_data
                 .playlists

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -237,7 +237,7 @@ pub fn handle_command_for_artist_list_window(
             });
         }
         Command::ShowActionsOnSelectedItem => {
-            let mut actions = vec![ArtistAction::BrowseRecommendations];
+            let mut actions = vec![ArtistAction::GoToArtistRadio];
             if data
                 .user_data
                 .followed_artists
@@ -289,7 +289,7 @@ pub fn handle_command_for_album_list_window(
             });
         }
         Command::ShowActionsOnSelectedItem => {
-            let mut actions = vec![AlbumAction::BrowseArtist];
+            let mut actions = vec![AlbumAction::GoToArtist];
             if data
                 .user_data
                 .saved_albums

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -78,13 +78,6 @@ pub enum ItemId {
     Playlist(PlaylistId<'static>),
 }
 
-#[derive(Debug, Clone)]
-/// A Spotify recommendation seed
-pub enum SeedItem {
-    Track(Track),
-    Artist(Artist),
-}
-
 /// A simplified version of `rspotify::CurrentPlaybackContext`
 /// containing only fields needed to handle a `event::PlayerRequest`
 pub struct SimplifiedPlayback {
@@ -228,16 +221,6 @@ impl TrackOrder {
             Self::Album => x.album_info().cmp(&y.album_info()),
             Self::Duration => x.duration.cmp(&y.duration),
             Self::Artists => x.artists_info().cmp(&y.artists_info()),
-        }
-    }
-}
-
-impl SeedItem {
-    /// gets the uri of the seed item
-    pub fn uri(&self) -> String {
-        match self {
-            Self::Track(track) => track.id.uri(),
-            Self::Artist(artist) => artist.id.uri(),
         }
     }
 }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -1,4 +1,4 @@
-use crate::{config, key};
+use crate::{config, key, utils::new_table_state};
 
 pub type UIStateGuard<'a> = parking_lot::MutexGuard<'a, UIState>;
 
@@ -38,6 +38,16 @@ impl UIState {
     pub fn create_new_page(&mut self, page: PageState) {
         self.history.push(page);
         self.popup = None;
+    }
+
+    pub fn create_new_radio_page(&mut self, uri: &str, desc: String) {
+        let new_page = PageState::Tracks {
+            title: "Recommendations".to_string(),
+            state: new_table_state(),
+            id: format!("radio::{uri}"),
+            desc,
+        };
+        self.create_new_page(new_page);
     }
 
     /// Returns whether there exists a focused popup.

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -9,7 +9,7 @@ pub enum PopupState {
     UserFollowedArtistList(ListState),
     UserSavedAlbumList(ListState),
     DeviceList(ListState),
-    ArtistList(Vec<Artist>, ListState),
+    ArtistList(ArtistPopupAction, Vec<Artist>, ListState),
     ThemeList(Vec<crate::config::Theme>, ListState),
     ActionList(ActionListItem, ListState),
 }
@@ -27,6 +27,13 @@ pub enum ActionListItem {
 pub enum PlaylistPopupAction {
     Browse,
     AddTrack(TrackId<'static>),
+}
+
+/// An action on an item in an artist popup list
+#[derive(Copy, Clone, Debug)]
+pub enum ArtistPopupAction {
+    Browse,
+    GoToRadio,
 }
 
 impl PopupState {

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -126,7 +126,7 @@ pub fn render_popup(
                 let rect = render_list_popup(frame, rect, "User Saved Albums", items, 7, ui);
                 (rect, false)
             }
-            PopupState::ArtistList(artists, ..) => {
+            PopupState::ArtistList(_, artists, ..) => {
                 let items = artists.iter().map(|a| (a.to_string(), false)).collect();
 
                 let rect = render_list_popup(frame, rect, "Artists", items, 5, ui);


### PR DESCRIPTION
## Changes
- renamed `Browse*` actions to `GoTo*` actions, e.g `BrowseAlbum` to `GoToAlbum`
- added 
   + `GoToArtistRadio`, `GoToAlbumRadio` actions for track
   + `GoToLibraryRadio` action for library
   + `GoToAlbumRadio`, `GoToArtistRadio` actions for album
- implemented Spotify-like radio page by using librespot's Mercury APIs, which allows the list of recommended tracks to look similar to what is shown in the official Spotify app and to support radio pages of other Spotify items beside track and artist
- added a TODO for fixing sorting not working in non-context pages