### PR TITLE
Add `enable_image_cache` config option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,7 +32,8 @@ All configuration files should be placed inside the application's configuration 
 | `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)    | `20`                                                       |
 | `track_table_item_max_len`           | the maximum length of a column in a track table                               | `32`                                                       |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS)                |
-| `enable_streaming`                   | create a device for streaming (streaming` feature only)                       | `true`                                                     |
+| `enable_streaming`                   | create a device for streaming (streaming feature only)                        | `true`                                                     |
+| `enable_cover_image_cache`           | store album's cover images in the cache folder                                | `true`                                                     |
 | `default_device`                     | the default device to connect to on startup if no playing device found        | `spotify-player`                                           |
 | `play_icon`                          | the icon to indicate playing state of a Spotify item                          | `▶`                                                        |
 | `pause_icon`                         | the icon to indicate pause state of a Spotify item                            | `▌▌`                                                       |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -13,6 +13,7 @@ page_size_in_rows = 20
 track_table_item_max_len = 32
 enable_media_control = false
 enable_streaming = true
+enable_cover_image_cache = true
 default_device = "spotify-player"
 play_icon = "▶"
 pause_icon = "▌▌"

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1163,7 +1163,7 @@ impl Client {
     #[cfg(feature = "notify")]
     fn notify_new_track(
         track: rspotify_model::FullTrack,
-        path: &std::path::PathBuf,
+        path: &std::path::Path,
         state: &SharedState,
     ) -> Result<()> {
         let mut n = notify_rust::Notification::new();
@@ -1201,7 +1201,7 @@ impl Client {
         };
 
         n.appname("spotify_player")
-            .icon(&path.to_str().unwrap())
+            .icon(path.to_str().unwrap())
             .summary(&get_text_from_format_str(
                 &state.app_config.notify_format.summary,
             ))
@@ -1218,7 +1218,7 @@ impl Client {
     async fn retrieve_image(
         &self,
         url: &str,
-        path: &std::path::PathBuf,
+        path: &std::path::Path,
         saved: bool,
     ) -> Result<Vec<u8>> {
         if path.exists() {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1079,7 +1079,7 @@ impl Client {
     /// updates the current playback state
     pub async fn update_current_playback_state(&self, state: &SharedState) -> Result<()> {
         // update the playback state
-        let _new_track = {
+        let new_track = {
             let playback = self.spotify.current_playback(None, None::<Vec<_>>).await?;
             let mut player = state.player.write();
 
@@ -1117,24 +1117,55 @@ impl Client {
             prev_track_name != curr_track_name && !curr_track_name.is_empty()
         };
 
+        if !new_track {
+            return Ok(());
+        }
+
         let track = match state.player.read().current_playing_track() {
             None => return Ok(()),
             Some(track) => track.clone(),
         };
 
-        self.get_current_track_cover_image(&track, state).await?;
+        let url = match crate::utils::get_track_album_image_url(&track) {
+            Some(url) => url,
+            None => return Ok(()),
+        };
+
+        let path = state.cache_folder.join("image").join(format!(
+            "{}-{}-cover.jpg",
+            track.album.name,
+            crate::utils::map_join(&track.album.artists, |a| &a.name, ", ")
+        ));
+
+        // Retrieve and save the new track's cover image into the cache folder.
+        // The notify feature still requires the cover images to be stored inside the cache folder.
+        if state.app_config.enable_cover_image_cache || cfg!(feature = "notify") {
+            self.retrieve_image(url, &path, true).await?;
+        }
+
+        #[cfg(feature = "image")]
+        if !state.data.read().caches.images.contains(url) {
+            let bytes = self.retrieve_image(url, &path, false).await?;
+            // Get the image from a url
+            let image =
+                image::load_from_memory(&bytes).context("Failed to load image from memory")?;
+
+            state.data.write().caches.images.put(url.to_owned(), image);
+        }
 
         // notify user about the playback's change if any
         #[cfg(feature = "notify")]
-        if _new_track {
-            Self::notify_new_track(track, state)?;
-        }
+        Self::notify_new_track(track, &path, state)?;
 
         Ok(())
     }
 
     #[cfg(feature = "notify")]
-    fn notify_new_track(track: rspotify_model::FullTrack, state: &SharedState) -> Result<()> {
+    fn notify_new_track(
+        track: rspotify_model::FullTrack,
+        path: &std::path::PathBuf,
+        state: &SharedState,
+    ) -> Result<()> {
         let mut n = notify_rust::Notification::new();
 
         let re = regex::Regex::new(r"\{.*?\}").unwrap();
@@ -1170,18 +1201,7 @@ impl Client {
         };
 
         n.appname("spotify_player")
-            .icon(
-                state
-                    .cache_folder
-                    .join("image")
-                    .join(format!(
-                        "{}-{}-cover.jpg",
-                        track.album.name,
-                        crate::utils::map_join(&track.album.artists, |a| &a.name, ", ")
-                    ))
-                    .to_str()
-                    .unwrap(),
-            )
+            .icon(&path.to_str().unwrap())
             .summary(&get_text_from_format_str(
                 &state.app_config.notify_format.summary,
             ))
@@ -1194,7 +1214,18 @@ impl Client {
         Ok(())
     }
 
-    async fn download_and_save_image(&self, url: &str, path: &std::path::PathBuf) -> Result<()> {
+    /// retrieves an image from a `url` and saves it into a `path` (if specified)
+    async fn retrieve_image(
+        &self,
+        url: &str,
+        path: &std::path::PathBuf,
+        saved: bool,
+    ) -> Result<Vec<u8>> {
+        if path.exists() {
+            tracing::info!("Retrieving an image from the file: {}", path.display());
+            return Ok(std::fs::read(path)?);
+        }
+
         tracing::info!("Retrieving an image from url: {url}");
 
         let bytes = self
@@ -1206,45 +1237,13 @@ impl Client {
             .bytes()
             .await?;
 
-        let mut file = std::fs::File::create(path)?;
-        file.write_all(&bytes)?;
-
-        Ok(())
-    }
-
-    pub async fn get_current_track_cover_image(
-        &self,
-        track: &rspotify_model::FullTrack,
-        state: &SharedState,
-    ) -> Result<()> {
-        let url = match crate::utils::get_track_album_image_url(track) {
-            Some(url) => url,
-            None => return Ok(()),
-        };
-
-        let path = state.cache_folder.join("image").join(format!(
-            "{}-{}-cover.jpg",
-            track.album.name,
-            crate::utils::map_join(&track.album.artists, |a| &a.name, ", ")
-        ));
-
-        if !path.exists() {
-            self.download_and_save_image(url, &path).await?;
+        if saved {
+            tracing::info!("Saving the retrieved image into {}", path.display());
+            let mut file = std::fs::File::create(path)?;
+            file.write_all(&bytes)?;
         }
 
-        #[cfg(feature = "image")]
-        if !state.data.read().caches.images.contains(url) {
-            tracing::info!("Retrieving an image from the file: {}", path.display());
-
-            let bytes = std::fs::read(path)?;
-            // Get the image from a url
-            let image =
-                image::load_from_memory(&bytes).context("Failed to load image from memory")?;
-
-            state.data.write().caches.images.put(url.to_owned(), image);
-        }
-
-        Ok(())
+        Ok(bytes.to_vec())
     }
 
     /// cleans up a list of albums, which includes

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -69,6 +69,8 @@ pub struct AppConfig {
     #[cfg(feature = "streaming")]
     pub enable_streaming: bool,
 
+    pub enable_cover_image_cache: bool,
+
     pub default_device: String,
 
     pub device: DeviceConfig,
@@ -194,6 +196,8 @@ impl Default for AppConfig {
 
             #[cfg(feature = "streaming")]
             enable_streaming: true,
+
+            enable_cover_image_cache: true,
 
             default_device: "spotify-player".to_string(),
 


### PR DESCRIPTION
Resolves #154 

Allows to disable/enable storing cover images inside the `$APP_CACHE/image` folder using `enable_image_cache` config option.

**Note**: this new config option is ignored if `notify` feature is enabled as the feature requires reading the cover images from the cache folder to display a notification on Linux. 