### PR TITLE
Extend CLI functionalities

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -51,8 +51,6 @@ async fn send_data(data: Vec<u8>, socket: &UdpSocket, dest_addr: SocketAddr) -> 
     for chunk in data.chunks(4096) {
         socket.send_to(chunk, dest_addr).await?;
     }
-    // send an empty data at the end to indicate end of chunks
-    socket.send_to(&[], dest_addr).await?;
     Ok(())
 }
 

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -380,6 +380,20 @@ async fn handle_playback_request(client: &Client, command: Command) -> Result<()
                 )
                 .await?;
         }
+        Command::Like { unlike } => {
+            if let Some(PlayableItem::Track(t)) = playback.item {
+                if let Some(id) = t.id {
+                    if unlike {
+                        client
+                            .spotify
+                            .current_user_saved_tracks_delete([id])
+                            .await?;
+                    } else {
+                        client.spotify.current_user_saved_tracks_add([id]).await?;
+                    }
+                }
+            }
+        }
     }
 
     Ok(())

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -350,8 +350,8 @@ async fn handle_playback_request(client: &Client, command: Command) -> Result<()
 
             client.spotify.repeat(next_repeat_state, device_id).await?;
         }
-        Command::Volume(percent, offset) => {
-            let percent = if offset {
+        Command::Volume { percent, is_offset } => {
+            let percent = if is_offset {
                 std::cmp::max(
                     0,
                     (playback.device.volume_percent.unwrap_or_default() as i8) + percent,

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -158,17 +158,6 @@ async fn handle_playback_request(client: &Client, command: Command) -> Result<()
 
     match command {
         Command::Start(context_id, context_type) => {
-            let context_id = match context_type {
-                ContextType::Playlist => PlayContextId::Playlist(PlaylistId::from_id(context_id)?),
-                ContextType::Album => PlayContextId::Album(AlbumId::from_id(context_id)?),
-                ContextType::Artist => PlayContextId::Artist(ArtistId::from_id(context_id)?),
-            };
-
-            client
-                .spotify
-                .start_context_playback(context_id, device_id, None, None)
-                .await?;
-
             // for some reasons, when starting a new playback, the integrated `spotify-player`
             // client doesn't respect the initial shuffle state, so we need to manually update the state
             client

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -141,14 +141,14 @@ async fn handle_get_key_request(client: &Client, key: Key) -> Result<Vec<u8>> {
 async fn get_spotify_id_from_context_id(
     client: &Client,
     context_type: ContextType,
-    context_id: ContextId,
+    context_id: IdOrName,
 ) -> Result<ContextSid> {
     // For `cli::ContextId::Name`, we search for the first item matching the name and return its spotify id
 
     let sid = match context_type {
         ContextType::Playlist => match context_id {
-            ContextId::Id(id) => ContextSid::Playlist(PlaylistId::from_id(id)?),
-            ContextId::Name(name) => {
+            IdOrName::Id(id) => ContextSid::Playlist(PlaylistId::from_id(id)?),
+            IdOrName::Name(name) => {
                 let results = client
                     .search_specific_type(&name, SearchType::Playlist)
                     .await?;
@@ -166,8 +166,8 @@ async fn get_spotify_id_from_context_id(
             }
         },
         ContextType::Album => match context_id {
-            ContextId::Id(id) => ContextSid::Album(AlbumId::from_id(id)?),
-            ContextId::Name(name) => {
+            IdOrName::Id(id) => ContextSid::Album(AlbumId::from_id(id)?),
+            IdOrName::Name(name) => {
                 let results = client
                     .search_specific_type(&name, SearchType::Album)
                     .await?;
@@ -185,8 +185,8 @@ async fn get_spotify_id_from_context_id(
             }
         },
         ContextType::Artist => match context_id {
-            ContextId::Id(id) => ContextSid::Artist(ArtistId::from_id(id)?),
-            ContextId::Name(name) => {
+            IdOrName::Id(id) => ContextSid::Artist(ArtistId::from_id(id)?),
+            IdOrName::Name(name) => {
                 let results = client
                     .search_specific_type(&name, SearchType::Artist)
                     .await?;
@@ -211,7 +211,7 @@ async fn get_spotify_id_from_context_id(
 async fn handle_get_context_request(
     client: &Client,
     context_type: ContextType,
-    context_id: ContextId,
+    context_id: IdOrName,
 ) -> Result<Vec<u8>> {
     let sid = get_spotify_id_from_context_id(client, context_type, context_id).await?;
     let context = match sid {

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -34,15 +34,30 @@ pub fn init_get_subcommand() -> Command {
 fn init_playback_start_subcommand() -> Command {
     Command::new("start")
         .about("Start a new playback")
+        .subcommand_required(true)
         .subcommand(add_context_args(
             Command::new("context").about("Start a context playback"),
         ))
-        .arg(
-            Arg::new("liked")
-                .short('l')
-                .long("liked")
-                .action(ArgAction::SetTrue)
-                .help("Play liked songs playlist"),
+        .subcommand(
+            Command::new("liked")
+                .about("Start liked tracks playback")
+                .arg(
+                    Arg::new("limit")
+                        .short('l')
+                        .long("limit")
+                        .default_value("200")
+                        .value_parser(value_parser!(usize))
+                        .help("The limit for number of tracks to play"),
+                )
+                .arg(
+                    Arg::new("random")
+                        .short('r')
+                        .long("random")
+                        .action(ArgAction::SetTrue)
+                        .help(
+                            "Randomly pick the tracks instead of picking tracks from the beginning",
+                        ),
+                ),
         )
 }
 

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -24,6 +24,11 @@ fn init_playback_start_subcommand() -> Command {
         .subcommand(add_context_args(
             Command::new("context").about("Start a context playback"),
         ))
+        .arg(
+            Arg::new("liked")
+                .action(ArgAction::SetTrue)
+                .help("Play liked songs playlist"),
+        )
 }
 
 fn add_context_args(cmd: Command) -> Command {

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -111,4 +111,15 @@ pub fn init_playback_subcommand() -> Command {
                         .required(true),
                 ),
         )
+        .subcommand(
+            Command::new("like")
+                .about("Like the currently playing track")
+                .arg(
+                    Arg::new("unlike")
+                        .long("unlike")
+                        .short('u')
+                        .action(ArgAction::SetTrue)
+                        .help("Unlike the currently playing track"),
+                ),
+        )
 }

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -1,18 +1,9 @@
 use clap::{builder::EnumValueParser, value_parser, Arg, ArgAction, ArgGroup, Command};
 
-use super::{ContextType, Key};
+use super::{ContextType, Key, PlayableType};
 
 pub fn init_connect_subcommand() -> Command {
-    Command::new("connect")
-        .about("Connect to a Spotify device")
-        .arg(Arg::new("id").long("id").short('i').help("device's id"))
-        .arg(
-            Arg::new("name")
-                .long("name")
-                .short('n')
-                .help("device's name"),
-        )
-        .group(ArgGroup::new("device").args(["id", "name"]).required(true))
+    add_id_or_name_group(Command::new("connect").about("Connect to a Spotify device"))
 }
 
 pub fn init_get_subcommand() -> Command {
@@ -59,22 +50,31 @@ fn init_playback_start_subcommand() -> Command {
                         ),
                 ),
         )
+        .subcommand(add_id_or_name_group(
+            Command::new("radio").about("Start a radio playback").arg(
+                Arg::new("playable_type").value_parser(EnumValueParser::<PlayableType>::new()),
+            ),
+        ))
 }
 
 fn add_context_args(cmd: Command) -> Command {
-    cmd.arg(
-        Arg::new("context_type")
-            .value_parser(EnumValueParser::<ContextType>::new())
-            .required(true),
+    add_id_or_name_group(
+        cmd.arg(
+            Arg::new("context_type")
+                .value_parser(EnumValueParser::<ContextType>::new())
+                .required(true),
+        ),
     )
-    .arg(Arg::new("id").long("id").short('i').help("context's id"))
-    .arg(
-        Arg::new("name")
-            .long("name")
-            .short('n')
-            .help("context's name"),
-    )
-    .group(ArgGroup::new("context").args(["id", "name"]).required(true))
+}
+
+fn add_id_or_name_group(cmd: Command) -> Command {
+    cmd.arg(Arg::new("id").long("id").short('i'))
+        .arg(Arg::new("name").long("name").short('n'))
+        .group(
+            ArgGroup::new("id_or_name")
+                .args(["id", "name"])
+                .required(true),
+        )
 }
 
 pub fn init_playback_subcommand() -> Command {

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -51,8 +51,14 @@ pub fn init_playback_subcommand() -> Command {
                 .about("Set the volume percentage")
                 .arg(
                     Arg::new("percent")
-                        .value_parser(value_parser!(u8).range(0..=100))
+                        .value_parser(value_parser!(i8).range(-100..=100))
                         .required(true),
+                )
+                .arg(
+                    Arg::new("offset")
+                        .long("offset")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Modify the volume percent by an offset"),
                 ),
         )
         .subcommand(

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -1,6 +1,6 @@
 use clap::{builder::EnumValueParser, value_parser, Arg, ArgAction, ArgGroup, Command};
 
-use super::{ContextType, Key, PlayableType};
+use super::{ContextType, ItemType, Key};
 
 pub fn init_connect_subcommand() -> Command {
     add_id_or_name_group(Command::new("connect").about("Connect to a Spotify device"))
@@ -51,9 +51,9 @@ fn init_playback_start_subcommand() -> Command {
                 ),
         )
         .subcommand(add_id_or_name_group(
-            Command::new("radio").about("Start a radio playback").arg(
-                Arg::new("playable_type").value_parser(EnumValueParser::<PlayableType>::new()),
-            ),
+            Command::new("radio")
+                .about("Start a radio playback")
+                .arg(Arg::new("item_type").value_parser(EnumValueParser::<ItemType>::new())),
         ))
 }
 

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -2,6 +2,19 @@ use clap::{builder::EnumValueParser, value_parser, Arg, ArgAction, ArgGroup, Com
 
 use super::{ContextType, Key};
 
+pub fn init_connect_subcommand() -> Command {
+    Command::new("connect")
+        .about("Connect to a Spotify device")
+        .arg(Arg::new("id").long("id").short('i').help("device's id"))
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .short('n')
+                .help("device's name"),
+        )
+        .group(ArgGroup::new("device").args(["id", "name"]).required(true))
+}
+
 pub fn init_get_subcommand() -> Command {
     Command::new("get")
         .about("Get spotify data")
@@ -39,17 +52,12 @@ fn add_context_args(cmd: Command) -> Command {
             .value_parser(EnumValueParser::<ContextType>::new())
             .required(true),
     )
-    .arg(
-        Arg::new("id")
-            .long("id")
-            .short('i')
-            .help("id of the context item"),
-    )
+    .arg(Arg::new("id").long("id").short('i').help("context's id"))
     .arg(
         Arg::new("name")
             .long("name")
             .short('n')
-            .help("name of the context item"),
+            .help("context's name"),
     )
     .group(ArgGroup::new("context").args(["id", "name"]).required(true))
 }

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use clap::{builder::EnumValueParser, value_parser, Arg, ArgGroup, Command};
+use clap::{builder::EnumValueParser, value_parser, Arg, ArgAction, ArgGroup, Command};
 
 use super::{ContextType, Key};
 

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -99,7 +99,7 @@ pub fn init_playback_subcommand() -> Command {
                     Arg::new("offset")
                         .long("offset")
                         .action(clap::ArgAction::SetTrue)
-                        .help("Modify the volume percent by an offset"),
+                        .help("Increase the volume percent by an offset"),
                 ),
         )
         .subcommand(

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -31,7 +31,7 @@ fn init_playback_start_subcommand() -> Command {
         ))
         .subcommand(
             Command::new("liked")
-                .about("Start liked tracks playback")
+                .about("Start a liked tracks playback")
                 .arg(
                     Arg::new("limit")
                         .short('l')

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -26,6 +26,8 @@ fn init_playback_start_subcommand() -> Command {
         ))
         .arg(
             Arg::new("liked")
+                .short('l')
+                .long("liked")
                 .action(ArgAction::SetTrue)
                 .help("Play liked songs playlist"),
         )

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use clap::{builder::EnumValueParser, value_parser, Arg, Command};
+use clap::{builder::EnumValueParser, value_parser, Arg, ArgGroup, Command};
 
 use super::{ContextType, Key};
 
@@ -13,27 +13,38 @@ pub fn init_get_subcommand() -> Command {
                     .required(true),
             ),
         )
-        .subcommand(
-            Command::new("context")
-                .about("Get context data")
-                .arg(
-                    Arg::new("context_type")
-                        .value_parser(EnumValueParser::<ContextType>::new())
-                        .required(true),
-                )
-                .arg(Arg::new("context_id").required(true)),
-        )
+        .subcommand(add_context_args(
+            Command::new("context").about("Get context data"),
+        ))
 }
 
 fn init_playback_start_subcommand() -> Command {
     Command::new("start")
-        .about("Start a context playback")
-        .arg(
-            Arg::new("context_type")
-                .value_parser(EnumValueParser::<ContextType>::new())
-                .required(true),
-        )
-        .arg(Arg::new("context_id").required(true))
+        .about("Start a new playback")
+        .subcommand(add_context_args(
+            Command::new("context").about("Start a context playback"),
+        ))
+}
+
+fn add_context_args(cmd: Command) -> Command {
+    cmd.arg(
+        Arg::new("context_type")
+            .value_parser(EnumValueParser::<ContextType>::new())
+            .required(true),
+    )
+    .arg(
+        Arg::new("id")
+            .long("id")
+            .short('i')
+            .help("id of the context item"),
+    )
+    .arg(
+        Arg::new("name")
+            .long("name")
+            .short('n')
+            .help("name of the context item"),
+    )
+    .group(ArgGroup::new("context").args(["id", "name"]).required(true))
 }
 
 pub fn init_playback_subcommand() -> Command {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -118,6 +118,10 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
                 .expect("position_offset_ms is required");
             Command::Seek(*position_offset_ms)
         }
+        "like" => {
+            let unlike = args.get_flag("unlike");
+            Command::Like { unlike }
+        }
         _ => unreachable!(),
     };
 

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -110,7 +110,10 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
                 .get_one::<i8>("percent")
                 .expect("percent arg is required");
             let offset = args.get_flag("offset");
-            Command::Volume(*percent, offset)
+            Command::Volume {
+                percent: *percent,
+                is_offset: offset,
+            }
         }
         "seek" => {
             let position_offset_ms = args

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -20,18 +20,18 @@ fn receive_data(socket: &UdpSocket) -> Result<Vec<u8>> {
     Ok(data)
 }
 
-fn get_context_id(args: &ArgMatches) -> Result<ContextId> {
+fn get_context_id(args: &ArgMatches) -> Result<IdOrName> {
     let id = args
         .get_one::<Id>("context")
         .expect("context group is required");
 
     match id.as_str() {
-        "name" => Ok(ContextId::Name(
+        "name" => Ok(IdOrName::Name(
             args.get_one::<String>("name")
                 .expect("name should be specified")
                 .to_owned(),
         )),
-        "id" => Ok(ContextId::Id(
+        "id" => Ok(IdOrName::Id(
             args.get_one::<String>("id")
                 .expect("id should be specified")
                 .to_owned(),

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -71,9 +71,10 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
         "repeat" => Command::Repeat,
         "volume" => {
             let percent = args
-                .get_one::<u8>("percent")
+                .get_one::<i8>("percent")
                 .expect("percent arg is required");
-            Command::Volume(*percent)
+            let offset = args.get_flag("offset");
+            Command::Volume(*percent, offset)
         }
         "seek" => {
             let position_offset_ms = args

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -89,12 +89,12 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
                 Command::StartLikedTracks { limit, random }
             }
             Some(("radio", args)) => {
-                let playable_type = args
-                    .get_one::<PlayableType>("playable_type")
-                    .expect("context_type is required")
+                let item_type = args
+                    .get_one::<ItemType>("item_type")
+                    .expect("item_type is required")
                     .to_owned();
                 let id_or_name = get_id_or_name(args)?;
-                Command::StartRadio(playable_type, id_or_name)
+                Command::StartRadio(item_type, id_or_name)
             }
             _ => {
                 anyhow::bail!("invalid command!");

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -21,11 +21,11 @@ fn receive_data(socket: &UdpSocket) -> Result<Vec<u8>> {
 }
 
 fn get_context_id(args: &ArgMatches) -> Result<IdOrName> {
-    let id = args
-        .get_one::<Id>("context")
-        .expect("context group is required");
-
-    match id.as_str() {
+    match args
+        .get_one::<Id>("id_or_name")
+        .expect("id_or_name group is required")
+        .as_str()
+    {
         "name" => Ok(IdOrName::Name(
             args.get_one::<String>("name")
                 .expect("name should be specified")
@@ -120,11 +120,11 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
 }
 
 fn handle_connect_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()> {
-    let id = args
-        .get_one::<Id>("device")
-        .expect("device group is required");
-
-    let data = match id.as_str() {
+    let data = match args
+        .get_one::<Id>("id_or_name")
+        .expect("id_or_name group is required")
+        .as_str()
+    {
         "name" => IdOrName::Name(
             args.get_one::<String>("name")
                 .expect("name should be specified")

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -79,9 +79,18 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
                     .expect("context_type is required")
                     .to_owned();
                 let context_id = get_context_id(args)?;
-                Command::Start(context_type, context_id)
+                Command::StartContext(context_type, context_id)
             }
-            _ => unimplemented!(),
+            Some(("liked", args)) => {
+                let limit = *args
+                    .get_one::<usize>("limit")
+                    .expect("limit should have a default value");
+                let random = args.get_flag("random");
+                Command::StartLikedTracks { limit, random }
+            }
+            _ => {
+                anyhow::bail!("invalid command!");
+            }
         },
         "play-pause" => Command::PlayPause,
         "next" => Command::Next,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -1,12 +1,12 @@
+mod client;
 mod commands;
 mod handlers;
-mod socket;
 
 use serde::{Deserialize, Serialize};
 
+pub use client::start_socket;
 pub use commands::{init_get_subcommand, init_playback_subcommand};
 pub use handlers::handle_cli_subcommand;
-pub use socket::start_socket;
 
 #[derive(Debug, Serialize, Deserialize, clap::ValueEnum, Clone)]
 pub enum Key {

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -68,6 +68,7 @@ pub enum Command {
     Repeat,
     Volume(i8, bool),
     Seek(i64),
+    Like { unlike: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -66,7 +66,7 @@ pub enum Command {
     Previous,
     Shuffle,
     Repeat,
-    Volume(i8, bool),
+    Volume { percent: i8, is_offset: bool },
     Seek(i64),
     Like { unlike: bool },
 }

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -41,7 +41,8 @@ pub enum IdOrName {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Command {
-    Start(ContextType, IdOrName),
+    StartContext(ContextType, IdOrName),
+    StartLikedTracks { limit: usize, random: bool },
     PlayPause,
     Next,
     Previous,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -27,6 +27,14 @@ pub enum ContextType {
     Artist,
 }
 
+#[derive(Debug, Serialize, Deserialize, clap::ValueEnum, Clone)]
+pub enum PlayableType {
+    Playlist,
+    Album,
+    Artist,
+    Track,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetRequest {
     Key(Key),
@@ -43,6 +51,7 @@ pub enum IdOrName {
 pub enum Command {
     StartContext(ContextType, IdOrName),
     StartLikedTracks { limit: usize, random: bool },
+    StartRadio(PlayableType, IdOrName),
     PlayPause,
     Next,
     Previous,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -30,12 +30,18 @@ pub enum ContextType {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetRequest {
     Key(Key),
-    Context(String, ContextType),
+    Context(ContextType, ContextId),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ContextId {
+    Id(String),
+    Name(String),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Command {
-    Start(String, ContextType),
+    Start(ContextType, ContextId),
     PlayPause,
     Next,
     Previous,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -28,7 +28,7 @@ pub enum ContextType {
 }
 
 #[derive(Debug, Serialize, Deserialize, clap::ValueEnum, Clone)]
-pub enum PlayableType {
+pub enum ItemType {
     Playlist,
     Album,
     Artist,
@@ -51,7 +51,7 @@ pub enum IdOrName {
 pub enum Command {
     StartContext(ContextType, IdOrName),
     StartLikedTracks { limit: usize, random: bool },
-    StartRadio(PlayableType, IdOrName),
+    StartRadio(ItemType, IdOrName),
     PlayPause,
     Next,
     Previous,
@@ -66,4 +66,14 @@ pub enum Request {
     Get(GetRequest),
     Playback(Command),
     Connect(IdOrName),
+}
+
+impl From<ContextType> for ItemType {
+    fn from(value: ContextType) -> Self {
+        match value {
+            ContextType::Playlist => Self::Playlist,
+            ContextType::Album => Self::Album,
+            ContextType::Artist => Self::Artist,
+        }
+    }
 }

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod client;
 mod commands;
 mod handlers;
 
+use rspotify::model::*;
 use serde::{Deserialize, Serialize};
 
 pub use client::start_socket;
@@ -33,6 +34,14 @@ pub enum ItemType {
     Album,
     Artist,
     Track,
+}
+
+/// Spotify item's ID
+enum ItemId {
+    Playlist(PlaylistId<'static>),
+    Artist(ArtistId<'static>),
+    Album(AlbumId<'static>),
+    Track(TrackId<'static>),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,6 +83,17 @@ impl From<ContextType> for ItemType {
             ContextType::Playlist => Self::Playlist,
             ContextType::Album => Self::Album,
             ContextType::Artist => Self::Artist,
+        }
+    }
+}
+
+impl ItemId {
+    pub fn uri(&self) -> String {
+        match self {
+            ItemId::Playlist(id) => id.uri(),
+            ItemId::Artist(id) => id.uri(),
+            ItemId::Album(id) => id.uri(),
+            ItemId::Track(id) => id.uri(),
         }
     }
 }

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -30,18 +30,18 @@ pub enum ContextType {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetRequest {
     Key(Key),
-    Context(ContextType, ContextId),
+    Context(ContextType, IdOrName),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum ContextId {
+pub enum IdOrName {
     Id(String),
     Name(String),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Command {
-    Start(ContextType, ContextId),
+    Start(ContextType, IdOrName),
     PlayPause,
     Next,
     Previous,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -5,7 +5,7 @@ mod handlers;
 use serde::{Deserialize, Serialize};
 
 pub use client::start_socket;
-pub use commands::{init_get_subcommand, init_playback_subcommand};
+pub use commands::{init_connect_subcommand, init_get_subcommand, init_playback_subcommand};
 pub use handlers::handle_cli_subcommand;
 
 #[derive(Debug, Serialize, Deserialize, clap::ValueEnum, Clone)]
@@ -55,4 +55,5 @@ pub enum Command {
 pub enum Request {
     Get(GetRequest),
     Playback(Command),
+    Connect(IdOrName),
 }

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -41,7 +41,7 @@ pub enum Command {
     Previous,
     Shuffle,
     Repeat,
-    Volume(u8),
+    Volume(i8, bool),
     Seek(i64),
 }
 

--- a/spotify_player/src/cli/socket.rs
+++ b/spotify_player/src/cli/socket.rs
@@ -204,8 +204,20 @@ async fn handle_playback_request(client: &Client, command: Command) -> Result<()
 
             client.spotify.repeat(next_repeat_state, device_id).await?;
         }
-        Command::Volume(percent) => {
-            client.spotify.volume(percent, device_id).await?;
+        Command::Volume(percent, offset) => {
+            let percent = if offset {
+                std::cmp::max(
+                    0,
+                    (playback.device.volume_percent.unwrap_or_default() as i8) + percent,
+                )
+            } else {
+                percent
+            };
+
+            client
+                .spotify
+                .volume(percent.try_into()?, device_id)
+                .await?;
         }
         Command::Seek(position_offset_ms) => {
             let progress = match playback.progress {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -729,7 +729,7 @@ impl Client {
         })
     }
 
-    async fn search_specific_type(
+    pub async fn search_specific_type(
         &self,
         query: &str,
         _type: rspotify_model::SearchType,

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -632,7 +632,7 @@ impl Client {
         Ok(())
     }
 
-    async fn radio_tracks(&self, seed_uri: String) -> Result<Vec<Track>> {
+    pub async fn radio_tracks(&self, seed_uri: String) -> Result<Vec<Track>> {
         let session = self.spotify.session()?;
 
         // Get an autoplay URI from the seed URI.

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -24,6 +24,7 @@ fn init_app_cli_arguments() -> clap::ArgMatches {
         .author("Thang Pham <phamducthang1234@gmail>")
         .subcommand(cli::init_get_subcommand())
         .subcommand(cli::init_playback_subcommand())
+        .subcommand(cli::init_connect_subcommand())
         .arg(
             clap::Arg::new("theme")
                 .short('t')


### PR DESCRIPTION
Resolves #184 

## Changes
- added more subcommands for `playback start` command: `playback start context|liked|radio`
- added support for specifying either `id` or `name` for a Spotify item as a command's argument
- added new commands:
  + `playback like`
  + `connect` 
- sent error messages back to socket handling `get` commands upon errors 
- updated `playback volume` command to support increasing/decreasing volume by an offset