### PR TITLE
[#97] Refactor default themes

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -22,7 +22,7 @@ All configuration files should be placed inside the application's configuration 
 | `client_id`                          | the Spotify client's ID                                                       | `65b708073fc0480ea92a077233ca87bd`          |
 | `ap_port`                            | the application's Spotify session connection port                             | `None`                                      |
 | `proxy`                              | the application's Spotify session connection proxy                            | `None`                                      |
-| `theme`                              | the application's theme                                                       | `dracula`                                   |
+| `theme`                              | the application's theme                                                       | `default`                                   |
 | `app_refresh_duration_in_ms`         | the duration (in ms) between two consecutive application refreshes            | `32`                                        |
 | `playback_refresh_duration_in_ms`    | the duration (in ms) between two consecutive playback refreshes               | `0`                                         |
 | `cover_image_refresh_duration_in_ms` | the duration (in ms) between two cover image refreshes (`image` feature only) | `2000`                                      |
@@ -79,17 +79,19 @@ More details on the above configuration options can be found under the [Librespo
 
 ## Themes
 
-`spotify-player` uses `theme.toml` to define additional themes in addition to the default themes (`dracula`, `ayu_light`, `gruvbox_dark`, `solarized_light`).
+`spotify-player` uses `theme.toml` to look for user-defined themes.
 
-The new theme can then be used by setting the `theme` option in the [general configuration](#general) file or specifying the `-t <THEME>` (`--theme <THEME>`) option when running the player.
+The application's theme can be modified by setting the `theme` option in `app.toml` or by specifying the `-t <THEME>` (`--theme <THEME>`) option when running the player.
 
-A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of predefined style for application's components). `name` and `palette` are required when defining a new theme. If `component_style` is not specified, a default value will be used.
+A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of pre-defined styles for application's components).
+
+`name` and `palette` are required when defining a new theme. If `component_style` is not specified, a default value will be used.
 
 An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file
 
 ### Use script to add theme
 
-I have created [a `theme_parse` python script](../scripts/theme_parse) (require `pyaml` and `requests` libraries) to parse [Iterm2 alacritty's color schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/alacritty) into `spotify-player` compatible theme configurations.
+[a `theme_parse` python script](../scripts/theme_parse) (require `pyaml` and `requests` libraries) can be used to parse [Iterm2 alacritty's color schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/alacritty) into `spotify-player` compatible theme configurations.
 
 For example, you can run
 
@@ -101,7 +103,7 @@ to parse [Builtin Solarized Dark](https://github.com/mbadolato/iTerm2-Color-Sche
 
 ### Palette
 
-To define a theme's color palette, user needs to specify **all** the below fields:
+A theme's palette consists of the following fields:
 
 - `background`
 - `foreground`
@@ -121,14 +123,13 @@ To define a theme's color palette, user needs to specify **all** the below field
 - `bright_red`
 - `bright_white`
 - `bright_yellow`
-- `selection_background`
-- `selection_foreground`
 
-A field in the color palette must be set to the hex representation of a RGB color. For example, `background = "#1e1f29"`.
+If a field is not specified, its default value will be based on the terminal's corresponding color.
+If specified, a field's value must be set to be a hex representation of a RGB color. For example, `background = "#1e1f29"`.
 
 ### Component Styles
 
-To define application's component styles, user needs to specify **all** the below fields:
+To define application's component styles, user needs to specify **all of the below fields**:
 
 - `block_title`
 - `playback_track`
@@ -139,7 +140,7 @@ To define application's component styles, user needs to specify **all** the belo
 - `page_desc`
 - `table_header`
 
-A field in the component styles is a `Style` struct which has three optional fields: `fg`, `bg` and `modifiers`. `fg` and `bg` can be either a palette's color (string in pascal case) or a custom RGB color using the following format: `fg = { Rgb { r = 0, g = 0, b = 0} }`. `modifiers` can only be either `Italic` or `Bold`.
+A field in the component styles is a `Style` struct which has three optional fields: `fg`, `bg` and `modifiers`. `fg` and `bg` can be either a palette's color (string in pascal case) or a custom RGB color using the following format: `fg = { Rgb { r = ..., g = ..., b = ... } }`. `modifiers` can only be either `Italic` or `Bold`.
 
 Default value for application's component styles:
 
@@ -148,7 +149,7 @@ block_title = { fg = "Magenta"  }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
-playback_progress_bar = { bg = "SelectionBackground", fg = "Green" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -1,4 +1,4 @@
-theme = "dracula"
+theme = "default"
 client_id = "65b708073fc0480ea92a077233ca87bd"
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -1,39 +1,61 @@
-# example theme configuration file
-# This file adds two new themes `dracula2` and `solarized_dark`
-# in addition to the default application's themes.
-
 [[themes]]
-name = "dracula2"
+name = "dracula"
 [themes.palette]
 background = "#1e1f29"
 foreground = "#f8f8f2"
 black = "#000000"
-blue = "#bd93f9"
-cyan = "#8be9fd"
-green = "#50fa7b"
-magenta = "#ff79c6"
 red = "#ff5555"
-white = "#bbbbbb"
+green = "#50fa7b"
 yellow = "#f1fa8c"
+blue = "#bd93f9"
+magenta = "#ff79c6"
+cyan = "#8be9fd"
+white = "#bbbbbb"
 bright_black = "#555555"
-bright_blue = "#bd93f9"
-bright_cyan = "#8be9fd"
-bright_green = "#50fa7b"
-bright_magenta = "#ff79c6"
 bright_red = "#ff5555"
-bright_white = "#ffffff"
+bright_green = "#50fa7b"
 bright_yellow = "#f1fa8c"
-selection_background = "#44475a"
-selection_foreground =  "#ffffff"
-
+bright_blue = "#bd93f9"
+bright_magenta = "#ff79c6"
+bright_cyan = "#8be9fd"
+bright_white = "#ffffff"
 [themes.component_style]
-# The `component_style` field of a theme is optional.
-# If not specified, a default value will be used as below:
 block_title = { fg = "Magenta"  }
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
-playback_progress_bar = { bg = "SelectionBackground", fg = "Green" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+
+[[themes]]
+name = "gruvbox_dark"
+[themes.palette]
+background = "#282828"
+foreground = "#ebdbb2"
+black = "#282828"
+red = "#cc241d"
+green = "#98971a"
+yellow = "#d79921"
+blue = "#458588"
+magenta = "#b16286"
+cyan = "#689d6a"
+white = "#a89984"
+bright_black = "#928374"
+bright_red = "#fb4934"
+bright_green = "#b8bb26"
+bright_yellow = "#fabd2f"
+bright_blue = "#83a598"
+bright_magenta = "#d3869b"
+bright_cyan = "#8ec07c"
+bright_white = "#ebdbb2"
+[themes.component_style]
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "BrightBlack" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
@@ -44,20 +66,59 @@ name = "solarized_dark"
 background = "#002b36"
 foreground = "#839496"
 black = "#073642"
-blue = "#268bd2"
-cyan = "#2aa198"
-green = "#859900"
-magenta = "#d33682"
 red = "#dc322f"
-white = "#eee8d5"
+green = "#859900"
 yellow = "#b58900"
+blue = "#268bd2"
+magenta = "#d33682"
+cyan = "#2aa198"
+white = "#eee8d5"
 bright_black = "#002b36"
-bright_blue = "#839496"
-bright_cyan = "#93a1a1"
-bright_green = "#586e75"
-bright_magenta = "#6c71c4"
 bright_red = "#cb4b16"
-bright_white = "#fdf6e3"
+bright_green = "#586e75"
 bright_yellow = "#657b83"
-selection_background = "#073642"
-selection_foreground =  "#93a1a1"
+bright_blue = "#839496"
+bright_magenta = "#6c71c4"
+bright_cyan = "#93a1a1"
+bright_white = "#fdf6e3"
+[themes.component_style]
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "White" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+    
+[[themes]]
+name = "solarized_light"
+[themes.palette]
+background = "#fdf6e3"
+foreground = "#657b83"
+black = "#073642"
+red = "#dc322f"
+green = "#859900"
+yellow = "#b58900"
+blue = "#268bd2"
+magenta = "#d33682"
+cyan = "#2aa198"
+white = "#eee8d5"
+bright_black = "#002b36"
+bright_red = "#cb4b16"
+bright_green = "#586e75"
+bright_yellow = "#657b83"
+bright_blue = "#839496"
+bright_magenta = "#6c71c4"
+bright_cyan = "#93a1a1"
+bright_white = "#fdf6e3"
+[themes.component_style]
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "BrightBlack" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+    

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -59,6 +59,38 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+
+[[themes]]
+name = "gruvbox_light"
+[themes.palette]
+background = "#fbf1c7"
+foreground = "#282828"
+black = "#fbf1c7"
+red = "#9d0006"
+green = "#79740e"
+yellow = "#b57614"
+blue = "#076678"
+magenta = "#8f3f71"
+cyan = "#427b58"
+white = "#3c3836"
+bright_black = "#9d8374"
+bright_red = "#cc241d"
+bright_green = "#98971a"
+bright_yellow = "#d79921"
+bright_blue = "#458588"
+bright_magenta = "#b16186"
+bright_cyan = "#689d69"
+bright_white = "#7c6f64"
+[themes.component_style]
+block_title = { fg = "Magenta"  }
+playback_track = { fg = "Cyan", modifiers = ["Bold"] }
+playback_album = { fg = "Yellow" }
+playback_metadata = { fg = "BrightBlack" }
+playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
+current_playing = { fg = "Green", modifiers = ["Bold"] }
+page_desc = { fg = "Cyan", modifiers = ["Bold"] }
+table_header = { fg = "Blue" }
+
     
 [[themes]]
 name = "solarized_dark"
@@ -121,4 +153,3 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
-    

--- a/scripts/theme_parse
+++ b/scripts/theme_parse
@@ -12,47 +12,51 @@ if len(sys.argv) > 1:
     else:
         saved_name = name
 else:
-    name = 'Dracula'
-    saved_name = 'dracula'
+    print("Usage: theme_parse `theme_name` `theme_saved_name`", file=sys.stderr)
+    exit(1)
 
-url = f'https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/alacritty/{name}.yml'
+url = f"https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/alacritty/{name}.yml"
 
-content = requests.get(url).content
+req = requests.get(url)
 
-data = yaml.safe_load(content)
+if req.status_code != 200:
+    print(
+        f"GET {url} request failed with status code: {req.status_code}", file=sys.stderr
+    )
+    exit(1)
+
+data = yaml.safe_load(req.content)
 
 print(
-    f'''[[themes]]
+    f"""[[themes]]
 name = "{saved_name}"
 [themes.palette]
 background = "{data["colors"]["primary"]["background"]}"
 foreground = "{data["colors"]["primary"]["foreground"]}"
 black = "{data["colors"]["normal"]["black"]}"
-blue = "{data["colors"]["normal"]["blue"]}"
-cyan = "{data["colors"]["normal"]["cyan"]}"
-green = "{data["colors"]["normal"]["green"]}"
-magenta = "{data["colors"]["normal"]["magenta"]}"
 red = "{data["colors"]["normal"]["red"]}"
-white = "{data["colors"]["normal"]["white"]}"
+green = "{data["colors"]["normal"]["green"]}"
 yellow = "{data["colors"]["normal"]["yellow"]}"
+blue = "{data["colors"]["normal"]["blue"]}"
+magenta = "{data["colors"]["normal"]["magenta"]}"
+cyan = "{data["colors"]["normal"]["cyan"]}"
+white = "{data["colors"]["normal"]["white"]}"
 bright_black = "{data["colors"]["bright"]["black"]}"
-bright_blue = "{data["colors"]["bright"]["blue"]}"
-bright_cyan = "{data["colors"]["bright"]["cyan"]}"
-bright_green = "{data["colors"]["bright"]["green"]}"
-bright_magenta = "{data["colors"]["bright"]["magenta"]}"
 bright_red = "{data["colors"]["bright"]["red"]}"
-bright_white = "{data["colors"]["bright"]["white"]}"
+bright_green = "{data["colors"]["bright"]["green"]}"
 bright_yellow = "{data["colors"]["bright"]["yellow"]}"
-selection_background = "{data["colors"]["selection"]["background"]}"
-selection_foreground =  "{data["colors"]["selection"]["text"]}"
+bright_blue = "{data["colors"]["bright"]["blue"]}"
+bright_magenta = "{data["colors"]["bright"]["magenta"]}"
+bright_cyan = "{data["colors"]["bright"]["cyan"]}"
+bright_white = "{data["colors"]["bright"]["white"]}"
 [themes.component_style]
 block_title = {{ fg = "Magenta"  }}
 playback_track = {{ fg = "Cyan", modifiers = ["Bold"] }}
 playback_album = {{ fg = "Yellow" }}
 playback_metadata = {{ fg = "BrightBlack" }}
-playback_progress_bar = {{ bg = "SelectionBackground", fg = "Green" }}
+playback_progress_bar = {{ bg = "BrightBlack", fg = "Green" }}
 current_playing = {{ fg = "Green", modifiers = ["Bold"] }}
 page_desc = {{ fg = "Cyan", modifiers = ["Bold"] }}
 table_header = {{ fg = "Blue" }}
-    '''
+    """
 )

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -19,8 +19,8 @@ pub struct Theme {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Palette {
-    pub background: Color,
-    pub foreground: Color,
+    pub background: Option<Color>,
+    pub foreground: Option<Color>,
 
     pub black: Color,
     pub blue: Color,
@@ -68,8 +68,6 @@ pub struct Style {
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub enum StyleColor {
-    Background,
-    Foreground,
     Black,
     Blue,
     Cyan,
@@ -144,9 +142,14 @@ impl ThemeConfig {
 
 impl Theme {
     pub fn app_style(&self) -> style::Style {
-        style::Style::default()
-            .bg(self.palette.background.color)
-            .fg(self.palette.foreground.color)
+        let mut style = style::Style::default();
+        if let Some(ref c) = self.palette.background {
+            style = style.bg(c.color);
+        }
+        if let Some(ref c) = self.palette.foreground {
+            style = style.fg(c.color);
+        }
+        style
     }
 
     pub fn selection_style(&self, is_active: bool) -> style::Style {
@@ -223,8 +226,6 @@ impl Style {
 impl StyleColor {
     pub fn color(&self, palette: &Palette) -> style::Color {
         match *self {
-            Self::Background => palette.background.color,
-            Self::Foreground => palette.foreground.color,
             Self::Black => palette.black.color,
             Self::Blue => palette.blue.color,
             Self::Cyan => palette.cyan.color,
@@ -321,8 +322,8 @@ impl Default for Theme {
         Self {
             name: "default".to_owned(),
             palette: Palette {
-                background: "#1e1f29".into(),
-                foreground: "#f8f8f2".into(),
+                background: None,
+                foreground: None,
 
                 // ANSI colors for default palette
                 // Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -22,22 +22,38 @@ pub struct Palette {
     pub background: Option<Color>,
     pub foreground: Option<Color>,
 
+    #[serde(default = "Color::black")]
     pub black: Color,
+    #[serde(default = "Color::blue")]
     pub blue: Color,
+    #[serde(default = "Color::cyan")]
     pub cyan: Color,
+    #[serde(default = "Color::green")]
     pub green: Color,
+    #[serde(default = "Color::magenta")]
     pub magenta: Color,
+    #[serde(default = "Color::red")]
     pub red: Color,
+    #[serde(default = "Color::white")]
     pub white: Color,
+    #[serde(default = "Color::yellow")]
     pub yellow: Color,
 
+    #[serde(default = "Color::bright_black")]
     pub bright_black: Color,
+    #[serde(default = "Color::bright_white")]
     pub bright_white: Color,
+    #[serde(default = "Color::bright_red")]
     pub bright_red: Color,
+    #[serde(default = "Color::bright_magenta")]
     pub bright_magenta: Color,
+    #[serde(default = "Color::bright_green")]
     pub bright_green: Color,
+    #[serde(default = "Color::bright_cyan")]
     pub bright_cyan: Color,
+    #[serde(default = "Color::bright_blue")]
     pub bright_blue: Color,
+    #[serde(default = "Color::bright_yellow")]
     pub bright_yellow: Color,
 }
 
@@ -295,6 +311,60 @@ impl Color {
             color: style::Color::Rgb(r, g, b),
         })
     }
+
+    // Terminal's ANSI colors construction functions.
+    // Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+    // The conversion from `style::Color` can be a bit counter-intuitive
+    // as the `tui-rs` library doesn't follow the ANSI naming standard.
+
+    pub fn black() -> Self {
+        style::Color::Black.into()
+    }
+    pub fn red() -> Self {
+        style::Color::LightRed.into()
+    }
+    pub fn green() -> Self {
+        style::Color::LightGreen.into()
+    }
+    pub fn yellow() -> Self {
+        style::Color::LightYellow.into()
+    }
+    pub fn blue() -> Self {
+        style::Color::LightBlue.into()
+    }
+    pub fn magenta() -> Self {
+        style::Color::LightMagenta.into()
+    }
+    pub fn cyan() -> Self {
+        style::Color::LightCyan.into()
+    }
+    pub fn white() -> Self {
+        style::Color::Gray.into()
+    }
+    pub fn bright_black() -> Self {
+        style::Color::DarkGray.into()
+    }
+    pub fn bright_red() -> Self {
+        style::Color::Red.into()
+    }
+    pub fn bright_green() -> Self {
+        style::Color::Green.into()
+    }
+    pub fn bright_yellow() -> Self {
+        style::Color::Yellow.into()
+    }
+    pub fn bright_blue() -> Self {
+        style::Color::Blue.into()
+    }
+    pub fn bright_magenta() -> Self {
+        style::Color::Magenta.into()
+    }
+    pub fn bright_cyan() -> Self {
+        style::Color::Cyan.into()
+    }
+    pub fn bright_white() -> Self {
+        style::Color::White.into()
+    }
 }
 
 impl From<&str> for Color {
@@ -324,28 +394,23 @@ impl Default for Theme {
             palette: Palette {
                 background: None,
                 foreground: None,
-
-                // ANSI colors for default palette
-                // Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
-                // The conversion from `style::Color` can be a bit counter-intuitive
-                // as the `tui-rs` library doesn't follow the ANSI naming standard.
-                black: style::Color::Black.into(),
-                red: style::Color::LightRed.into(),
-                green: style::Color::LightGreen.into(),
-                yellow: style::Color::LightYellow.into(),
-                blue: style::Color::LightBlue.into(),
-                magenta: style::Color::LightMagenta.into(),
-                cyan: style::Color::LightCyan.into(),
-                white: style::Color::Gray.into(),
-
-                bright_black: style::Color::DarkGray.into(),
-                bright_red: style::Color::Red.into(),
-                bright_green: style::Color::Green.into(),
-                bright_yellow: style::Color::Yellow.into(),
-                bright_blue: style::Color::Blue.into(),
-                bright_magenta: style::Color::Magenta.into(),
-                bright_cyan: style::Color::Cyan.into(),
-                bright_white: style::Color::White.into(),
+                // the default theme uses the terminal's ANSI colors
+                black: Color::black(),
+                red: Color::red(),
+                green: Color::green(),
+                yellow: Color::yellow(),
+                blue: Color::blue(),
+                magenta: Color::magenta(),
+                cyan: Color::cyan(),
+                white: Color::white(),
+                bright_black: Color::bright_black(),
+                bright_red: Color::bright_red(),
+                bright_green: Color::bright_green(),
+                bright_yellow: Color::bright_yellow(),
+                bright_blue: Color::bright_blue(),
+                bright_magenta: Color::bright_magenta(),
+                bright_cyan: Color::bright_cyan(),
+                bright_white: Color::bright_white(),
             },
             component_style: ComponentStyle::default(),
         }
@@ -366,7 +431,9 @@ impl Default for ComponentStyle {
                 .bg(StyleColor::BrightBlack)
                 .fg(StyleColor::Green),
 
-            current_playing: Style::default().fg(StyleColor::Green),
+            current_playing: Style::default()
+                .fg(StyleColor::Green)
+                .modifiers(vec![StyleModifier::Bold]),
 
             page_desc: Style::default()
                 .fg(StyleColor::Cyan)

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -309,93 +309,16 @@ impl From<&str> for Color {
     }
 }
 
+impl From<style::Color> for Color {
+    fn from(value: style::Color) -> Self {
+        Self { color: value }
+    }
+}
+
 impl Default for ThemeConfig {
     fn default() -> Self {
         Self {
-            themes: vec![
-                Theme::default(),
-                Theme {
-                    // Ayu Light color palette based on https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/alacritty/ayu_light.yml
-                    name: "ayu_light".to_owned(),
-                    palette: Palette {
-                        foreground: "#5c6773".into(),
-                        background: "#fafafa".into(),
-                        selection_foreground: "#5c6773".into(),
-                        selection_background: "#f0eee4".into(),
-                        black: "#000000".into(),
-                        blue: "#41a6d9".into(),
-                        cyan: "#4dbf99".into(),
-                        green: "#86b300".into(),
-                        magenta: "#f07178".into(),
-                        red: "#ff3333".into(),
-                        white: "#ffffff".into(),
-                        yellow: "#f29718".into(),
-                        bright_black: "#323232".into(),
-                        bright_blue: "#73d8ff".into(),
-                        bright_cyan: "#7ff1cb".into(),
-                        bright_green: "#b8e532".into(),
-                        bright_magenta: "#ffa3aa".into(),
-                        bright_red: "#ff6565".into(),
-                        bright_white: "#ffffff".into(),
-                        bright_yellow: "#ffc94a".into(),
-                    },
-                    component_style: ComponentStyle::default(),
-                },
-                Theme {
-                    // Gruvbox Dark color palette based on https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/alacritty/Gruvbox%20Dark.yml
-                    name: "gruvbox_dark".to_owned(),
-                    palette: Palette {
-                        foreground: "#e6d4a3".into(),
-                        background: "#1e1e1e".into(),
-                        selection_foreground: "#534a42".into(),
-                        selection_background: "#e6d4a3".into(),
-                        black: "#1e1e1e".into(),
-                        blue: "#377375".into(),
-                        cyan: "#578e57".into(),
-                        green: "#868715".into(),
-                        magenta: "#a04b73".into(),
-                        red: "#be0f17".into(),
-                        white: "#978771".into(),
-                        yellow: "#cc881a".into(),
-                        bright_black: "#7f7061".into(),
-                        bright_blue: "#719586".into(),
-                        bright_cyan: "#7db669".into(),
-                        bright_green: "#aab01e".into(),
-                        bright_magenta: "#c77089".into(),
-                        bright_red: "#f73028".into(),
-                        bright_white: "#e6d4a3".into(),
-                        bright_yellow: "#f7b125".into(),
-                    },
-                    component_style: ComponentStyle::default(),
-                },
-                Theme {
-                    // Solarized Light palette based on https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/alacritty/Builtin%20Solarized%20Light.yml
-                    name: "solarized_light".to_owned(),
-                    palette: Palette {
-                        background: "#fdf6e3".into(),
-                        foreground: "#657b83".into(),
-                        selection_background: "#eee8d5".into(),
-                        selection_foreground: "#586e75".into(),
-                        black: "#073642".into(),
-                        blue: "#268bd2".into(),
-                        cyan: "#2aa198".into(),
-                        green: "#859900".into(),
-                        magenta: "#d33682".into(),
-                        red: "#dc322f".into(),
-                        white: "#eee8d5".into(),
-                        yellow: "#b58900".into(),
-                        bright_black: "#002b36".into(),
-                        bright_blue: "#839496".into(),
-                        bright_cyan: "#93a1a1".into(),
-                        bright_green: "#586e75".into(),
-                        bright_magenta: "#6c71c4".into(),
-                        bright_red: "#cb4b16".into(),
-                        bright_white: "#fdf6e3".into(),
-                        bright_yellow: "#657b83".into(),
-                    },
-                    component_style: ComponentStyle::default(),
-                },
-            ],
+            themes: vec![Theme::default()],
         }
     }
 }
@@ -403,29 +326,32 @@ impl Default for ThemeConfig {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            // Dracula color palette based on https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/alacritty/Dracula.yml
-            name: "dracula".to_owned(),
+            name: "default".to_owned(),
             palette: Palette {
                 background: "#1e1f29".into(),
                 foreground: "#f8f8f2".into(),
-                selection_background: "#44475a".into(),
-                selection_foreground: "#ffffff".into(),
-                black: "#000000".into(),
-                blue: "#bd93f9".into(),
-                cyan: "#8be9fd".into(),
-                green: "#50fa7b".into(),
-                magenta: "#ff79c6".into(),
-                red: "#ff5555".into(),
-                white: "#bbbbbb".into(),
-                yellow: "#f1fa8c".into(),
-                bright_black: "#555555".into(),
-                bright_blue: "#bd93f9".into(),
-                bright_cyan: "#8be9fd".into(),
-                bright_green: "#50fa7b".into(),
-                bright_magenta: "#ff79c6".into(),
-                bright_red: "#ff5555".into(),
-                bright_white: "#ffffff".into(),
-                bright_yellow: "#f1fa8c".into(),
+
+                // ANSI colors for default palette
+                // Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+                // The conversion from `style::Color` can be a bit counter-intuitive
+                // as the `tui-rs` library doesn't follow the ANSI naming standard.
+                black: style::Color::Black.into(),
+                red: style::Color::LightRed.into(),
+                green: style::Color::LightGreen.into(),
+                yellow: style::Color::LightYellow.into(),
+                blue: style::Color::LightBlue.into(),
+                magenta: style::Color::LightMagenta.into(),
+                cyan: style::Color::LightCyan.into(),
+                white: style::Color::Gray.into(),
+
+                bright_black: style::Color::DarkGray.into(),
+                bright_red: style::Color::Red.into(),
+                bright_green: style::Color::Green.into(),
+                bright_yellow: style::Color::Yellow.into(),
+                bright_blue: style::Color::Blue.into(),
+                bright_magenta: style::Color::Magenta.into(),
+                bright_cyan: style::Color::Cyan.into(),
+                bright_white: style::Color::White.into(),
             },
             component_style: ComponentStyle::default(),
         }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -363,12 +363,10 @@ impl Default for ComponentStyle {
             playback_album: Style::default().fg(StyleColor::Yellow),
             playback_metadata: Style::default().fg(StyleColor::BrightBlack),
             playback_progress_bar: Style::default()
-                .bg(StyleColor::SelectionBackground)
+                .bg(StyleColor::BrightBlack)
                 .fg(StyleColor::Green),
 
-            current_playing: Style::default()
-                .fg(StyleColor::Green)
-                .modifiers(vec![StyleModifier::Bold]),
+            current_playing: Style::default().fg(StyleColor::Green),
 
             page_desc: Style::default()
                 .fg(StyleColor::Cyan)

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -21,8 +21,6 @@ pub struct Theme {
 pub struct Palette {
     pub background: Color,
     pub foreground: Color,
-    pub selection_background: Color,
-    pub selection_foreground: Color,
 
     pub black: Color,
     pub blue: Color,
@@ -72,8 +70,6 @@ pub struct Style {
 pub enum StyleColor {
     Background,
     Foreground,
-    SelectionBackground,
-    SelectionForeground,
     Black,
     Blue,
     Cyan,
@@ -156,8 +152,7 @@ impl Theme {
     pub fn selection_style(&self, is_active: bool) -> style::Style {
         if is_active {
             style::Style::default()
-                .bg(self.palette.selection_background.color)
-                .fg(self.palette.selection_foreground.color)
+                .add_modifier(style::Modifier::REVERSED)
                 .add_modifier(style::Modifier::BOLD)
         } else {
             style::Style::default()
@@ -230,8 +225,6 @@ impl StyleColor {
         match *self {
             Self::Background => palette.background.color,
             Self::Foreground => palette.foreground.color,
-            Self::SelectionBackground => palette.selection_background.color,
-            Self::SelectionForeground => palette.selection_foreground.color,
             Self::Black => palette.black.color,
             Self::Blue => palette.blue.color,
             Self::Cyan => palette.cyan.color,


### PR DESCRIPTION
Resolves #97 

## TODO
- [x] remove built-in themes in favour of a single default ANSI theme
- [x] update `theme_parse` script
- [x] update theme/palette documentation
- [x] update `theme.toml` and `app.toml` examples

## Theme config changes
- made `background` and `foreground` fields optional in a theme's palette. Default to use terminal's background/foreground colors if not specified.
- made 16 ANSI color fields optional in a theme's palette. Default to use terminal's ANSI colors if not specified.
- removed `selection_background` and `selection_foreground` fields from a theme's palette
- tweaked default value for `playback_progress_bar` component style