### PR TITLE
Windows duplicate keys

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -8,6 +8,8 @@ use crate::{
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
 use anyhow::Result;
+use std::time::{Duration, Instant};
+use std::env;
 
 mod page;
 mod popup;
@@ -66,14 +68,20 @@ pub enum ClientRequest {
 
 /// starts a terminal event handler (key pressed, mouse clicked, etc)
 pub fn start_event_handler(state: SharedState, client_pub: flume::Sender<ClientRequest>) {
+    let mut cached_var = false;
+    let mut last_cache_time = Instant::now();
     while let Ok(event) = crossterm::event::read() {
-        let _enter = tracing::info_span!("terminal_event", event = ?event).entered();
-        if let Err(err) = match event {
-            crossterm::event::Event::Mouse(event) => handle_mouse_event(event, &client_pub, &state),
-            crossterm::event::Event::Key(event) => handle_key_event(event, &client_pub, &state),
-            _ => Ok(()),
-        } {
-            tracing::error!("Failed to handle event: {err:#}");
+        if env::consts::OS.to_string() != "windows" || (!cached_var || last_cache_time.elapsed() >= Duration::from_millis(300)) {
+            let _enter = tracing::info_span!("terminal_event", event = ?event).entered();
+            if let Err(err) = match event {
+                crossterm::event::Event::Mouse(event) => handle_mouse_event(event, &client_pub, &state),
+                crossterm::event::Event::Key(event) => handle_key_event(event, &client_pub, &state),
+                _ => Ok(()),
+            } {
+                tracing::error!("Failed to handle event: {err:#}");
+            }
+            cached_var = true;
+            last_cache_time = Instant::now();
         }
     }
 }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -68,10 +68,9 @@ pub enum ClientRequest {
 
 /// starts a terminal event handler (key pressed, mouse clicked, etc)
 pub fn start_event_handler(state: SharedState, client_pub: flume::Sender<ClientRequest>) {
-    let mut cached_var = false;
     let mut last_cache_time = Instant::now();
     while let Ok(event) = crossterm::event::read() {
-        if env::consts::OS.to_string() != "windows" || (!cached_var || last_cache_time.elapsed() >= Duration::from_millis(300)) {
+        if env::consts::OS.to_string() != "windows" || last_cache_time.elapsed() >= Duration::from_millis(300) {
             let _enter = tracing::info_span!("terminal_event", event = ?event).entered();
             if let Err(err) = match event {
                 crossterm::event::Event::Mouse(event) => handle_mouse_event(event, &client_pub, &state),
@@ -80,7 +79,6 @@ pub fn start_event_handler(state: SharedState, client_pub: flume::Sender<ClientR
             } {
                 tracing::error!("Failed to handle event: {err:#}");
             }
-            cached_var = true;
             last_cache_time = Instant::now();
         }
     }


### PR DESCRIPTION
Resolves #136 

Hi, I saw that the error happened because the code was called twice, I couldn't figure out the reason, but this change worked for me.

I put a timer to give a delay of 0.3 seconds for each command only when it is windows and that solved the error, as I have no experience in rust so I don't know if there would be another way to solve it