### PR TITLE
Add configuration option for streaming

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ All configuration files should be placed inside the application's configuration 
 | `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)    | `20`                                                       |
 | `track_table_item_max_len`           | the maximum length of a column in a track table                               | `32`                                                       |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS)                |
+| `enable_streaming`                   | create a device for streaming (streaming` feature only)                       | `true`                                                     |
 | `default_device`                     | the default device to connect to on startup if no playing device found        | `spotify-player`                                           |
 | `play_icon`                          | the icon to indicate playing state of a Spotify item                          | `▶`                                                        |
 | `pause_icon`                         | the icon to indicate pause state of a Spotify item                            | `▌▌`                                                       |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -12,6 +12,7 @@ cover_image_refresh_duration_in_ms = 2000
 page_size_in_rows = 20
 track_table_item_max_len = 32
 enable_media_control = false
+enable_streaming = true
 default_device = "spotify-player"
 play_icon = "▶"
 pause_icon = "▌▌"

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -66,6 +66,9 @@ pub struct AppConfig {
     #[cfg(feature = "media-control")]
     pub enable_media_control: bool,
 
+    #[cfg(feature = "streaming")]
+    pub enable_streaming: bool,
+
     pub default_device: String,
 
     pub device: DeviceConfig,
@@ -188,6 +191,9 @@ impl Default for AppConfig {
             #[cfg(feature = "media-control")]
             #[cfg(all(unix, not(target_os = "macos")))]
             enable_media_control: true,
+
+            #[cfg(feature = "streaming")]
+            enable_streaming: true,
 
             default_device: "spotify-player".to_string(),
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -57,10 +57,12 @@ async fn init_spotify(
 
     // if `streaming` feature is enabled, create a new streaming connection
     #[cfg(feature = "streaming")]
-    client
-        .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
-        .await
-        .context("failed to create a new streaming connection")?;
+    if state.app_config.enable_streaming {
+        client
+            .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
+            .await
+            .context("failed to create a new streaming connection")?;
+    }
 
     // initialize the playback state
     client.update_current_playback_state(state).await?;


### PR DESCRIPTION
Allow streaming to be disabled via app.conf using `enable_streaming` when the `streaming` feature is used.

I wasn't sure whether `enable_streaming` or `disable_streaming` made more sense, I don't have a strong preference so just did the same as `enable_media_control`.