### PR TITLE
Add daemon support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,6 +3960,7 @@ dependencies = [
  "clap",
  "config_parser2",
  "crossterm 0.26.1",
+ "daemonize",
  "dirs-next",
  "flume",
  "image",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -46,6 +46,7 @@ flume = "0.10.14"
 serde_json = "1.0.95"
 once_cell = "1.17.1"
 regex = "1.7.3"
+daemonize = "0.5.0"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -46,7 +46,7 @@ flume = "0.10.14"
 serde_json = "1.0.96"
 once_cell = "1.17.1"
 regex = "1.8.1"
-daemonize = "0.5.0"
+daemonize = { version = "0.5.0", optional = true }
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]
@@ -63,5 +63,6 @@ media-control = ["souvlaki", "winit"]
 image = ["viuer", "dep:image"]
 sixel = ["image", "viuer/sixel"]
 notify = ["notify-rust"]
+daemon = ["daemonize"]
 
 default = ["rodio-backend", "media-control"]

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -21,10 +21,7 @@ pub async fn start_client_handler(
             ClientRequest::NewStreamingConnection => {
                 // send a notification to current streaming subcriber channels to shutdown all running connections
                 streaming_pub.send(()).unwrap_or_default();
-                match client
-                    .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
-                    .await
-                {
+                match client.new_streaming_connection(streaming_sub.clone(), client_pub.clone()) {
                     Err(err) => tracing::error!(
                         "Encountered an error during creating a new streaming connection: {err:#}",
                     ),

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -47,7 +47,7 @@ impl Client {
 
     /// creates a new streaming connection
     #[cfg(feature = "streaming")]
-    pub async fn new_streaming_connection(
+    pub fn new_streaming_connection(
         &self,
         streaming_sub: flume::Receiver<()>,
         client_pub: flume::Sender<ClientRequest>,

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -68,7 +68,6 @@ async fn init_spotify(
     if state.app_config.enable_streaming {
         client
             .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
-            .await
             .context("failed to create a new streaming connection")?;
     }
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -314,6 +314,7 @@ fn main() -> Result<()> {
                         std::process::exit(1);
                     }
 
+                    tracing::info!("Starting the application as a daemon...");
                     let daemonize = daemonize::Daemonize::new();
                     daemonize.start()?;
                 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -12,6 +12,15 @@ mod utils;
 
 /// run the application UI
 pub fn run(state: SharedState) -> Result<()> {
+    #[cfg(feature = "image")]
+    {
+        // initialize viuer supports for kitty and iterm2
+        viuer::get_kitty_support();
+        viuer::is_iterm_supported();
+        #[cfg(feature = "sixel")]
+        viuer::is_sixel_supported();
+    }
+
     let mut terminal = init_ui().context("failed to initialize the application's UI")?;
 
     let ui_refresh_duration =


### PR DESCRIPTION
Resolves #135. Resolves #42.

Added support for daemonizing `spotify_player`.

## Changes
- added `daemon` feature
- added `-d`/`--daemon` flag to run the application as a daemon
- handled socket errors to avoid stopping the client loop when errors happen