### PR TITLE
Add buffered playback

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -191,6 +191,8 @@ impl Client {
                             tracing::warn!("Connection failed (device_id={id}): {err}");
                         } else {
                             tracing::info!("Connection succeeded (device_id={id})!");
+                            // upon new connection, reset the buffered playback
+                            state.player.write().buffered_playback = None;
                             self.update_playback(state);
                             break;
                         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -212,17 +212,17 @@ fn handle_global_command(
             client_pub.send(ClientRequest::Player(PlayerRequest::Shuffle))?;
         }
         Command::VolumeUp => {
-            if let Some(ref playback) = state.player.read().playback {
-                if let Some(percent) = playback.device.volume_percent {
-                    let volume = std::cmp::min(percent + 5, 100_u32);
+            if let Some(ref playback) = state.player.read().buffered_playback {
+                if let Some(volume) = playback.volume {
+                    let volume = std::cmp::min(volume + 5, 100_u32);
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
                 }
             }
         }
         Command::VolumeDown => {
-            if let Some(ref playback) = state.player.read().playback {
-                if let Some(percent) = playback.device.volume_percent {
-                    let volume = percent.saturating_sub(5_u32);
+            if let Some(ref playback) = state.player.read().buffered_playback {
+                if let Some(volume) = playback.volume {
+                    let volume = volume.saturating_sub(5_u32);
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
                 }
             }
@@ -248,6 +248,8 @@ fn handle_global_command(
         }
         Command::RefreshPlayback => {
             client_pub.send(ClientRequest::GetCurrentPlayback)?;
+            // this will also reset the buffered playback
+            state.player.write().buffered_playback = None;
         }
         Command::ShowActionsOnCurrentTrack => {
             if let Some(track) = state.player.read().current_playing_track() {

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -90,9 +90,11 @@ pub enum ItemId {
 }
 
 /// A simplified version of `rspotify::CurrentPlaybackContext`
-/// containing only fields needed to handle a `event::PlayerRequest`
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SimplifiedPlayback {
+    pub device_name: String,
     pub device_id: Option<String>,
+    pub volume: Option<u32>,
     pub is_playing: bool,
     pub repeat_state: rspotify_model::RepeatState,
     pub shuffle_state: bool,

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -7,20 +7,14 @@ pub struct PlayerState {
 
     pub playback: Option<rspotify_model::CurrentPlaybackContext>,
     pub playback_last_updated_time: Option<std::time::Instant>,
+    /// a buffered state to speedup the feedback of playback metadata update to user
+    // Related issue: https://github.com/aome510/spotify-player/issues/109
+    pub buffered_playback: Option<SimplifiedPlayback>,
+
     pub queue: Option<rspotify_model::CurrentUserQueue>,
 }
 
 impl PlayerState {
-    /// gets a simplified version of the current playback
-    pub fn simplified_playback(&self) -> Option<SimplifiedPlayback> {
-        self.playback.as_ref().map(|p| SimplifiedPlayback {
-            device_id: p.device.id.clone(),
-            is_playing: p.is_playing,
-            repeat_state: p.repeat_state,
-            shuffle_state: p.shuffle_state,
-        })
-    }
-
     /// gets the current playing track
     pub fn current_playing_track(&self) -> Option<&rspotify_model::FullTrack> {
         match self.playback {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -90,7 +90,9 @@ pub fn render_playback_window(
                 (metadata_rect, progress_bar_rect)
             };
 
-            render_playback_text(frame, state, ui, metadata_rect, track, playback);
+            if let Some(ref playback) = player.buffered_playback {
+                render_playback_text(frame, state, ui, metadata_rect, track, playback);
+            }
 
             let progress = std::cmp::min(
                 player
@@ -130,7 +132,7 @@ fn render_playback_text(
     ui: &UIStateGuard,
     rect: Rect,
     track: &rspotify_model::FullTrack,
-    playback: &rspotify_model::CurrentPlaybackContext,
+    playback: &SimplifiedPlayback,
 ) {
     // Construct a "styled" text (`playback_text`) from playback's data
     // based on a user-configurable format string (app_config.playback_format)
@@ -181,8 +183,8 @@ fn render_playback_text(
                     "repeat: {} | shuffle: {} | volume: {}% | device: {}",
                     <&'static str>::from(playback.repeat_state),
                     playback.shuffle_state,
-                    playback.device.volume_percent.unwrap_or_default(),
-                    playback.device.name,
+                    playback.volume.unwrap_or_default(),
+                    playback.device_name,
                 ),
                 ui.theme.playback_metadata(),
             ),


### PR DESCRIPTION
Resolves #109 

Implemented a buffered playback state that allows speedup of the feedback of playback metadata update to the user by 
1. assuming metadata update requests always succeed
2. buffering all the updates 