### PR TITLE
Implement tracks context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -3912,6 +3912,7 @@ dependencies = [
  "lru",
  "lyric_finder",
  "maybe-async",
+ "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "reqwest",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -43,6 +43,7 @@ viuer = { version = "0.6.2", optional = true }
 image = { version = "0.24.5", optional = true }
 flume = "0.10.14"
 serde_json = "1.0.91"
+once_cell = "1.16.0"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -127,6 +127,7 @@ pub async fn start_player_event_watchers(
                             ContextId::Album(_) => ContextPageUIState::new_album(),
                             ContextId::Artist(_) => ContextPageUIState::new_artist(),
                             ContextId::Playlist(_) => ContextPageUIState::new_playlist(),
+                            ContextId::Tracks(_) => ContextPageUIState::new_tracks(),
                         });
                     }
                     None => {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -304,7 +304,10 @@ impl Client {
                     state.data.write().caches.search.put(query, results);
                 }
             }
-            ClientRequest::GetRadioTracks { uri, name } => {
+            ClientRequest::GetRadioTracks {
+                seed_uri: uri,
+                seed_name: name,
+            } => {
                 let radio_uri = format!("radio:{}", uri);
                 if !state.data.read().caches.context.contains(&radio_uri) {
                     let tracks = self.radio_tracks(uri).await?;

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -309,19 +309,13 @@ impl Client {
                 if !state.data.read().caches.context.contains(&radio_uri) {
                     let tracks = self.radio_tracks(uri).await?;
 
-                    state
-                        .data
-                        .write()
-                        .caches
-                        .context
-                        //TODO: handle description for radio page
-                        .put(
-                            radio_uri,
-                            Context::Tracks {
-                                tracks,
-                                desc: format!("{} Radio", name),
-                            },
-                        );
+                    state.data.write().caches.context.put(
+                        radio_uri,
+                        Context::Tracks {
+                            tracks,
+                            desc: format!("{} Radio", name),
+                        },
+                    );
                 }
             }
             ClientRequest::AddTrackToQueue(track_id) => {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -44,8 +44,8 @@ pub enum ClientRequest {
     GetContext(ContextId),
     GetCurrentPlayback,
     GetRadioTracks {
-        uri: String,
-        name: String,
+        seed_uri: String,
+        seed_name: String,
     },
     Search(String),
     AddTrackToQueue(TrackId<'static>),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -43,7 +43,10 @@ pub enum ClientRequest {
     GetUserRecentlyPlayedTracks,
     GetContext(ContextId),
     GetCurrentPlayback,
-    GetRadioTracks(String),
+    GetRadioTracks {
+        uri: String,
+        name: String,
+    },
     Search(String),
     AddTrackToQueue(TrackId<'static>),
     AddTrackToPlaylist(PlaylistId<'static>, TrackId<'static>),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     command::{self, Command},
     key::{Key, KeySequence},
     state::*,
-    utils::{new_list_state, new_table_state},
+    utils::new_list_state,
 };
 
 #[cfg(feature = "lyric-finder")]

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -271,30 +271,34 @@ fn handle_global_command(
             ui.popup = Some(PopupState::UserSavedAlbumList(new_list_state()));
         }
         Command::TopTrackPage => {
-            ui.create_new_page(PageState::Tracks {
-                id: "top-tracks".to_string(),
-                title: "Top Tracks".to_string(),
-                desc: "User's top tracks".to_string(),
-                state: new_table_state(),
+            ui.create_new_page(PageState::Context {
+                id: None,
+                context_page_type: ContextPageType::Browsing(ContextId::Tracks(
+                    USER_TOP_TRACKS_ID.to_owned(),
+                )),
+                state: None,
             });
             client_pub.send(ClientRequest::GetUserTopTracks)?;
         }
         Command::RecentlyPlayedTrackPage => {
-            ui.create_new_page(PageState::Tracks {
-                id: "recently-played-tracks".to_string(),
-                title: "Recently Played Tracks".to_string(),
-                desc: "User's recently played tracks".to_string(),
-                state: new_table_state(),
+            ui.create_new_page(PageState::Context {
+                id: None,
+                context_page_type: ContextPageType::Browsing(ContextId::Tracks(
+                    USER_RECENTLY_PLAYED_TRACKS_ID.to_owned(),
+                )),
+                state: None,
             });
             client_pub.send(ClientRequest::GetUserRecentlyPlayedTracks)?;
         }
         Command::LikedTrackPage => {
-            ui.create_new_page(PageState::Tracks {
-                id: "liked-tracks".to_string(),
-                title: "Liked Tracks".to_string(),
-                desc: "User's liked tracks".to_string(),
-                state: new_table_state(),
+            ui.create_new_page(PageState::Context {
+                id: None,
+                context_page_type: ContextPageType::Browsing(ContextId::Tracks(
+                    USER_LIKED_TRACKS_ID.to_owned(),
+                )),
+                state: None,
             });
+            client_pub.send(ClientRequest::GetUserSavedTracks)?;
         }
         Command::LibraryPage => {
             ui.create_new_page(PageState::Library {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -136,9 +136,6 @@ fn handle_key_event(
             PageType::Context => {
                 page::handle_key_sequence_for_context_page(&key_sequence, client_pub, state)?
             }
-            PageType::Tracks => {
-                page::handle_key_sequence_for_tracks_page(&key_sequence, client_pub, state)?
-            }
             PageType::Browse => {
                 page::handle_key_sequence_for_browse_page(&key_sequence, client_pub, state)?
             }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -1,5 +1,4 @@
 use anyhow::Context as _;
-use rand::Rng;
 
 use super::*;
 
@@ -154,11 +153,6 @@ pub fn handle_key_sequence_for_context_page(
         None => return Ok(false),
     };
 
-    let context_id = match state.ui.lock().current_page() {
-        PageState::Context { id, .. } => id.clone(),
-        _ => anyhow::bail!("expect a context page"),
-    };
-
     match command {
         Command::Search => {
             let mut ui = state.ui.lock();
@@ -167,63 +161,7 @@ pub fn handle_key_sequence_for_context_page(
                 query: "".to_owned(),
             });
         }
-        Command::PlayRandom => {
-            if let Some(context_id) = context_id {
-                let data = state.data.read();
-
-                // randomly play a track from the current context
-                if let Some(context) = data.caches.context.peek(&context_id.uri()) {
-                    let tracks = context.tracks();
-                    let offset = match context {
-                        // Spotify does not allow to manually specify `offset` for artist context
-                        Context::Artist { .. } => None,
-                        _ => {
-                            if tracks.is_empty() {
-                                None
-                            } else {
-                                let id = rand::thread_rng().gen_range(0..tracks.len());
-                                Some(rspotify_model::Offset::Uri(tracks[id].id.uri()))
-                            }
-                        }
-                    };
-
-                    client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                        Playback::Context(context_id, offset),
-                    )))?;
-                }
-            }
-        }
         _ => {
-            // handle sort/reverse tracks commands
-            let order = match command {
-                Command::SortTrackByTitle => Some(TrackOrder::TrackName),
-                Command::SortTrackByAlbum => Some(TrackOrder::Album),
-                Command::SortTrackByArtists => Some(TrackOrder::Artists),
-                Command::SortTrackByAddedDate => Some(TrackOrder::AddedAt),
-                Command::SortTrackByDuration => Some(TrackOrder::Duration),
-                _ => None,
-            };
-
-            // TODO: handle sort commands for non-context pages
-            if let Some(order) = order {
-                if let Some(context_id) = context_id {
-                    let mut data = state.data.write();
-                    if let Some(context) = data.caches.context.peek_mut(&context_id.uri()) {
-                        context.sort_tracks(order);
-                    }
-                }
-                return Ok(true);
-            }
-            if command == Command::ReverseTrackOrder {
-                if let Some(context_id) = context_id {
-                    let mut data = state.data.write();
-                    if let Some(context) = data.caches.context.peek_mut(&context_id.uri()) {
-                        context.reverse_tracks();
-                    }
-                }
-                return Ok(true);
-            }
-
             // the command hasn't been handled, assign the job to the focused window's handler
             return window::handle_command_for_focused_context_window(command, client_pub, state);
         }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -231,64 +231,6 @@ pub fn handle_key_sequence_for_context_page(
     Ok(true)
 }
 
-pub fn handle_key_sequence_for_tracks_page(
-    key_sequence: &KeySequence,
-    client_pub: &flume::Sender<ClientRequest>,
-    state: &SharedState,
-) -> Result<bool> {
-    let command = match state
-        .keymap_config
-        .find_command_from_key_sequence(key_sequence)
-    {
-        Some(command) => command,
-        None => return Ok(false),
-    };
-
-    let mut ui = state.ui.lock();
-    let data = state.data.read();
-
-    let id = match ui.current_page() {
-        PageState::Tracks { id, .. } => id,
-        _ => anyhow::bail!("expect a tracks page"),
-    };
-
-    let tracks = data
-        .get_tracks_by_id(id)
-        .map(|tracks| ui.search_filtered_items(tracks))
-        .unwrap_or_default();
-
-    match command {
-        Command::Search => {
-            ui.current_page_mut().select(0);
-            ui.popup = Some(PopupState::Search {
-                query: "".to_owned(),
-            });
-            Ok(true)
-        }
-        Command::PlayRandom => {
-            // randomly play a song from the list of recommendation tracks
-            let offset = {
-                let id = rand::thread_rng().gen_range(0..tracks.len());
-                Some(rspotify_model::Offset::Uri(tracks[id].id.uri()))
-            };
-            client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                Playback::URIs(tracks.iter().map(|t| t.id.clone()).collect(), offset),
-            )))?;
-
-            Ok(true)
-        }
-        _ => window::handle_command_for_track_table_window(
-            command,
-            client_pub,
-            None,
-            Some(tracks.iter().map(|t| t.id.as_ref()).collect()),
-            tracks,
-            &data,
-            ui,
-        ),
-    }
-}
-
 pub fn handle_key_sequence_for_browse_page(
     key_sequence: &KeySequence,
     client_pub: &flume::Sender<ClientRequest>,

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -53,9 +53,9 @@ pub fn handle_key_sequence_for_popup(
                             });
                         }
                         ArtistPopupAction::GoToRadio => {
-                            let uri = artists[id].id.uri();
-                            let desc = format!("{} Radio", artists[id].name);
-                            ui.create_new_radio_page(&uri, desc);
+                            let uri = format!("radio:{}", artists[id].id.uri());
+                            let name = format!("{} Radio", artists[id].name);
+                            ui.create_new_radio_page(&uri, name);
                             client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                         }
                     }
@@ -443,9 +443,9 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     TrackAction::GoToTrackRadio => {
-                        let uri = track.id.uri();
-                        let desc = format!("{} Radio", track.name);
-                        ui.create_new_radio_page(&uri, desc);
+                        let uri = format!("radio:{}", track.id.uri());
+                        let name = format!("{} Radio", track.name);
+                        ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     TrackAction::GoToArtistRadio => {
@@ -457,9 +457,9 @@ fn handle_command_for_action_list_popup(
                     }
                     TrackAction::GoToAlbumRadio => {
                         if let Some(ref album) = track.album {
-                            let uri = album.id.uri();
-                            let desc = format!("{} Radio", album.name);
-                            ui.create_new_radio_page(&uri, desc);
+                            let uri = format!("radio:{}", album.id.uri());
+                            let name = format!("{} Radio", album.name);
+                            ui.create_new_radio_page(&uri, name);
                             client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                         }
                     }
@@ -492,9 +492,9 @@ fn handle_command_for_action_list_popup(
                         ));
                     }
                     AlbumAction::GoToAlbumRadio => {
-                        let uri = album.id.uri();
-                        let desc = format!("{} Radio", album.name);
-                        ui.create_new_radio_page(&uri, desc);
+                        let uri = format!("radio:{}", album.id.uri());
+                        let name = format!("{} Radio", album.name);
+                        ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     AlbumAction::GoToArtistRadio => {
@@ -522,9 +522,9 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     ArtistAction::GoToArtistRadio => {
-                        let uri = artist.id.uri();
-                        let desc = format!("{} Radio", artist.name);
-                        ui.create_new_radio_page(&uri, desc);
+                        let uri = format!("radio:{}", artist.id.uri());
+                        let name = format!("{} Radio", artist.name);
+                        ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     ArtistAction::Unfollow => {
@@ -542,9 +542,9 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     PlaylistAction::GoToPlaylistRadio => {
-                        let uri = playlist.id.uri();
-                        let desc = format!("{} Radio", playlist.name);
-                        ui.create_new_radio_page(&uri, desc);
+                        let uri = format!("radio:{}", playlist.id.uri());
+                        let name = format!("{} Radio", playlist.name);
+                        ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
                     }
                     PlaylistAction::DeleteFromLibrary => {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -53,7 +53,7 @@ pub fn handle_key_sequence_for_popup(
                             });
                         }
                         ArtistPopupAction::GoToRadio => {
-                            let uri = format!("radio:{}", artists[id].id.uri());
+                            let uri = artists[id].id.uri();
                             let name = format!("{} Radio", artists[id].name);
                             ui.create_new_radio_page(&uri, name);
                             client_pub.send(ClientRequest::GetRadioTracks(uri))?;
@@ -443,7 +443,7 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     TrackAction::GoToTrackRadio => {
-                        let uri = format!("radio:{}", track.id.uri());
+                        let uri = track.id.uri();
                         let name = format!("{} Radio", track.name);
                         ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
@@ -457,7 +457,7 @@ fn handle_command_for_action_list_popup(
                     }
                     TrackAction::GoToAlbumRadio => {
                         if let Some(ref album) = track.album {
-                            let uri = format!("radio:{}", album.id.uri());
+                            let uri = album.id.uri();
                             let name = format!("{} Radio", album.name);
                             ui.create_new_radio_page(&uri, name);
                             client_pub.send(ClientRequest::GetRadioTracks(uri))?;
@@ -492,7 +492,7 @@ fn handle_command_for_action_list_popup(
                         ));
                     }
                     AlbumAction::GoToAlbumRadio => {
-                        let uri = format!("radio:{}", album.id.uri());
+                        let uri = album.id.uri();
                         let name = format!("{} Radio", album.name);
                         ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
@@ -522,7 +522,7 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     ArtistAction::GoToArtistRadio => {
-                        let uri = format!("radio:{}", artist.id.uri());
+                        let uri = artist.id.uri();
                         let name = format!("{} Radio", artist.name);
                         ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;
@@ -542,7 +542,7 @@ fn handle_command_for_action_list_popup(
                         ui.popup = None;
                     }
                     PlaylistAction::GoToPlaylistRadio => {
-                        let uri = format!("radio:{}", playlist.id.uri());
+                        let uri = playlist.id.uri();
                         let name = format!("{} Radio", playlist.name);
                         ui.create_new_radio_page(&uri, name);
                         client_pub.send(ClientRequest::GetRadioTracks(uri))?;

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -54,9 +54,9 @@ pub fn handle_key_sequence_for_popup(
                         }
                         ArtistPopupAction::GoToRadio => {
                             let uri = artists[id].id.uri();
-                            let name = format!("{} Radio", artists[id].name);
-                            ui.create_new_radio_page(&uri, name);
-                            client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                            let name = artists[id].name.to_owned();
+                            ui.create_new_radio_page(&uri);
+                            client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                         }
                     }
 
@@ -444,9 +444,9 @@ fn handle_command_for_action_list_popup(
                     }
                     TrackAction::GoToTrackRadio => {
                         let uri = track.id.uri();
-                        let name = format!("{} Radio", track.name);
-                        ui.create_new_radio_page(&uri, name);
-                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                        let name = track.name.to_owned();
+                        ui.create_new_radio_page(&uri);
+                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                     }
                     TrackAction::GoToArtistRadio => {
                         ui.popup = Some(PopupState::ArtistList(
@@ -458,9 +458,9 @@ fn handle_command_for_action_list_popup(
                     TrackAction::GoToAlbumRadio => {
                         if let Some(ref album) = track.album {
                             let uri = album.id.uri();
-                            let name = format!("{} Radio", album.name);
-                            ui.create_new_radio_page(&uri, name);
-                            client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                            let name = album.name.to_owned();
+                            ui.create_new_radio_page(&uri);
+                            client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                         }
                     }
                     TrackAction::DeleteFromLikedTracks => {
@@ -493,9 +493,9 @@ fn handle_command_for_action_list_popup(
                     }
                     AlbumAction::GoToAlbumRadio => {
                         let uri = album.id.uri();
-                        let name = format!("{} Radio", album.name);
-                        ui.create_new_radio_page(&uri, name);
-                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                        let name = album.name.to_owned();
+                        ui.create_new_radio_page(&uri);
+                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                     }
                     AlbumAction::GoToArtistRadio => {
                         ui.popup = Some(PopupState::ArtistList(
@@ -523,9 +523,9 @@ fn handle_command_for_action_list_popup(
                     }
                     ArtistAction::GoToArtistRadio => {
                         let uri = artist.id.uri();
-                        let name = format!("{} Radio", artist.name);
-                        ui.create_new_radio_page(&uri, name);
-                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                        let name = artist.name.to_owned();
+                        ui.create_new_radio_page(&uri);
+                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                     }
                     ArtistAction::Unfollow => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Artist(
@@ -543,9 +543,9 @@ fn handle_command_for_action_list_popup(
                     }
                     PlaylistAction::GoToPlaylistRadio => {
                         let uri = playlist.id.uri();
-                        let name = format!("{} Radio", playlist.name);
-                        ui.create_new_radio_page(&uri, name);
-                        client_pub.send(ClientRequest::GetRadioTracks(uri))?;
+                        let name = playlist.name.to_owned();
+                        ui.create_new_radio_page(&uri);
+                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
                     }
                     PlaylistAction::DeleteFromLibrary => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -261,9 +261,6 @@ fn handle_key_sequence_for_search_popup(
         PageType::Context => {
             page::handle_key_sequence_for_context_page(key_sequence, client_pub, state)
         }
-        PageType::Tracks => {
-            page::handle_key_sequence_for_tracks_page(key_sequence, client_pub, state)
-        }
         PageType::Browse => {
             page::handle_key_sequence_for_browse_page(key_sequence, client_pub, state)
         }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -56,7 +56,10 @@ pub fn handle_key_sequence_for_popup(
                             let uri = artists[id].id.uri();
                             let name = artists[id].name.to_owned();
                             ui.create_new_radio_page(&uri);
-                            client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                            client_pub.send(ClientRequest::GetRadioTracks {
+                                seed_uri: uri,
+                                seed_name: name,
+                            })?;
                         }
                     }
 
@@ -446,7 +449,10 @@ fn handle_command_for_action_list_popup(
                         let uri = track.id.uri();
                         let name = track.name.to_owned();
                         ui.create_new_radio_page(&uri);
-                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                        client_pub.send(ClientRequest::GetRadioTracks {
+                            seed_uri: uri,
+                            seed_name: name,
+                        })?;
                     }
                     TrackAction::GoToArtistRadio => {
                         ui.popup = Some(PopupState::ArtistList(
@@ -460,7 +466,10 @@ fn handle_command_for_action_list_popup(
                             let uri = album.id.uri();
                             let name = album.name.to_owned();
                             ui.create_new_radio_page(&uri);
-                            client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                            client_pub.send(ClientRequest::GetRadioTracks {
+                                seed_uri: uri,
+                                seed_name: name,
+                            })?;
                         }
                     }
                     TrackAction::DeleteFromLikedTracks => {
@@ -495,7 +504,10 @@ fn handle_command_for_action_list_popup(
                         let uri = album.id.uri();
                         let name = album.name.to_owned();
                         ui.create_new_radio_page(&uri);
-                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                        client_pub.send(ClientRequest::GetRadioTracks {
+                            seed_uri: uri,
+                            seed_name: name,
+                        })?;
                     }
                     AlbumAction::GoToArtistRadio => {
                         ui.popup = Some(PopupState::ArtistList(
@@ -525,7 +537,10 @@ fn handle_command_for_action_list_popup(
                         let uri = artist.id.uri();
                         let name = artist.name.to_owned();
                         ui.create_new_radio_page(&uri);
-                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                        client_pub.send(ClientRequest::GetRadioTracks {
+                            seed_uri: uri,
+                            seed_name: name,
+                        })?;
                     }
                     ArtistAction::Unfollow => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Artist(
@@ -545,7 +560,10 @@ fn handle_command_for_action_list_popup(
                         let uri = playlist.id.uri();
                         let name = playlist.name.to_owned();
                         ui.create_new_radio_page(&uri);
-                        client_pub.send(ClientRequest::GetRadioTracks { uri, name })?;
+                        client_pub.send(ClientRequest::GetRadioTracks {
+                            seed_uri: uri,
+                            seed_name: name,
+                        })?;
                     }
                     PlaylistAction::DeleteFromLibrary => {
                         client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -88,11 +88,10 @@ pub fn handle_command_for_focused_context_window(
                         client_pub,
                         ContextId::Tracks(TracksId::new(
                             format!("artist-{}-top-tracks", artist.name),
-                            format!("Artist {}'s top tracks", artist.name),
                             "Artist Top Tracks",
                         )),
                         Playback::URIs(
-                            top_tracks.iter().map(|t| t.id.into_static()).collect(),
+                            top_tracks.iter().map(|t| t.id.clone_static()).collect(),
                             None,
                         ),
                         ui.search_filtered_items(top_tracks),
@@ -101,7 +100,7 @@ pub fn handle_command_for_focused_context_window(
                     ),
                 }
             }
-            Context::Album { album, tracks } => handle_command_for_track_table_window(
+            Context::Album { tracks, .. } => handle_command_for_track_table_window(
                 command,
                 client_pub,
                 context_id.clone(),
@@ -110,7 +109,7 @@ pub fn handle_command_for_focused_context_window(
                 &data,
                 ui,
             ),
-            Context::Playlist { playlist, tracks } => handle_command_for_track_table_window(
+            Context::Playlist { tracks, .. } => handle_command_for_track_table_window(
                 command,
                 client_pub,
                 context_id.clone(),
@@ -119,11 +118,11 @@ pub fn handle_command_for_focused_context_window(
                 &data,
                 ui,
             ),
-            Context::Tracks { tracks } => handle_command_for_track_table_window(
+            Context::Tracks { tracks, .. } => handle_command_for_track_table_window(
                 command,
                 client_pub,
                 context_id.clone(),
-                Playback::URIs(tracks.iter().map(|t| t.id.into_static()).collect(), None),
+                Playback::URIs(tracks.iter().map(|t| t.id.clone_static()).collect(), None),
                 ui.search_filtered_items(tracks),
                 &data,
                 ui,

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -89,6 +89,7 @@ pub fn handle_command_for_focused_context_window(
                         ContextId::Tracks(TracksId::new(
                             format!("artist-{}-top-tracks", artist.name),
                             format!("Artist {}'s top tracks", artist.name),
+                            "Artist Top Tracks",
                         )),
                         Playback::URIs(
                             top_tracks.iter().map(|t| t.id.into_static()).collect(),

--- a/spotify_player/src/state/consant.rs
+++ b/spotify_player/src/state/consant.rs
@@ -1,0 +1,16 @@
+pub use super::*;
+
+pub const USER_TOP_TRACKS_ID: TracksId =
+    TracksId::new("tracks:user-top-tracks", "User's top tracks", "Top Tracks");
+
+pub const USER_RECENTLY_PLAYED_TRACKS_ID: TracksId = TracksId::new(
+    "tracks:user-recently-played-tracks",
+    "User's recently played tracks",
+    "Recently Played Tracks",
+);
+
+pub const USER_LIKED_TRACKS_ID: TracksId = TracksId::new(
+    "tracks:user-liked-tracks",
+    "User's liked tracks",
+    "Liked Tracks",
+);

--- a/spotify_player/src/state/consant.rs
+++ b/spotify_player/src/state/consant.rs
@@ -1,15 +1,15 @@
 pub use super::*;
 use once_cell::sync::Lazy;
 
-pub const USER_TOP_TRACKS_ID: Lazy<TracksId> =
+pub static USER_TOP_TRACKS_ID: Lazy<TracksId> =
     Lazy::new(|| TracksId::new("tracks:user-top-tracks", "Top Tracks"));
 
-pub const USER_RECENTLY_PLAYED_TRACKS_ID: Lazy<TracksId> = Lazy::new(|| {
+pub static USER_RECENTLY_PLAYED_TRACKS_ID: Lazy<TracksId> = Lazy::new(|| {
     TracksId::new(
         "tracks:user-recently-played-tracks",
         "Recently Played Tracks",
     )
 });
 
-pub const USER_LIKED_TRACKS_ID: Lazy<TracksId> =
+pub static USER_LIKED_TRACKS_ID: Lazy<TracksId> =
     Lazy::new(|| TracksId::new("tracks:user-liked-tracks", "Liked Tracks"));

--- a/spotify_player/src/state/consant.rs
+++ b/spotify_player/src/state/consant.rs
@@ -1,16 +1,15 @@
 pub use super::*;
+use once_cell::sync::Lazy;
 
-pub const USER_TOP_TRACKS_ID: TracksId =
-    TracksId::new("tracks:user-top-tracks", "User's top tracks", "Top Tracks");
+pub const USER_TOP_TRACKS_ID: Lazy<TracksId> =
+    Lazy::new(|| TracksId::new("tracks:user-top-tracks", "Top Tracks"));
 
-pub const USER_RECENTLY_PLAYED_TRACKS_ID: TracksId = TracksId::new(
-    "tracks:user-recently-played-tracks",
-    "User's recently played tracks",
-    "Recently Played Tracks",
-);
+pub const USER_RECENTLY_PLAYED_TRACKS_ID: Lazy<TracksId> = Lazy::new(|| {
+    TracksId::new(
+        "tracks:user-recently-played-tracks",
+        "Recently Played Tracks",
+    )
+});
 
-pub const USER_LIKED_TRACKS_ID: TracksId = TracksId::new(
-    "tracks:user-liked-tracks",
-    "User's liked tracks",
-    "Liked Tracks",
-);
+pub const USER_LIKED_TRACKS_ID: Lazy<TracksId> =
+    Lazy::new(|| TracksId::new("tracks:user-liked-tracks", "Liked Tracks"));

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -53,7 +53,7 @@ impl Default for Caches {
 }
 
 impl AppData {
-    pub fn get_tracks_by_id(&self, id: ContextId) -> Option<&Vec<Track>> {
+    pub fn get_tracks_by_id(&self, id: &ContextId) -> Option<&Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
         if let ContextId::Tracks(TracksId { uri, .. }) = id {
             if uri == "liked-track" {
@@ -71,7 +71,7 @@ impl AppData {
         })
     }
 
-    pub fn get_tracks_by_id_mut(&mut self, id: ContextId) -> Option<&mut Vec<Track>> {
+    pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
         if let ContextId::Tracks(TracksId { uri, .. }) = id {
             if uri == "liked-track" {

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -55,10 +55,31 @@ impl Default for Caches {
 impl AppData {
     pub fn get_tracks_by_id(&self, id: ContextId) -> Option<&Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
-        if id == ContextId::Tracks(String::from("liked-tracks")) {
-            return Some(&self.user_data.saved_tracks);
+        if let ContextId::Tracks(TracksId { uri, .. }) = id {
+            if uri == "liked-track" {
+                return Some(&self.user_data.saved_tracks);
+            }
         }
+
         self.caches.context.peek(&id.uri()).map(|c| match c {
+            Context::Album { tracks, .. } => tracks,
+            Context::Playlist { tracks, .. } => tracks,
+            Context::Artist {
+                top_tracks: tracks, ..
+            } => tracks,
+            Context::Tracks { tracks } => tracks,
+        })
+    }
+
+    pub fn get_tracks_by_id_mut(&mut self, id: ContextId) -> Option<&mut Vec<Track>> {
+        // liked track page's id is handled separately because it is stored as a part of user data
+        if let ContextId::Tracks(TracksId { uri, .. }) = id {
+            if uri == "liked-track" {
+                return Some(&mut self.user_data.saved_tracks);
+            }
+        }
+
+        self.caches.context.peek_mut(&id.uri()).map(|c| match c {
             Context::Album { tracks, .. } => tracks,
             Context::Playlist { tracks, .. } => tracks,
             Context::Artist {

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -55,6 +55,8 @@ impl Default for Caches {
 impl AppData {
     pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
+        // TODO: handle rendering/event handling for user's liked tracks page, which are currently broken
+        // related issue: https://github.com/aome510/spotify-player/issues/78
         if let ContextId::Tracks(tracks_id) = id {
             if *tracks_id == *USER_LIKED_TRACKS_ID {
                 return Some(&mut self.user_data.saved_tracks);

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroUsize};
 
-use super::model::*;
+use super::{model::*, USER_LIKED_TRACKS_ID};
 
 pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
 
@@ -55,8 +55,8 @@ impl Default for Caches {
 impl AppData {
     pub fn get_tracks_by_id(&self, id: &ContextId) -> Option<&Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
-        if let ContextId::Tracks(TracksId { uri, .. }) = id {
-            if uri == "liked-track" {
+        if let ContextId::Tracks(tracks_id) = id {
+            if *tracks_id == *USER_LIKED_TRACKS_ID {
                 return Some(&self.user_data.saved_tracks);
             }
         }
@@ -73,8 +73,8 @@ impl AppData {
 
     pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
-        if let ContextId::Tracks(TracksId { uri, .. }) = id {
-            if uri == "liked-track" {
+        if let ContextId::Tracks(tracks_id) = id {
+            if *tracks_id == *USER_LIKED_TRACKS_ID {
                 return Some(&mut self.user_data.saved_tracks);
             }
         }

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -27,7 +27,6 @@ pub struct UserData {
 pub struct Caches {
     pub context: lru::LruCache<String, Context>,
     pub search: lru::LruCache<String, SearchResults>,
-    pub tracks: lru::LruCache<String, Vec<Track>>,
     #[cfg(feature = "lyric-finder")]
     pub lyrics: lru::LruCache<String, lyric_finder::LyricResult>,
     #[cfg(feature = "image")]
@@ -45,7 +44,6 @@ impl Default for Caches {
         Self {
             context: lru::LruCache::new(NonZeroUsize::new(64).unwrap()),
             search: lru::LruCache::new(NonZeroUsize::new(64).unwrap()),
-            tracks: lru::LruCache::new(NonZeroUsize::new(64).unwrap()),
             #[cfg(feature = "lyric-finder")]
             lyrics: lru::LruCache::new(NonZeroUsize::new(64).unwrap()),
             #[cfg(feature = "image")]
@@ -55,12 +53,19 @@ impl Default for Caches {
 }
 
 impl AppData {
-    pub fn get_tracks_by_id(&self, id: &str) -> Option<&Vec<Track>> {
-        match id {
-            // LikedTrackPage's id is handled separately because it is stored as a part of user data
-            "liked-tracks" => Some(&self.user_data.saved_tracks),
-            _ => self.caches.tracks.peek(id),
+    pub fn get_tracks_by_id(&self, id: ContextId) -> Option<&Vec<Track>> {
+        // liked track page's id is handled separately because it is stored as a part of user data
+        if id == ContextId::Tracks(String::from("liked-tracks")) {
+            return Some(&self.user_data.saved_tracks);
         }
+        self.caches.context.peek(&id.uri()).map(|c| match c {
+            Context::Album { tracks, .. } => tracks,
+            Context::Playlist { tracks, .. } => tracks,
+            Context::Artist {
+                top_tracks: tracks, ..
+            } => tracks,
+            Context::Tracks { tracks } => tracks,
+        })
     }
 }
 

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -53,24 +53,6 @@ impl Default for Caches {
 }
 
 impl AppData {
-    pub fn get_tracks_by_id(&self, id: &ContextId) -> Option<&Vec<Track>> {
-        // liked track page's id is handled separately because it is stored as a part of user data
-        if let ContextId::Tracks(tracks_id) = id {
-            if *tracks_id == *USER_LIKED_TRACKS_ID {
-                return Some(&self.user_data.saved_tracks);
-            }
-        }
-
-        self.caches.context.peek(&id.uri()).map(|c| match c {
-            Context::Album { tracks, .. } => tracks,
-            Context::Playlist { tracks, .. } => tracks,
-            Context::Artist {
-                top_tracks: tracks, ..
-            } => tracks,
-            Context::Tracks { tracks } => tracks,
-        })
-    }
-
     pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
         // liked track page's id is handled separately because it is stored as a part of user data
         if let ContextId::Tracks(tracks_id) = id {
@@ -85,7 +67,7 @@ impl AppData {
             Context::Artist {
                 top_tracks: tracks, ..
             } => tracks,
-            Context::Tracks { tracks } => tracks,
+            Context::Tracks { tracks, .. } => tracks,
         })
     }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -1,8 +1,10 @@
 mod data;
+mod consant;
 mod model;
 mod player;
 mod ui;
 
+pub use consant::*;
 pub use data::*;
 pub use model::*;
 pub use player::*;

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -1,5 +1,5 @@
-mod data;
 mod consant;
+mod data;
 mod model;
 mod player;
 mod ui;

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -157,7 +157,7 @@ impl Context {
                 ref tracks,
             } => {
                 format!(
-                    "Album: {} | {} | {} songs",
+                    "{} | {} | {} songs",
                     album.name,
                     album.release_date,
                     tracks.len()
@@ -168,16 +168,14 @@ impl Context {
                 tracks,
             } => {
                 format!(
-                    "Playlist: {} | {} | {} songs",
+                    "{} | {} | {} songs",
                     playlist.name,
                     playlist.owner.0,
                     tracks.len()
                 )
             }
-            Context::Artist { ref artist, .. } => {
-                format!("Artist: {}", artist.name)
-            }
-            Context::Tracks { desc, .. } => desc.to_string(),
+            Context::Artist { ref artist, .. } => artist.name.to_string(),
+            Context::Tracks { desc, tracks } => format!("{} | {} songs", desc, tracks.len()),
         }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -26,12 +26,18 @@ pub enum Context {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TracksId {
+    pub uri: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// A context Id
 pub enum ContextId {
     Playlist(PlaylistId<'static>),
     Album(AlbumId<'static>),
     Artist(ArtistId<'static>),
-    Tracks(String),
+    Tracks(TracksId),
 }
 
 #[derive(Clone, Debug)]
@@ -180,7 +186,7 @@ impl ContextId {
             Self::Album(id) => id.uri(),
             Self::Artist(id) => id.uri(),
             Self::Playlist(id) => id.uri(),
-            Self::Tracks(uri) => uri.to_owned(),
+            Self::Tracks(id) => id.uri.to_owned(),
         }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -20,6 +20,9 @@ pub enum Context {
         albums: Vec<Album>,
         related_artists: Vec<Artist>,
     },
+    Tracks {
+        tracks: Vec<Track>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -28,6 +31,7 @@ pub enum ContextId {
     Playlist(PlaylistId<'static>),
     Album(AlbumId<'static>),
     Artist(ArtistId<'static>),
+    Tracks(String),
 }
 
 #[derive(Clone, Debug)]
@@ -138,16 +142,6 @@ pub struct Category {
 }
 
 impl Context {
-    /// sorts tracks in the context by a sort oder
-    pub fn sort_tracks(&mut self, sort_order: TrackOrder) {
-        self.tracks_mut().sort_by(|x, y| sort_order.compare(x, y));
-    }
-
-    /// reverses order of tracks in the context
-    pub fn reverse_tracks(&mut self) {
-        self.tracks_mut().reverse();
-    }
-
     /// gets the context's description
     pub fn description(&self) -> String {
         match self {
@@ -178,29 +172,6 @@ impl Context {
             }
         }
     }
-
-    /// gets context tracks (immutable)
-    pub fn tracks(&self) -> &Vec<Track> {
-        match self {
-            Context::Album { ref tracks, .. } => tracks,
-            Context::Playlist { ref tracks, .. } => tracks,
-            Context::Artist {
-                top_tracks: ref tracks,
-                ..
-            } => tracks,
-        }
-    }
-
-    /// gets context tracks (mutable)
-    pub fn tracks_mut(&mut self) -> &mut Vec<Track> {
-        match self {
-            Context::Album { tracks, .. } => tracks,
-            Context::Playlist { tracks, .. } => tracks,
-            Context::Artist {
-                top_tracks: tracks, ..
-            } => tracks,
-        }
-    }
 }
 
 impl ContextId {
@@ -209,6 +180,7 @@ impl ContextId {
             Self::Album(id) => id.uri(),
             Self::Artist(id) => id.uri(),
             Self::Playlist(id) => id.uri(),
+            Self::Tracks(uri) => uri.to_owned(),
         }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -22,13 +22,13 @@ pub enum Context {
     },
     Tracks {
         tracks: Vec<Track>,
+        desc: String,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TracksId {
     pub uri: String,
-    pub name: String,
     pub kind: String,
 }
 
@@ -177,6 +177,7 @@ impl Context {
             Context::Artist { ref artist, .. } => {
                 format!("Artist: {}", artist.name)
             }
+            Context::Tracks { desc, .. } => desc.to_string(),
         }
     }
 }
@@ -385,15 +386,13 @@ impl std::fmt::Display for Category {
 }
 
 impl TracksId {
-    pub fn new<U, N, K>(uri: U, name: N, kind: K) -> Self
+    pub fn new<U, K>(uri: U, kind: K) -> Self
     where
         U: Into<String>,
-        N: Into<String>,
         K: Into<String>,
     {
         Self {
             uri: uri.into(),
-            name: name.into(),
             kind: kind.into(),
         }
     }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -382,3 +382,26 @@ impl std::fmt::Display for Category {
         write!(f, "{}", self.name)
     }
 }
+
+impl TracksId {
+    pub fn new<U, N>(uri: U, name: N) -> Self
+    where
+        U: Into<String>,
+        N: Into<String>,
+    {
+        Self {
+            uri: uri.into(),
+            name: name.into(),
+        }
+    }
+}
+
+impl Playback {
+    /// creates new playback with a specified offset based on the current playback
+    pub fn offset(&self, offset: Option<rspotify_model::Offset>) -> Self {
+        match self {
+            Playback::Context(id, _) => Playback::Context(id.clone(), offset),
+            Playback::URIs(uri, _) => Playback::URIs(uri.clone(), offset),
+        }
+    }
+}

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -29,6 +29,7 @@ pub enum Context {
 pub struct TracksId {
     pub uri: String,
     pub name: String,
+    pub kind: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -384,14 +385,16 @@ impl std::fmt::Display for Category {
 }
 
 impl TracksId {
-    pub fn new<U, N>(uri: U, name: N) -> Self
+    pub fn new<U, N, K>(uri: U, name: N, kind: K) -> Self
     where
         U: Into<String>,
         N: Into<String>,
+        K: Into<String>,
     {
         Self {
             uri: uri.into(),
             name: name.into(),
+            kind: kind.into(),
         }
     }
 }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -42,12 +42,11 @@ impl UIState {
         self.popup = None;
     }
 
-    pub fn create_new_radio_page(&mut self, uri: &str, name: String) {
+    pub fn create_new_radio_page(&mut self, uri: &str) {
         self.create_new_page(PageState::Context {
             id: None,
             context_page_type: ContextPageType::Browsing(super::ContextId::Tracks(TracksId::new(
                 format!("radio:{uri}"),
-                name,
                 "Recommendations",
             ))),
             state: None,

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -40,14 +40,16 @@ impl UIState {
         self.popup = None;
     }
 
-    pub fn create_new_radio_page(&mut self, uri: &str, desc: String) {
-        let new_page = PageState::Tracks {
-            title: "Recommendations".to_string(),
-            state: new_table_state(),
-            id: format!("radio::{uri}"),
-            desc,
-        };
-        self.create_new_page(new_page);
+    pub fn create_new_radio_page(&mut self, uri: &str, name: String) {
+        self.create_new_page(PageState::Context {
+            id: None,
+            context_page_type: ContextPageType::Browsing(super::ContextId::Tracks(TracksId::new(
+                uri,
+                name,
+                "Recommendations",
+            ))),
+            state: None,
+        });
     }
 
     /// Returns whether there exists a focused popup.

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -46,7 +46,7 @@ impl UIState {
         self.create_new_page(PageState::Context {
             id: None,
             context_page_type: ContextPageType::Browsing(super::ContextId::Tracks(TracksId::new(
-                uri,
+                format!("radio:{uri}"),
                 name,
                 "Recommendations",
             ))),

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -1,9 +1,11 @@
-use crate::{config, key, utils::new_table_state};
+use crate::{config, key};
 
 pub type UIStateGuard<'a> = parking_lot::MutexGuard<'a, UIState>;
 
 mod page;
 mod popup;
+
+use super::*;
 
 pub use page::*;
 pub use popup::*;

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -234,6 +234,20 @@ impl SearchPageUIState {
     }
 }
 
+impl ContextPageType {
+    pub fn title(&self) -> String {
+        match self {
+            ContextPageType::CurrentPlaying => String::from("Current Playing"),
+            ContextPageType::Browsing(id) => match id {
+                ContextId::Playlist(_) => String::from("Playlist"),
+                ContextId::Album(_) => String::from("Album"),
+                ContextId::Artist(_) => String::from("Artist"),
+                ContextId::Tracks(id) => id.name.to_owned(),
+            },
+        }
+    }
+}
+
 impl ContextPageUIState {
     pub fn new_playlist() -> Self {
         Self::Playlist {

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -242,7 +242,7 @@ impl ContextPageType {
                 ContextId::Playlist(_) => String::from("Playlist"),
                 ContextId::Album(_) => String::from("Album"),
                 ContextId::Artist(_) => String::from("Artist"),
-                ContextId::Tracks(id) => id.name.to_owned(),
+                ContextId::Tracks(id) => id.kind.to_owned(),
             },
         }
     }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -16,12 +16,6 @@ pub enum PageState {
         current_query: String,
         state: SearchPageUIState,
     },
-    Tracks {
-        id: String,
-        title: String,
-        desc: String,
-        state: TableState,
-    },
     #[cfg(feature = "lyric-finder")]
     Lyric {
         track: String,
@@ -37,7 +31,6 @@ pub enum PageType {
     Library,
     Context,
     Search,
-    Tracks,
     Browse,
     #[cfg(feature = "lyric-finder")]
     Lyric,
@@ -79,6 +72,9 @@ pub enum ContextPageUIState {
         album_list: ListState,
         related_artist_list: ListState,
         focus: ArtistFocusState,
+    },
+    Tracks {
+        track_table: TableState,
     },
 }
 
@@ -128,7 +124,6 @@ impl PageState {
             PageState::Library { .. } => PageType::Library,
             PageState::Context { .. } => PageType::Context,
             PageState::Search { .. } => PageType::Search,
-            PageState::Tracks { .. } => PageType::Tracks,
             PageState::Browse { .. } => PageType::Browse,
             #[cfg(feature = "lyric-finder")]
             PageState::Lyric { .. } => PageType::Lyric,
@@ -184,6 +179,9 @@ impl PageState {
                 SearchFocusState::Playlists => Some(MutableWindowState::List(playlist_list)),
             },
             Self::Context { state, .. } => state.as_mut().map(|state| match state {
+                ContextPageUIState::Tracks { track_table } => {
+                    MutableWindowState::Table(track_table)
+                }
                 ContextPageUIState::Playlist { track_table } => {
                     MutableWindowState::Table(track_table)
                 }
@@ -201,7 +199,6 @@ impl PageState {
                     }
                 },
             }),
-            Self::Tracks { state, .. } => Some(MutableWindowState::Table(state)),
             Self::Browse { state } => match state {
                 BrowsePageUIState::CategoryList { state } => Some(MutableWindowState::List(state)),
                 BrowsePageUIState::CategoryPlaylistList { state, .. } => {

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -269,6 +269,12 @@ impl ContextPageUIState {
             focus: ArtistFocusState::TopTracks,
         }
     }
+
+    pub fn new_tracks() -> Self {
+        Self::Tracks {
+            track_table: utils::new_table_state(),
+        }
+    }
 }
 
 impl<'a> MutableWindowState<'a> {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -107,7 +107,6 @@ fn render_main_layout(
         PageType::Library => page::render_library_page(is_active, frame, state, ui, chunks[1]),
         PageType::Search => page::render_search_page(is_active, frame, state, ui, chunks[1]),
         PageType::Context => page::render_context_page(is_active, frame, state, ui, chunks[1]),
-        PageType::Tracks => page::render_tracks_page(is_active, frame, state, ui, chunks[1]),
         PageType::Browse => page::render_browse_page(is_active, frame, state, ui, chunks[1]),
         #[cfg(feature = "lyric-finder")]
         PageType::Lyric => page::render_lyric_page(is_active, frame, state, ui, chunks[1]),

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -197,13 +197,10 @@ pub fn render_context_page(
     };
 
     let block = Block::default()
-        .title(ui.theme.block_title_with_style(match context_page_type {
-            ContextPageType::CurrentPlaying => "Context (Current Playing)",
-            ContextPageType::Browsing(_) => "Context (Browsing)",
-        }))
+        .title(ui.theme.block_title_with_style(context_page_type.title()))
         .borders(Borders::ALL);
 
-    let context_uri = match id {
+    let id = match id {
         None => {
             frame.render_widget(
                 Paragraph::new("Cannot determine the current page's context").block(block),
@@ -211,10 +208,10 @@ pub fn render_context_page(
             );
             return Ok(());
         }
-        Some(id) => id.uri(),
+        Some(id) => id,
     };
 
-    match state.data.read().caches.context.peek(&context_uri) {
+    match state.data.read().caches.context.peek(&id.uri()) {
         Some(context) => {
             frame.render_widget(block, rect);
 
@@ -255,6 +252,16 @@ pub fn render_context_page(
                     )?;
                 }
                 Context::Album { tracks, .. } => {
+                    render_track_table_window(
+                        frame,
+                        chunks[1],
+                        is_active,
+                        state,
+                        ui.search_filtered_items(tracks),
+                        ui,
+                    )?;
+                }
+                Context::Tracks { tracks } => {
                     render_track_table_window(
                         frame,
                         chunks[1],

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -372,58 +372,6 @@ pub fn render_library_page(
     Ok(())
 }
 
-pub fn render_tracks_page(
-    is_active: bool,
-    frame: &mut Frame,
-    state: &SharedState,
-    ui: &mut UIStateGuard,
-    rect: Rect,
-) -> Result<()> {
-    let data = state.data.read();
-
-    let (id, title, desc) = match ui.current_page() {
-        PageState::Tracks {
-            id, title, desc, ..
-        } => (id, title, desc),
-        s => anyhow::bail!("expect a tracks page state, found {s:?}"),
-    };
-
-    let block = Block::default()
-        .title(ui.theme.block_title_with_style(title))
-        .borders(Borders::ALL);
-
-    let tracks = match data.get_tracks_by_id(id) {
-        Some(tracks) => tracks,
-        None => {
-            // tracks are still loading
-            frame.render_widget(Paragraph::new("loading...").block(block), rect);
-            return Ok(());
-        }
-    };
-
-    // render the window's border and title
-    frame.render_widget(block, rect);
-
-    // render the window's description
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
-        .split(rect);
-    let page_desc =
-        Paragraph::new(desc.clone()).block(Block::default().style(ui.theme.page_desc()));
-    frame.render_widget(page_desc, chunks[0]);
-
-    render_track_table_window(
-        frame,
-        chunks[1],
-        is_active,
-        state,
-        ui.search_filtered_items(tracks),
-        ui,
-    )
-}
-
 pub fn render_browse_page(
     is_active: bool,
     frame: &mut Frame,
@@ -725,11 +673,9 @@ pub fn render_track_table_window(
                 } => top_track_table,
                 ContextPageUIState::Playlist { track_table } => track_table,
                 ContextPageUIState::Album { track_table } => track_table,
+                ContextPageUIState::Tracks { track_table } => track_table,
             };
             utils::render_table_window(frame, track_table, rect, n_tracks, track_table_state);
-        }
-        PageState::Tracks { state, .. } => {
-            utils::render_table_window(frame, track_table, rect, n_tracks, state);
         }
         s => anyhow::bail!("reach unsupported page state {s:?} when rendering track table"),
     }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -261,7 +261,7 @@ pub fn render_context_page(
                         ui,
                     )?;
                 }
-                Context::Tracks { tracks } => {
+                Context::Tracks { tracks, .. } => {
                     render_track_table_window(
                         frame,
                         chunks[1],


### PR DESCRIPTION
## Overview

This PR adds new context type `Tracks` that should replace the use of tracks page and related structs. One benefit this change brings is that it allows to unify the handling codes for a tracks page and a context page, hence making the codes cleaner and easier to manage.

## Changes
- added structs/functions representing "tracks" context page's functionalities
- removed structs/functions representing "tracks" page's functionalities
- refactor command handling codes for context pages