### PR TITLE
remove colon from log file name

### DIFF
--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -84,7 +84,7 @@ async fn init_spotify(
 fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
     let log_prefix = format!(
         "spotify-player-{}",
-        chrono::Local::now().format("%y-%m-%d-%R")
+        chrono::Local::now().format("%y-%m-%d-%H-%M")
     );
 
     // initialize the application's logging


### PR DESCRIPTION
Fixes #167 

Windows file names can't have colons. I changed the log file format accordingly. If you want to keep the colon you can use ꞉ as described [here](https://stackoverflow.com/questions/10386344/how-to-get-a-file-in-windows-with-a-colon-in-the-filename).