### PR TITLE
Fix liked tracks errors

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -263,6 +263,13 @@ impl Client {
             }
             ClientRequest::GetUserSavedTracks => {
                 let tracks = self.current_user_saved_tracks().await?;
+                state.data.write().caches.context.put(
+                    USER_LIKED_TRACKS_ID.uri.to_owned(),
+                    Context::Tracks {
+                        tracks: tracks.clone(),
+                        desc: "User's top tracks".to_string(),
+                    },
+                );
                 state.data.write().user_data.saved_tracks = tracks;
             }
             ClientRequest::GetUserRecentlyPlayedTracks => {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -267,7 +267,7 @@ impl Client {
                     USER_LIKED_TRACKS_ID.uri.to_owned(),
                     Context::Tracks {
                         tracks: tracks.clone(),
-                        desc: "User's top tracks".to_string(),
+                        desc: "User's liked tracks".to_string(),
                     },
                 );
                 state.data.write().user_data.saved_tracks = tracks;

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -160,17 +160,14 @@ pub fn handle_command_for_track_table_window(
         }
         Command::PlayRandom => {
             let id = rand::thread_rng().gen_range(0..tracks.len());
-            let offset = Some(rspotify_model::Offset::Uri(tracks[id].id.uri()));
 
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                base_playback.offset(offset),
+                base_playback.uri_offset(tracks[id].id.uri()),
             )))?;
         }
         Command::ChooseSelected => {
-            let offset = Some(rspotify_model::Offset::Uri(tracks[id].id.uri()));
-
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                base_playback.offset(offset),
+                base_playback.uri_offset(tracks[id].id.uri()),
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {

--- a/spotify_player/src/state/consant.rs
+++ b/spotify_player/src/state/consant.rs
@@ -1,6 +1,8 @@
 pub use super::*;
 use once_cell::sync::Lazy;
 
+pub const PLAYBACK_TRACKS_LIMIT: usize = 200;
+
 pub static USER_TOP_TRACKS_ID: Lazy<TracksId> =
     Lazy::new(|| TracksId::new("tracks:user-top-tracks", "Top Tracks"));
 

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroUsize};
 
-use super::{model::*, USER_LIKED_TRACKS_ID};
+use super::model::*;
 
 pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
 
@@ -54,15 +54,6 @@ impl Default for Caches {
 
 impl AppData {
     pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
-        // liked track page's id is handled separately because it is stored as a part of user data
-        // TODO: handle rendering/event handling for user's liked tracks page, which are currently broken
-        // related issue: https://github.com/aome510/spotify-player/issues/78
-        if let ContextId::Tracks(tracks_id) = id {
-            if *tracks_id == *USER_LIKED_TRACKS_ID {
-                return Some(&mut self.user_data.saved_tracks);
-            }
-        }
-
         self.caches.context.peek_mut(&id.uri()).map(|c| match c {
             Context::Album { tracks, .. } => tracks,
             Context::Playlist { tracks, .. } => tracks,

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -412,7 +412,7 @@ impl Playback {
                         .position(|id| id.uri() == uri)
                         .unwrap_or_default();
                     let l = pos.saturating_sub(super::PLAYBACK_TRACKS_LIMIT / 2);
-                    let r = l + super::PLAYBACK_TRACKS_LIMIT;
+                    let r = std::cmp::min(l + super::PLAYBACK_TRACKS_LIMIT, ids.len());
                     // For a list with too many tracks, to avoid payload limit when making the `start_playback`
                     // API request, we restrict the range of tracks to be played, which is based on the
                     // playing track's position (if any) and the application's limit (PLAYBACK_TRACKS_LIMIT).

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -404,15 +404,15 @@ impl Playback {
                 Playback::Context(id.clone(), Some(rspotify_model::Offset::Uri(uri)))
             }
             Playback::URIs(ids, _) => {
-                let pos = ids
-                    .iter()
-                    .position(|id| id.uri() == uri)
-                    .unwrap_or_default();
                 let ids = if ids.len() < super::PLAYBACK_TRACKS_LIMIT {
                     ids.clone()
                 } else {
+                    let pos = ids
+                        .iter()
+                        .position(|id| id.uri() == uri)
+                        .unwrap_or_default();
                     let l = pos.saturating_sub(super::PLAYBACK_TRACKS_LIMIT / 2);
-                    let r = l + super::PLAYBACK_TRACKS_LIMIT - 1;
+                    let r = l + super::PLAYBACK_TRACKS_LIMIT;
                     // For a list with too many tracks, to avoid payload limit when making the `start_playback`
                     // API request, we restrict the range of tracks to be played, which is based on the
                     // playing track's position (if any) and the application's limit (PLAYBACK_TRACKS_LIMIT).

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -398,10 +398,30 @@ impl TracksId {
 
 impl Playback {
     /// creates new playback with a specified offset based on the current playback
-    pub fn offset(&self, offset: Option<rspotify_model::Offset>) -> Self {
+    pub fn uri_offset(&self, uri: String) -> Self {
         match self {
-            Playback::Context(id, _) => Playback::Context(id.clone(), offset),
-            Playback::URIs(uri, _) => Playback::URIs(uri.clone(), offset),
+            Playback::Context(id, _) => {
+                Playback::Context(id.clone(), Some(rspotify_model::Offset::Uri(uri)))
+            }
+            Playback::URIs(ids, _) => {
+                let pos = ids
+                    .iter()
+                    .position(|id| id.uri() == uri)
+                    .unwrap_or_default();
+                let ids = if ids.len() < super::PLAYBACK_TRACKS_LIMIT {
+                    ids.clone()
+                } else {
+                    let l = pos.saturating_sub(super::PLAYBACK_TRACKS_LIMIT / 2);
+                    let r = l + super::PLAYBACK_TRACKS_LIMIT - 1;
+                    // For a list with too many tracks, to avoid payload limit when making the `start_playback`
+                    // API request, we restrict the range of tracks to be played, which is based on the
+                    // playing track's position (if any) and the application's limit (PLAYBACK_TRACKS_LIMIT).
+                    // Related issue: https://github.com/aome510/spotify-player/issues/78
+                    ids[l..r].to_vec()
+                };
+
+                Playback::URIs(ids, Some(rspotify_model::Offset::Uri(uri)))
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes
- fixed rendering liked tracks page
- fixed `StartPlayback` request not working for liked tracks page with a large number of tracks
   + related: #78 