### PR TITLE
More flexible theme config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -136,6 +136,7 @@ If specified, a field's value must be set to be a hex representation of a RGB co
 To define application's component styles, the user can specify any of the below fields:
 
 - `block_title`
+- `border`
 - `playback_track`
 - `playback_album`
 - `playback_metadata`
@@ -150,6 +151,7 @@ Default value for application's component styles:
 
 ```toml
 block_title = { fg = "Magenta"  }
+border = {} # uses the palette's fg and bg color
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }

--- a/docs/config.md
+++ b/docs/config.md
@@ -133,7 +133,7 @@ If specified, a field's value must be set to be a hex representation of a RGB co
 
 ### Component Styles
 
-To define application's component styles, user needs to specify **all of the below fields**:
+To define application's component styles, the user can specify any of the below fields:
 
 - `block_title`
 - `playback_track`

--- a/docs/config.md
+++ b/docs/config.md
@@ -144,6 +144,7 @@ To define application's component styles, the user can specify any of the below 
 - `current_playing`
 - `page_desc`
 - `table_header`
+- `selection`
 
 A field in the component styles is a `Style` struct which has three optional fields: `fg`, `bg` and `modifiers`. `fg` and `bg` can be either a palette's color (string in pascal case) or a custom RGB color using the following format: `fg = { Rgb { r = ..., g = ..., b = ... } }`. `modifiers` can only be either `Italic` or `Bold`.
 
@@ -159,6 +160,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = {} # if not set, this is bold and reverses fg and bg color
 ```
 
 ## Keymaps

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,7 +89,7 @@ The application's theme can be modified by setting the `theme` option in `app.to
 
 A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of pre-defined styles for application's components).
 
-`name` and `palette` are required when defining a new theme. If `component_style` is not specified, a default value will be used.
+`name` is required when defining a new theme. If `palette` is not set, the terminals colorscheme will be used. If `component_style` is not specified, a default value will be used.
 
 An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,7 +89,7 @@ The application's theme can be modified by setting the `theme` option in `app.to
 
 A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of pre-defined styles for application's components).
 
-`name` is required when defining a new theme. If `palette` is not set, the terminals colorscheme will be used. If `component_style` is not specified, a default value will be used.
+`name` is required when defining a new theme. If `palette` is not set, a palette based on the terminal's colorscheme will be used. If `component_style` is not specified, a default value will be used.
 
 An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file
 
@@ -146,13 +146,13 @@ To define application's component styles, the user can specify any of the below 
 - `table_header`
 - `selection`
 
-A field in the component styles is a `Style` struct which has three optional fields: `fg`, `bg` and `modifiers`. `fg` and `bg` can be either a palette's color (string in pascal case) or a custom RGB color using the following format: `fg = { Rgb { r = ..., g = ..., b = ... } }`. `modifiers` can only be either `Italic` or `Bold`.
+A field in the component styles is a `Style` struct which has three optional fields: `fg`, `bg` and `modifiers`. `fg` and `bg` can be either a palette's color (string in pascal case) or a custom RGB color using the following format: `fg = { Rgb { r = ..., g = ..., b = ... } }`. The default values for `fg` and `bg` are the `palette`'s `fg` and `bg`. `modifiers` can only be `Italic`, `Bold` or `Reversed`.
 
 Default value for application's component styles:
 
 ```toml
 block_title = { fg = "Magenta"  }
-border = {} # uses the palette's fg and bg color
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
@@ -160,7 +160,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
-selection = {} # if not set, this is bold and reverses fg and bg color
+selection = { modifiers = ["Bold", "Reversed"] }
 ```
 
 ## Keymaps

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -21,6 +21,7 @@ bright_cyan = "#8be9fd"
 bright_white = "#ffffff"
 [themes.component_style]
 block_title = { fg = "Magenta"  }
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
@@ -28,6 +29,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = { modifiers = ["Bold", "Reversed"] }
 
 [[themes]]
 name = "gruvbox_dark"
@@ -52,6 +54,7 @@ bright_cyan = "#8ec07c"
 bright_white = "#ebdbb2"
 [themes.component_style]
 block_title = { fg = "Magenta"  }
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
@@ -59,6 +62,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = { modifiers = ["Bold", "Reversed"] }
 
 [[themes]]
 name = "gruvbox_light"
@@ -83,6 +87,7 @@ bright_cyan = "#689d69"
 bright_white = "#7c6f64"
 [themes.component_style]
 block_title = { fg = "Magenta"  }
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
@@ -90,6 +95,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = { modifiers = ["Bold", "Reversed"] }
 
     
 [[themes]]
@@ -115,6 +121,7 @@ bright_cyan = "#93a1a1"
 bright_white = "#fdf6e3"
 [themes.component_style]
 block_title = { fg = "Magenta"  }
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "White" }
@@ -122,6 +129,7 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = { modifiers = ["Bold", "Reversed"] }
     
 [[themes]]
 name = "solarized_light"
@@ -146,6 +154,7 @@ bright_cyan = "#93a1a1"
 bright_white = "#fdf6e3"
 [themes.component_style]
 block_title = { fg = "Magenta"  }
+border = {}
 playback_track = { fg = "Cyan", modifiers = ["Bold"] }
 playback_album = { fg = "Yellow" }
 playback_metadata = { fg = "BrightBlack" }
@@ -153,3 +162,4 @@ playback_progress_bar = { bg = "BrightBlack", fg = "Green" }
 current_playing = { fg = "Green", modifiers = ["Bold"] }
 page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 table_header = { fg = "Blue" }
+selection = { modifiers = ["Bold", "Reversed"] }

--- a/scripts/theme_parse
+++ b/scripts/theme_parse
@@ -51,6 +51,7 @@ bright_cyan = "{data["colors"]["bright"]["cyan"]}"
 bright_white = "{data["colors"]["bright"]["white"]}"
 [themes.component_style]
 block_title = {{ fg = "Magenta"  }}
+border = {{}}
 playback_track = {{ fg = "Cyan", modifiers = ["Bold"] }}
 playback_album = {{ fg = "Yellow" }}
 playback_metadata = {{ fg = "BrightBlack" }}
@@ -58,5 +59,6 @@ playback_progress_bar = {{ bg = "BrightBlack", fg = "Green" }}
 current_playing = {{ fg = "Green", modifiers = ["Bold"] }}
 page_desc = {{ fg = "Cyan", modifiers = ["Bold"] }}
 table_header = {{ fg = "Blue" }}
+selection = {{ modifiers = ["Bold", "Reversed"] }}
     """
 )

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -57,21 +57,16 @@ pub struct Palette {
     pub bright_yellow: Color,
 }
 
-// TODO: find a way to parse ComponentStyle config options without
-// having to specify all the fields
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct ComponentStyle {
-    pub block_title: Style,
-
-    pub playback_track: Style,
-    pub playback_album: Style,
-    pub playback_metadata: Style,
-    pub playback_progress_bar: Style,
-
-    pub current_playing: Style,
-
-    pub page_desc: Style,
-    pub table_header: Style,
+    pub block_title: Option<Style>,
+    pub playback_track: Option<Style>,
+    pub playback_album: Option<Style>,
+    pub playback_metadata: Option<Style>,
+    pub playback_progress_bar: Option<Style>,
+    pub current_playing: Option<Style>,
+    pub page_desc: Option<Style>,
+    pub table_header: Option<Style>,
 }
 
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -112,16 +107,6 @@ pub enum StyleModifier {
 #[derive(Clone, Debug)]
 pub struct Color {
     pub color: style::Color,
-}
-
-macro_rules! impl_component_style_getters {
-	($($f:ident),+) => {
-		$(
-            pub fn $f(&self) -> tui::style::Style {
-                self.component_style.$f.style(&self.palette)
-            }
-        )*
-	};
 }
 
 impl ThemeConfig {
@@ -196,16 +181,77 @@ impl Theme {
         tui::text::Span::styled(content.into(), self.block_title())
     }
 
-    impl_component_style_getters!(
-        block_title,
-        playback_track,
-        playback_album,
-        playback_metadata,
-        playback_progress_bar,
-        current_playing,
-        page_desc,
-        table_header
-    );
+    pub fn block_title(&self) -> tui::style::Style {
+        match &self.component_style.block_title {
+            None => Style::default()
+                .fg(StyleColor::Magenta)
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn playback_track(&self) -> tui::style::Style {
+        match &self.component_style.playback_track {
+            None => Style::default()
+                .fg(StyleColor::Cyan)
+                .modifiers(vec![StyleModifier::Bold])
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn playback_album(&self) -> tui::style::Style {
+        match &self.component_style.playback_album {
+            None => Style::default().fg(StyleColor::Yellow).style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn playback_metadata(&self) -> tui::style::Style {
+        match &self.component_style.playback_metadata {
+            None => Style::default()
+                .fg(StyleColor::BrightBlack)
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn playback_progress_bar(&self) -> tui::style::Style {
+        match &self.component_style.playback_metadata {
+            None => Style::default()
+                .bg(StyleColor::BrightBlack)
+                .fg(StyleColor::Green)
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn current_playing(&self) -> tui::style::Style {
+        match &self.component_style.current_playing {
+            None => Style::default()
+                .fg(StyleColor::Green)
+                .modifiers(vec![StyleModifier::Bold])
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn page_desc(&self) -> tui::style::Style {
+        match &self.component_style.page_desc {
+            None => Style::default()
+                .fg(StyleColor::Cyan)
+                .modifiers(vec![StyleModifier::Bold])
+                .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn table_header(&self) -> tui::style::Style {
+        match &self.component_style.table_header {
+            None => Style::default().fg(StyleColor::Blue).style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
 }
 
 impl Style {
@@ -413,32 +459,6 @@ impl Default for Theme {
                 bright_white: Color::bright_white(),
             },
             component_style: ComponentStyle::default(),
-        }
-    }
-}
-
-impl Default for ComponentStyle {
-    fn default() -> Self {
-        Self {
-            block_title: Style::default().fg(StyleColor::Magenta),
-
-            playback_track: Style::default()
-                .fg(StyleColor::Cyan)
-                .modifiers(vec![StyleModifier::Bold]),
-            playback_album: Style::default().fg(StyleColor::Yellow),
-            playback_metadata: Style::default().fg(StyleColor::BrightBlack),
-            playback_progress_bar: Style::default()
-                .bg(StyleColor::BrightBlack)
-                .fg(StyleColor::Green),
-
-            current_playing: Style::default()
-                .fg(StyleColor::Green)
-                .modifiers(vec![StyleModifier::Bold]),
-
-            page_desc: Style::default()
-                .fg(StyleColor::Cyan)
-                .modifiers(vec![StyleModifier::Bold]),
-            table_header: Style::default().fg(StyleColor::Blue),
         }
     }
 }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -12,6 +12,7 @@ pub struct ThemeConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Theme {
     pub name: String,
+    #[serde(default)]
     palette: Palette,
     #[serde(default)]
     component_style: ComponentStyle,
@@ -437,28 +438,34 @@ impl Default for Theme {
     fn default() -> Self {
         Self {
             name: "default".to_owned(),
-            palette: Palette {
-                background: None,
-                foreground: None,
-                // the default theme uses the terminal's ANSI colors
-                black: Color::black(),
-                red: Color::red(),
-                green: Color::green(),
-                yellow: Color::yellow(),
-                blue: Color::blue(),
-                magenta: Color::magenta(),
-                cyan: Color::cyan(),
-                white: Color::white(),
-                bright_black: Color::bright_black(),
-                bright_red: Color::bright_red(),
-                bright_green: Color::bright_green(),
-                bright_yellow: Color::bright_yellow(),
-                bright_blue: Color::bright_blue(),
-                bright_magenta: Color::bright_magenta(),
-                bright_cyan: Color::bright_cyan(),
-                bright_white: Color::bright_white(),
-            },
+            palette: Palette::default(),
             component_style: ComponentStyle::default(),
+        }
+    }
+}
+
+impl Default for Palette {
+    fn default() -> Self {
+        Self {
+            background: None,
+            foreground: None,
+            // the default theme uses the terminal's ANSI colors
+            black: Color::black(),
+            red: Color::red(),
+            green: Color::green(),
+            yellow: Color::yellow(),
+            blue: Color::blue(),
+            magenta: Color::magenta(),
+            cyan: Color::cyan(),
+            white: Color::white(),
+            bright_black: Color::bright_black(),
+            bright_red: Color::bright_red(),
+            bright_green: Color::bright_green(),
+            bright_yellow: Color::bright_yellow(),
+            bright_blue: Color::bright_blue(),
+            bright_magenta: Color::bright_magenta(),
+            bright_cyan: Color::bright_cyan(),
+            bright_white: Color::bright_white(),
         }
     }
 }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -61,6 +61,7 @@ pub struct Palette {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct ComponentStyle {
     pub block_title: Option<Style>,
+    pub border: Option<Style>,
     pub playback_track: Option<Style>,
     pub playback_album: Option<Style>,
     pub playback_metadata: Option<Style>,
@@ -187,6 +188,13 @@ impl Theme {
             None => Style::default()
                 .fg(StyleColor::Magenta)
                 .style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
+
+    pub fn border(&self) -> tui::style::Style {
+        match &self.component_style.border {
+            None => Style::default().style(&self.palette),
             Some(s) => s.style(&self.palette),
         }
     }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -69,6 +69,7 @@ pub struct ComponentStyle {
     pub current_playing: Option<Style>,
     pub page_desc: Option<Style>,
     pub table_header: Option<Style>,
+    pub selection: Option<Style>,
 }
 
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -157,9 +158,12 @@ impl Theme {
 
     pub fn selection_style(&self, is_active: bool) -> style::Style {
         if is_active {
-            style::Style::default()
-                .add_modifier(style::Modifier::REVERSED)
-                .add_modifier(style::Modifier::BOLD)
+            match &self.component_style.selection {
+                None => style::Style::default()
+                    .add_modifier(style::Modifier::REVERSED)
+                    .add_modifier(style::Modifier::BOLD),
+                Some(s) => s.style(&self.palette),
+            }
         } else {
             style::Style::default()
         }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -105,6 +105,7 @@ pub enum StyleColor {
 pub enum StyleModifier {
     Bold,
     Italic,
+    Reversed,
 }
 
 #[derive(Clone, Debug)]
@@ -327,6 +328,7 @@ impl From<StyleModifier> for style::Modifier {
         match m {
             StyleModifier::Bold => style::Modifier::BOLD,
             StyleModifier::Italic => style::Modifier::ITALIC,
+            StyleModifier::Reversed => style::Modifier::REVERSED,
         }
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -107,7 +107,8 @@ pub fn render_search_page(
     // renders borders with title
     let block = Block::default()
         .title(ui.theme.block_title_with_style("Search"))
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_style(ui.theme.border());
     frame.render_widget(block, rect);
 
     // renders the query input box
@@ -198,7 +199,8 @@ pub fn render_context_page(
 
     let block = Block::default()
         .title(ui.theme.block_title_with_style(context_page_type.title()))
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_style(ui.theme.border());
 
     let id = match id {
         None => {
@@ -455,7 +457,8 @@ pub fn render_lyric_page(
 
     let block = Block::default()
         .title(ui.theme.block_title_with_style("Lyric"))
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_style(ui.theme.border());
 
     let result = data.caches.lyrics.peek(&format!("{track} {artists}"));
     match result {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -14,7 +14,8 @@ pub fn render_playback_window(
     // render borders and title
     let block = Block::default()
         .title(ui.theme.block_title_with_style("Playback"))
-        .borders(Borders::ALL);
+        .borders(Borders::ALL)
+        .border_style(ui.theme.border());
     frame.render_widget(block, rect);
 
     let rect = {

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -36,6 +36,7 @@ pub fn render_popup(
                 let widget = Paragraph::new(format!("/{query}")).block(
                     Block::default()
                         .borders(Borders::ALL)
+                        .border_style(ui.theme.border())
                         .title(ui.theme.block_title_with_style("Search")),
                 );
                 frame.render_widget(widget, chunks[1]);
@@ -234,7 +235,8 @@ pub fn render_shortcut_help_popup(
         .block(
             Block::default()
                 .title(ui.theme.block_title_with_style("Shortcuts"))
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .border_style(ui.theme.border()),
         );
         frame.render_widget(help_table, chunks[1]);
         chunks[0]
@@ -297,7 +299,8 @@ pub fn render_commands_help_popup(
     .block(
         Block::default()
             .title(ui.theme.block_title_with_style("Commands"))
-            .borders(Borders::ALL),
+            .borders(Borders::ALL)
+            .border_style(ui.theme.border()),
     );
     frame.render_widget(help_table, rect);
 }
@@ -354,7 +357,8 @@ pub fn render_queue_popup(
         .block(
             Block::default()
                 .title(ui.theme.block_title_with_style("Queue"))
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .border_style(ui.theme.border()),
         )
     };
     frame.render_widget(queue_table, rect);

--- a/spotify_player/src/ui/utils.rs
+++ b/spotify_player/src/ui/utils.rs
@@ -28,7 +28,8 @@ pub fn construct_list_widget<'a>(
         .block(
             Block::default()
                 .title(theme.block_title_with_style(title))
-                .borders(borders),
+                .borders(borders)
+                .border_style(theme.border()),
         ),
         n_items,
     )
@@ -79,7 +80,8 @@ pub fn render_loading_window(theme: &config::Theme, frame: &mut Frame, rect: Rec
         Paragraph::new("Loading...").block(
             Block::default()
                 .title(theme.block_title_with_style(title))
-                .borders(Borders::ALL),
+                .borders(Borders::ALL)
+                .border_style(theme.border()),
         ),
         rect,
     );


### PR DESCRIPTION
Hi, thanks for this awesome piece of software!

I just recently came across this project and played around with the theme config a little. At some point I thought it would be nice to have darker borders. However, I could not find this option anywhere in the component styles. So I thought I'd try to implement this myself. After I had finished, I realized that this would require every user to update their theme.toml files because without the new `border` option spotify_player would not be able to parse them and error. Furthermore I saw that you recently refactored the theming config and deleted `fg_selected` and `bg_selected` (or how they were called) and I saw the TODO comment to find a solution to not having to set each component style when adding this section in theme.toml.

Hence I thought, before I add an option to change the border I'll try to figure out a way to solve this TODO. Afterwards, adding new component styles would not be an issue, because it would not affect older configs, that did not set this attribute. So that is what I ended up doing. With this PR
- it is possible to only set some of the component styles in theme.toml
- it is possible to not set the palette in theme.toml (and just modify component styles)
- it is possible to set the border style with the new component_style attribute `border`
- it is possible to set the style of the current selection with the new component_style `selection`

I am quite sure that none of these changes affect any existing theme configs.

With this I could now have a theme.toml like this
```toml
[[themes]]
name = "mine"
[themes.component_style]
border = { fg = "BrightBlack" }
selection = { fg = "Yellow", modifiers = ["Bold"] }
```
that would look like this with my terminal colors:

![Screenshot_20230203_203849](https://user-images.githubusercontent.com/16589944/216692764-dde16014-1658-425a-8eb7-36dbaf27846f.png)
