### PR TITLE
Added more navigation commands

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((rustic-mode . ((lsp-rust-features . ["lyric-finder" "image"]))))

--- a/README.md
+++ b/README.md
@@ -303,8 +303,6 @@ List of supported commands:
 | `SortTrackByAddedDate`         | sort the track table (if any) by track's added date                     | `s D`              |
 | `ReverseOrder`                 | reverse the order of the track table (if any)                           | `s r`              |
 
-> > > > > > > origin/master
-
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 
 **Tips**:

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ List of supported commands:
 | `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up                   | `k`, `C-p`, `up`   |
 | `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down         | `page_down`, `C-f` |
 | `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up       | `page_up`, `C-b`   |
+| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top              | `g g`              |
+| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom            | `G`                |
 | `ChooseSelected`               | choose the selected item                                                | `enter`            |
 | `RefreshPlayback`              | manually refresh the current playback                                   | `r`                |
 | `RestartIntegratedClient`      | restart the integrated librespot client (`streaming` feature only)      | `R`                |

--- a/README.md
+++ b/README.md
@@ -253,52 +253,54 @@ To open a shortcut help popup, press `?` or `C-h` (default shortcuts for `OpenCo
 
 List of supported commands:
 
-| Command                       | Description                                                             | Default shortcuts  |
-| ----------------------------- | ----------------------------------------------------------------------- | ------------------ |
-| `NextTrack`                   | next track                                                              | `n`                |
-| `PreviousTrack`               | previous track                                                          | `p`                |
-| `ResumePause`                 | resume/pause based on the current playback                              | `space`            |
-| `PlayRandom`                  | play a random track in the current context                              | `.`                |
-| `Repeat`                      | cycle the repeat mode                                                   | `C-r`              |
-| `Shuffle`                     | toggle the shuffle mode                                                 | `C-s`              |
-| `VolumeUp`                    | increase playback volume by 5%                                          | `+`                |
-| `VolumeDown`                  | decrease playback volume by 5%                                          | `-`                |
-| `SeekForward`                 | seek forward by 5s                                                      | `>`                |
-| `SeekBackward`                | seek backward by 5s                                                     | `<`                |
-| `Quit`                        | quit the application                                                    | `C-c`, `q`         |
-| `OpenCommandHelp`             | open a command help popup                                               | `?`, `C-h`         |
-| `ClosePopup`                  | close a popup                                                           | `esc`              |
-| `SelectNextOrScrollDown`      | select the next item in a list/table or scroll down                     | `j`, `C-n`, `down` |
-| `SelectPreviousOrScrollUp`    | select the previous item in a list/table or scroll up                   | `k`, `C-p`, `up`   |
-| `ChooseSelected`              | choose the selected item                                                | `enter`            |
-| `RefreshPlayback`             | manually refresh the current playback                                   | `r`                |
-| `RestartIntegratedClient`     | restart the integrated librespot client (`streaming` feature only)      | `R`                |
-| `ShowActionsOnSelectedItem`   | open a popup showing actions on a selected item                         | `g a`, `C-space`   |
-| `ShowActionsOnCurrentTrack`   | open a popup showing actions on the current track                       | `a`                |
-| `FocusNextWindow`             | focus the next focusable window (if any)                                | `tab`              |
-| `FocusPreviousWindow`         | focus the previous focusable window (if any)                            | `backtab`          |
-| `SwitchTheme`                 | open a popup for switching theme                                        | `T`                |
-| `SwitchDevice`                | open a popup for switching device                                       | `D`                |
-| `Search`                      | open a popup for searching in the current page                          | `/`                |
-| `Queue`                       | open a popup for showing the current queue                              | `z`                |
-| `BrowseUserPlaylists`         | open a popup for browsing user's playlists                              | `u p`              |
-| `BrowseUserFollowedArtists`   | open a popup for browsing user's followed artists                       | `u a`              |
-| `BrowseUserSavedAlbums`       | open a popup for browsing user's saved albums                           | `u A`              |
-| `CurrentlyPlayingContextPage` | go to the currently playing context page                                | `g space`          |
-| `TopTrackPage`                | go to the user top track page                                           | `g t`              |
-| `RecentlyPlayedTrackPage`     | go to the user recently played track page                               | `g r`              |
-| `LikedTrackPage`              | go to the user liked track page                                         | `g y`              |
-| `LyricPage`                   | go to the lyric page of the current track (`lyric-finder` feature only) | `g L`, `l`         |
-| `LibraryPage`                 | go to the user library page                                             | `g l`              |
-| `SearchPage`                  | go to the search page                                                   | `g s`              |
-| `BrowsePage`                  | go to the browse page                                                   | `g b`              |
-| `PreviousPage`                | go to the previous page                                                 | `backspace`, `C-q` |
-| `SortTrackByTitle`            | sort the track table (if any) by track's title                          | `s t`              |
-| `SortTrackByArtists`          | sort the track table (if any) by track's artists                        | `s a`              |
-| `SortTrackByAlbum`            | sort the track table (if any) by track's album                          | `s A`              |
-| `SortTrackByDuration`         | sort the track table (if any) by track's duration                       | `s d`              |
-| `SortTrackByAddedDate`        | sort the track table (if any) by track's added date                     | `s D`              |
-| `ReverseOrder`                | reverse the order of the track table (if any)                           | `s r`              |
+| Command                        | Description                                                             | Default shortcuts  |
+| ------------------------------ | ----------------------------------------------------------------------- | ------------------ |
+| `NextTrack`                    | next track                                                              | `n`                |
+| `PreviousTrack`                | previous track                                                          | `p`                |
+| `ResumePause`                  | resume/pause based on the current playback                              | `space`            |
+| `PlayRandom`                   | play a random track in the current context                              | `.`                |
+| `Repeat`                       | cycle the repeat mode                                                   | `C-r`              |
+| `Shuffle`                      | toggle the shuffle mode                                                 | `C-s`              |
+| `VolumeUp`                     | increase playback volume by 5%                                          | `+`                |
+| `VolumeDown`                   | decrease playback volume by 5%                                          | `-`                |
+| `SeekForward`                  | seek forward by 5s                                                      | `>`                |
+| `SeekBackward`                 | seek backward by 5s                                                     | `<`                |
+| `Quit`                         | quit the application                                                    | `C-c`, `q`         |
+| `OpenCommandHelp`              | open a command help popup                                               | `?`, `C-h`         |
+| `ClosePopup`                   | close a popup                                                           | `esc`              |
+| `SelectNextOrScrollDown`       | select the next item in a list/table or scroll down                     | `j`, `C-n`, `down` |
+| `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up                   | `k`, `C-p`, `up`   |
+| `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down         | `page_down`, `C-f` |
+| `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up       | `page_up`, `C-b`   |
+| `ChooseSelected`               | choose the selected item                                                | `enter`            |
+| `RefreshPlayback`              | manually refresh the current playback                                   | `r`                |
+| `RestartIntegratedClient`      | restart the integrated librespot client (`streaming` feature only)      | `R`                |
+| `ShowActionsOnSelectedItem`    | open a popup showing actions on a selected item                         | `g a`, `C-space`   |
+| `ShowActionsOnCurrentTrack`    | open a popup showing actions on the current track                       | `a`                |
+| `FocusNextWindow`              | focus the next focusable window (if any)                                | `tab`              |
+| `FocusPreviousWindow`          | focus the previous focusable window (if any)                            | `backtab`          |
+| `SwitchTheme`                  | open a popup for switching theme                                        | `T`                |
+| `SwitchDevice`                 | open a popup for switching device                                       | `D`                |
+| `Search`                       | open a popup for searching in the current page                          | `/`                |
+| `Queue`                        | open a popup for showing the current queue                              | `z`                |
+| `BrowseUserPlaylists`          | open a popup for browsing user's playlists                              | `u p`              |
+| `BrowseUserFollowedArtists`    | open a popup for browsing user's followed artists                       | `u a`              |
+| `BrowseUserSavedAlbums`        | open a popup for browsing user's saved albums                           | `u A`              |
+| `CurrentlyPlayingContextPage`  | go to the currently playing context page                                | `g space`          |
+| `TopTrackPage`                 | go to the user top track page                                           | `g t`              |
+| `RecentlyPlayedTrackPage`      | go to the user recently played track page                               | `g r`              |
+| `LikedTrackPage`               | go to the user liked track page                                         | `g y`              |
+| `LyricPage`                    | go to the lyric page of the current track (`lyric-finder` feature only) | `g L`, `l`         |
+| `LibraryPage`                  | go to the user library page                                             | `g l`              |
+| `SearchPage`                   | go to the search page                                                   | `g s`              |
+| `BrowsePage`                   | go to the browse page                                                   | `g b`              |
+| `PreviousPage`                 | go to the previous page                                                 | `backspace`, `C-q` |
+| `SortTrackByTitle`             | sort the track table (if any) by track's title                          | `s t`              |
+| `SortTrackByArtists`           | sort the track table (if any) by track's artists                        | `s a`              |
+| `SortTrackByAlbum`             | sort the track table (if any) by track's album                          | `s A`              |
+| `SortTrackByDuration`          | sort the track table (if any) by track's duration                       | `s d`              |
+| `SortTrackByAddedDate`         | sort the track table (if any) by track's added date                     | `s D`              |
+| `ReverseOrder`                 | reverse the order of the track table (if any)                           | `s r`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ List of supported commands:
 | `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up                   | `k`, `C-p`, `up`   |
 | `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down         | `page_down`, `C-f` |
 | `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up       | `page_up`, `C-b`   |
-| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top              | `g g`              |
-| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom            | `G`                |
+| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top              | `g g`, `home`      |
+| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom            | `G`, `end`         |
 | `ChooseSelected`               | choose the selected item                                                | `enter`            |
 | `RefreshPlayback`              | manually refresh the current playback                                   | `r`                |
 | `RestartIntegratedClient`      | restart the integrated librespot client (`streaming` feature only)      | `R`                |

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,7 @@ All configuration files should be placed inside the application's configuration 
 | `app_refresh_duration_in_ms`         | the duration (in ms) between two consecutive application refreshes            | `32`                                                       |
 | `playback_refresh_duration_in_ms`    | the duration (in ms) between two consecutive playback refreshes               | `0`                                                        |
 | `cover_image_refresh_duration_in_ms` | the duration (in ms) between two cover image refreshes (`image` feature only) | `2000`                                                     |
+| `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)    | `20`                                                       |
 | `track_table_item_max_len`           | the maximum length of a column in a track table                               | `32`                                                       |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS)                |
 | `default_device`                     | the default device to connect to on startup if no playing device found        | `spotify-player`                                           |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -6,6 +6,7 @@ copy_command = { command = "pbcopy", args = [] } # macos
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 cover_image_refresh_duration_in_ms = 2000
+page_size_in_rows = 20
 track_table_item_max_len = 32
 enable_media_control = false
 default_device = "spotify-player"

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -23,6 +23,9 @@ pub enum Command {
     SelectPreviousOrScrollUp,
     PageSelectNextOrScrollDown,
     PageSelectPreviousOrScrollUp,
+    SelectFirstOrScrollToTop,
+    SelectLastOrScrollToBottom,
+
     ChooseSelected,
 
     RefreshPlayback,
@@ -156,6 +159,12 @@ impl Command {
             }
             Self::PageSelectPreviousOrScrollUp => {
                 "select the previous page item in a list/table or scroll a page up"
+            }
+            Self::SelectFirstOrScrollToTop => {
+                "select the first item in a list/table or scroll to the top"
+            }
+            Self::SelectLastOrScrollToBottom => {
+                "select the last item in a list/table or scroll to the bottom"
             }
             Self::ChooseSelected => "choose the selected item and act on it",
             Self::RefreshPlayback => "manually refresh the current playback",

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -21,6 +21,8 @@ pub enum Command {
 
     SelectNextOrScrollDown,
     SelectPreviousOrScrollUp,
+    PageSelectNextOrScrollDown,
+    PageSelectPreviousOrScrollUp,
     ChooseSelected,
 
     RefreshPlayback,
@@ -147,6 +149,12 @@ impl Command {
             Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down",
             Self::SelectPreviousOrScrollUp => {
                 "select the previous item in a list/table or scroll up"
+            }
+            Self::PageSelectNextOrScrollDown => {
+                "select the next page item in a list/table or scroll a page down"
+            }
+            Self::PageSelectPreviousOrScrollUp => {
+                "select the previous page item in a list/table or scroll a page up"
             }
             Self::ChooseSelected => "choose the selected item and act on it",
             Self::RefreshPlayback => "manually refresh the current playback",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -239,7 +239,15 @@ impl Default for KeymapConfig {
                     command: Command::SelectFirstOrScrollToTop,
                 },
                 Keymap {
+                    key_sequence: "home".into(),
+                    command: Command::SelectFirstOrScrollToTop,
+                },
+                Keymap {
                     key_sequence: "G".into(),
+                    command: Command::SelectLastOrScrollToBottom,
+                },
+                Keymap {
+                    key_sequence: "end".into(),
                     command: Command::SelectLastOrScrollToBottom,
                 },
                 Keymap {

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -235,6 +235,14 @@ impl Default for KeymapConfig {
                     command: Command::PageSelectNextOrScrollDown,
                 },
                 Keymap {
+                    key_sequence: "g g".into(),
+                    command: Command::SelectFirstOrScrollToTop,
+                },
+                Keymap {
+                    key_sequence: "G".into(),
+                    command: Command::SelectLastOrScrollToBottom,
+                },
+                Keymap {
                     key_sequence: "s t".into(),
                     command: Command::SortTrackByTitle,
                 },

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -215,6 +215,22 @@ impl Default for KeymapConfig {
                     command: Command::SelectPreviousOrScrollUp,
                 },
                 Keymap {
+                    key_sequence: "page_up".into(),
+                    command: Command::PageSelectPreviousOrScrollUp,
+                },
+                Keymap {
+                    key_sequence: "C-b".into(),
+                    command: Command::PageSelectPreviousOrScrollUp,
+                },
+                Keymap {
+                    key_sequence: "page_down".into(),
+                    command: Command::PageSelectNextOrScrollDown,
+                },
+                Keymap {
+                    key_sequence: "C-f".into(),
+                    command: Command::PageSelectNextOrScrollDown,
+                },
+                Keymap {
                     key_sequence: "s t".into(),
                     command: Command::SortTrackByTitle,
                 },

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -35,6 +35,8 @@ pub struct AppConfig {
     #[cfg(feature = "image")]
     pub cover_image_refresh_duration_in_ms: u64,
 
+    pub page_size_in_rows: usize,
+
     pub track_table_item_max_len: usize,
 
     // icon configs
@@ -102,6 +104,8 @@ impl Default for AppConfig {
 
             #[cfg(feature = "image")]
             cover_image_refresh_duration_in_ms: 2000,
+
+            page_size_in_rows: 20,
 
             track_table_item_max_len: 32,
 

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
-
 use anyhow::Result;
 
 mod page;

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -2,6 +2,27 @@ use anyhow::Context as _;
 
 use super::*;
 
+macro_rules! handle_navigation_commands_for_page {
+    ($command:ident, $len:expr, $page:expr, $id:expr) => {
+        match $command {
+            Command::SelectNextOrScrollDown => {
+                if $id + 1 < $len {
+                    $page.select($id + 1);
+                }
+                return Ok(true);
+            }
+            Command::SelectPreviousOrScrollUp => {
+                if $id > 0 {
+                    $page.select($id - 1);
+                }
+                return Ok(true);
+            }
+            _ => {}
+        }
+    };
+}
+pub(super) use handle_navigation_commands_for_page;
+
 pub fn handle_key_sequence_for_library_page(
     key_sequence: &KeySequence,
     state: &SharedState,
@@ -206,6 +227,7 @@ pub fn handle_key_sequence_for_browse_page(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, len, page_state, selected);
     match command {
         Command::ChooseSelected => {
             match page_state {
@@ -242,16 +264,6 @@ pub fn handle_key_sequence_for_browse_page(
                 },
                 _ => anyhow::bail!("expect a browse page state"),
             };
-        }
-        Command::SelectNextOrScrollDown => {
-            if selected + 1 < len {
-                page_state.select(selected + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if selected > 0 {
-                page_state.select(selected - 1);
-            }
         }
         Command::Search => {
             page_state.select(0);

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -324,6 +324,12 @@ pub fn handle_key_sequence_for_lyric_page(
                 *scroll_offset -= 1;
             }
         }
+        Command::PageSelectNextOrScrollDown => {
+            *scroll_offset += state.app_config.page_size_in_rows;
+        }
+        Command::PageSelectPreviousOrScrollUp => {
+            *scroll_offset = scroll_offset.saturating_sub(state.app_config.page_size_in_rows);
+        }
         _ => return Ok(false),
     }
     Ok(true)

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -28,6 +28,14 @@ macro_rules! handle_navigation_commands_for_page {
                 $page.select($id.saturating_sub($state.app_config.page_size_in_rows));
                 return Ok(true);
             }
+            Command::SelectLastOrScrollToBottom => {
+                if $len > 0 {
+                    $page.select($len - 1);
+                }
+            }
+            Command::SelectFirstOrScrollToTop => {
+                $page.select(0);
+            }
             _ => {}
         }
     };
@@ -329,6 +337,14 @@ pub fn handle_key_sequence_for_lyric_page(
         }
         Command::PageSelectPreviousOrScrollUp => {
             *scroll_offset = scroll_offset.saturating_sub(state.app_config.page_size_in_rows);
+        }
+        Command::SelectFirstOrScrollToTop => {
+            *scroll_offset = 0;
+        }
+        // Don't know the number of rows of a lyric displayed in the page, so just use a "big" number.
+        // The `scroll_offset` will be adjust accordingly in the page rendering function.
+        Command::SelectLastOrScrollToBottom => {
+            *scroll_offset = 1024;
         }
         _ => return Ok(false),
     }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -428,6 +428,14 @@ fn handle_command_for_command_help_popup(
         Command::PageSelectPreviousOrScrollUp => {
             *scroll_offset = scroll_offset.saturating_sub(state.app_config.page_size_in_rows);
         }
+        Command::SelectFirstOrScrollToTop => {
+            *scroll_offset = 0;
+        }
+        // Don't know the number of commands displayed in the page, so just use a "big" number.
+        // The `scroll_offset` will be adjust accordingly in the popup rendering function.
+        Command::SelectLastOrScrollToBottom => {
+            *scroll_offset = 1024;
+        }
         _ => return Ok(false),
     }
     Ok(true)

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -209,7 +209,7 @@ pub fn handle_key_sequence_for_popup(
                 },
             )
         }
-        PopupState::CommandHelp { .. } => handle_command_for_command_help_popup(command, ui),
+        PopupState::CommandHelp { .. } => handle_command_for_command_help_popup(command, ui, state),
         PopupState::ActionList(item, ..) => {
             handle_command_for_action_list_popup(item.n_actions(), command, client_pub, state, ui)
         }
@@ -399,7 +399,11 @@ fn handle_command_for_list_popup(
 }
 
 /// handles a command for a command shortcut help popup
-fn handle_command_for_command_help_popup(command: Command, mut ui: UIStateGuard) -> Result<bool> {
+fn handle_command_for_command_help_popup(
+    command: Command,
+    mut ui: UIStateGuard,
+    state: &SharedState,
+) -> Result<bool> {
     let scroll_offset = match ui.popup {
         Some(PopupState::CommandHelp {
             ref mut scroll_offset,
@@ -417,6 +421,12 @@ fn handle_command_for_command_help_popup(command: Command, mut ui: UIStateGuard)
             if *scroll_offset > 0 {
                 *scroll_offset -= 1;
             }
+        }
+        Command::PageSelectNextOrScrollDown => {
+            *scroll_offset += state.app_config.page_size_in_rows;
+        }
+        Command::PageSelectPreviousOrScrollUp => {
+            *scroll_offset = scroll_offset.saturating_sub(state.app_config.page_size_in_rows);
         }
         _ => return Ok(false),
     }

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -77,12 +77,14 @@ pub fn handle_command_for_focused_context_window(
                         ui.search_filtered_items(albums),
                         &data,
                         ui,
+                        state,
                     ),
                     ArtistFocusState::RelatedArtists => handle_command_for_artist_list_window(
                         command,
                         ui.search_filtered_items(related_artists),
                         &data,
                         ui,
+                        state,
                     ),
                     ArtistFocusState::TopTracks => handle_command_for_track_table_window(
                         command,
@@ -98,6 +100,7 @@ pub fn handle_command_for_focused_context_window(
                         ui.search_filtered_items(top_tracks),
                         &data,
                         ui,
+                        state,
                     ),
                 }
             }
@@ -109,6 +112,7 @@ pub fn handle_command_for_focused_context_window(
                 ui.search_filtered_items(tracks),
                 &data,
                 ui,
+                state,
             ),
             Context::Playlist { tracks, .. } => handle_command_for_track_table_window(
                 command,
@@ -118,6 +122,7 @@ pub fn handle_command_for_focused_context_window(
                 ui.search_filtered_items(tracks),
                 &data,
                 ui,
+                state,
             ),
             Context::Tracks { tracks, .. } => handle_command_for_track_table_window(
                 command,
@@ -127,6 +132,7 @@ pub fn handle_command_for_focused_context_window(
                 ui.search_filtered_items(tracks),
                 &data,
                 ui,
+                state,
             ),
         },
         None => Ok(false),
@@ -142,13 +148,14 @@ pub fn handle_command_for_track_table_window(
     tracks: Vec<&Track>,
     data: &DataReadGuard,
     mut ui: UIStateGuard,
+    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= tracks.len() {
         return Ok(false);
     }
 
-    handle_navigation_commands_for_page!(command, tracks.len(), ui.current_page_mut(), id);
+    handle_navigation_commands_for_page!(state, command, tracks.len(), ui.current_page_mut(), id);
     match command {
         Command::PlayRandom => {
             let id = rand::thread_rng().gen_range(0..tracks.len());
@@ -183,13 +190,14 @@ pub fn handle_command_for_track_list_window(
     tracks: Vec<&Track>,
     data: &DataReadGuard,
     mut ui: UIStateGuard,
+    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= tracks.len() {
         return Ok(false);
     }
 
-    handle_navigation_commands_for_page!(command, tracks.len(), ui.current_page_mut(), id);
+    handle_navigation_commands_for_page!(state, command, tracks.len(), ui.current_page_mut(), id);
     match command {
         Command::ChooseSelected => {
             // for the track list, `ChooseSelected` on a track
@@ -218,13 +226,14 @@ pub fn handle_command_for_artist_list_window(
     artists: Vec<&Artist>,
     data: &DataReadGuard,
     mut ui: UIStateGuard,
+    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= artists.len() {
         return Ok(false);
     }
 
-    handle_navigation_commands_for_page!(command, artists.len(), ui.current_page_mut(), id);
+    handle_navigation_commands_for_page!(state, command, artists.len(), ui.current_page_mut(), id);
     match command {
         Command::ChooseSelected => {
             let context_id = ContextId::Artist(artists[id].id.clone());
@@ -261,13 +270,14 @@ pub fn handle_command_for_album_list_window(
     albums: Vec<&Album>,
     data: &DataReadGuard,
     mut ui: UIStateGuard,
+    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= albums.len() {
         return Ok(false);
     }
 
-    handle_navigation_commands_for_page!(command, albums.len(), ui.current_page_mut(), id);
+    handle_navigation_commands_for_page!(state, command, albums.len(), ui.current_page_mut(), id);
     match command {
         Command::ChooseSelected => {
             let context_id = ContextId::Album(albums[id].id.clone());
@@ -309,13 +319,20 @@ pub fn handle_command_for_playlist_list_window(
     playlists: Vec<&Playlist>,
     data: &DataReadGuard,
     mut ui: UIStateGuard,
+    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= playlists.len() {
         return Ok(false);
     }
 
-    handle_navigation_commands_for_page!(command, playlists.len(), ui.current_page_mut(), id);
+    handle_navigation_commands_for_page!(
+        state,
+        command,
+        playlists.len(),
+        ui.current_page_mut(),
+        id
+    );
     match command {
         Command::ChooseSelected => {
             let context_id = ContextId::Playlist(playlists[id].id.clone());

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -139,6 +139,7 @@ pub fn handle_command_for_focused_context_window(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 /// handles a command for the track table subwindow
 pub fn handle_command_for_track_table_window(
     command: Command,

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -1,3 +1,4 @@
+use super::page::handle_navigation_commands_for_page;
 use super::*;
 use crate::{
     command::{AlbumAction, ArtistAction, PlaylistAction, TrackAction},
@@ -147,17 +148,8 @@ pub fn handle_command_for_track_table_window(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, tracks.len(), ui.current_page_mut(), id);
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < tracks.len() {
-                ui.current_page_mut().select(id + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                ui.current_page_mut().select(id - 1);
-            }
-        }
         Command::PlayRandom => {
             let id = rand::thread_rng().gen_range(0..tracks.len());
 
@@ -197,17 +189,8 @@ pub fn handle_command_for_track_list_window(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, tracks.len(), ui.current_page_mut(), id);
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < tracks.len() {
-                ui.current_page_mut().select(id + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                ui.current_page_mut().select(id - 1);
-            }
-        }
         Command::ChooseSelected => {
             // for the track list, `ChooseSelected` on a track
             // will start a `URIs` playback containing only that track.
@@ -241,17 +224,8 @@ pub fn handle_command_for_artist_list_window(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, artists.len(), ui.current_page_mut(), id);
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < artists.len() {
-                ui.current_page_mut().select(id + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                ui.current_page_mut().select(id - 1);
-            }
-        }
         Command::ChooseSelected => {
             let context_id = ContextId::Artist(artists[id].id.clone());
             ui.create_new_page(PageState::Context {
@@ -293,17 +267,8 @@ pub fn handle_command_for_album_list_window(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, albums.len(), ui.current_page_mut(), id);
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < albums.len() {
-                ui.current_page_mut().select(id + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                ui.current_page_mut().select(id - 1);
-            }
-        }
         Command::ChooseSelected => {
             let context_id = ContextId::Album(albums[id].id.clone());
             ui.create_new_page(PageState::Context {
@@ -350,17 +315,8 @@ pub fn handle_command_for_playlist_list_window(
         return Ok(false);
     }
 
+    handle_navigation_commands_for_page!(command, playlists.len(), ui.current_page_mut(), id);
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < playlists.len() {
-                ui.current_page_mut().select(id + 1);
-            }
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                ui.current_page_mut().select(id - 1);
-            }
-        }
         Command::ChooseSelected => {
             let context_id = ContextId::Playlist(playlists[id].id.clone());
             ui.create_new_page(PageState::Context {


### PR DESCRIPTION
Resolves #127 

## Changes
- added more navigation commands
    + `PageSelectNextOrScrollDown`
    + `PageSelectPreviousOrScrollUp`
    + `SelectFirstOrScrollToTop`
    + `SelectLastOrScrollToBottom`
- added `page_size_in_rows` config option to control the behavior of page navigation commands
- added macro `handle_navigation_commands_for_page` to reduce the code duplication when implementing handlers for navigation commands