### PR TITLE
Make the client/application more robust to network errors

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -70,6 +70,11 @@ async fn handle_socket_request(
     socket: &UdpSocket,
     dest_addr: SocketAddr,
 ) -> Result<()> {
+    if client.spotify.session().await.is_invalid() {
+        tracing::info!("Spotify client's session is invalid, re-creating a new session...");
+        client.new_session(state).await?;
+    }
+
     match request {
         Request::Get(GetRequest::Key(key)) => match handle_get_key_request(client, key).await {
             Ok(result) => send_data(result, socket, dest_addr).await?,

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -51,6 +51,8 @@ async fn send_data(data: Vec<u8>, socket: &UdpSocket, dest_addr: SocketAddr) -> 
     for chunk in data.chunks(4096) {
         socket.send_to(chunk, dest_addr).await?;
     }
+    // send an empty buffer to indicate end of chunk
+    socket.send_to(&[], dest_addr).await?;
     Ok(())
 }
 

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -30,6 +30,16 @@ pub async fn start_client_handler(
                 Ok(session) => {
                     *client.spotify.session.lock().await = Some(session);
                     tracing::info!("Used a new session for Spotify client.");
+
+                    // upon creating a new session, also create a new streaming connection
+                    #[cfg(feature = "streaming")]
+                    {
+                        client.new_streaming_connection().await;
+                        client
+                            .client_pub
+                            .send(ClientRequest::ConnectDevice(None))
+                            .unwrap_or_default();
+                    }
                 }
             }
         }

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -21,17 +21,14 @@ pub async fn start_client_handler(
             ClientRequest::NewStreamingConnection => {
                 // send a notification to current streaming subcriber channels to shutdown all running connections
                 streaming_pub.send(()).unwrap_or_default();
-                match client.new_streaming_connection(streaming_sub.clone(), client_pub.clone()) {
-                    Err(err) => tracing::error!(
-                        "Encountered an error during creating a new streaming connection: {err:#}",
-                    ),
-                    Ok(id) => {
-                        // By default, when `NewStreamingConnection` is called, the app also connects to the new device
-                        client_pub
-                            .send(ClientRequest::ConnectDevice(Some(id)))
-                            .unwrap_or_default();
-                    }
-                }
+                let device_id = client
+                    .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
+                    .await;
+
+                // By default, when `NewStreamingConnection` is called, the app also connects to the new device
+                client_pub
+                    .send(ClientRequest::ConnectDevice(Some(device_id)))
+                    .unwrap_or_default();
             }
             _ => {
                 let state = state.clone();

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -55,7 +55,12 @@ impl Client {
         let session = self.spotify.session()?.clone();
         let device = self.spotify.device.clone();
         let device_id = session.device_id().to_string();
-        streaming::new_connection(session, device, client_pub, streaming_sub)?;
+        tokio::task::spawn_blocking(|| {
+            if let Err(err) = streaming::new_connection(session, device, client_pub, streaming_sub)
+            {
+                tracing::warn!("Failed to create a new streaming connection: {err}");
+            }
+        });
 
         Ok(device_id)
     }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -23,9 +23,9 @@ use serde::Deserialize;
 /// The application's client
 #[derive(Clone)]
 pub struct Client {
-    pub spotify: Arc<spotify::Spotify>,
     http: reqwest::Client,
-    client_pub: flume::Sender<ClientRequest>,
+    pub spotify: Arc<spotify::Spotify>,
+    pub client_pub: flume::Sender<ClientRequest>,
     #[cfg(feature = "streaming")]
     stream_conn: Arc<Mutex<Option<Spirc>>>,
 }
@@ -194,6 +194,9 @@ impl Client {
 
                     state.data.write().caches.lyrics.put(query, result);
                 }
+            }
+            ClientRequest::ConnectDevice(id) => {
+                self.connect_device(state, id).await;
             }
             #[cfg(feature = "streaming")]
             ClientRequest::NewStreamingConnection => {

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -21,7 +21,7 @@ pub struct Spotify {
     pub client_id: String,
     pub http: HttpClient,
     pub device: config::DeviceConfig,
-    session: Arc<tokio::sync::Mutex<Option<Session>>>,
+    pub session: Arc<tokio::sync::Mutex<Option<Session>>>,
 }
 
 impl fmt::Debug for Spotify {

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -9,18 +9,18 @@ use rspotify::{
 };
 use std::{fmt, sync::Arc};
 
-use crate::{config, token};
+use crate::{auth::AuthConfig, token};
 
 #[derive(Clone, Default)]
 /// A Spotify client to interact with Spotify API server
 pub struct Spotify {
+    pub auth_config: AuthConfig,
     pub creds: Credentials,
     pub oauth: OAuth,
     pub config: Config,
     pub token: Arc<Mutex<Option<Token>>>,
     pub client_id: String,
     pub http: HttpClient,
-    pub device: config::DeviceConfig,
     pub session: Arc<tokio::sync::Mutex<Option<Session>>>,
 }
 
@@ -38,7 +38,7 @@ impl fmt::Debug for Spotify {
 
 impl Spotify {
     /// creates a new Spotify client
-    pub fn new(session: Session, device: config::DeviceConfig, client_id: String) -> Spotify {
+    pub fn new(session: Session, auth_config: AuthConfig, client_id: String) -> Spotify {
         Self {
             creds: Credentials::default(),
             oauth: OAuth::default(),
@@ -49,7 +49,7 @@ impl Spotify {
             token: Arc::new(Mutex::new(None)),
             http: HttpClient::default(),
             session: Arc::new(tokio::sync::Mutex::new(Some(session))),
-            device,
+            auth_config,
             client_id,
         }
     }

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -109,8 +109,9 @@ impl BaseClient for Spotify {
         match token::get_token(&session, &self.client_id).await {
             Ok(token) => Ok(Some(token)),
             Err(err) => {
-                tracing::error!("Failed to get access token: {err:#}");
-                Ok(None)
+                tracing::error!("Failed to get a new token: {err:#}");
+                // if failed to get token, return the old token
+                Ok(self.token.lock().await.unwrap().clone())
             }
         }
     }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -227,15 +227,8 @@ impl AppConfig {
     // then updates the current configurations accordingly.
     pub fn parse_config_file(&mut self, path: &Path) -> Result<()> {
         let file_path = path.join(APP_CONFIG_FILE);
-        match std::fs::read_to_string(&file_path) {
-            Err(err) => {
-                tracing::warn!(
-                    "Failed to open the application config file (path={file_path:?}): {err:#}. Use the default configurations instead",
-                );
-            }
-            Ok(content) => {
-                self.parse(toml::from_str::<toml::Value>(&content)?)?;
-            }
+        if let Ok(content) = std::fs::read_to_string(file_path) {
+            self.parse(toml::from_str::<toml::Value>(&content)?)?;
         }
         Ok(())
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -52,6 +52,7 @@ pub enum ClientRequest {
     DeleteTrackFromPlaylist(PlaylistId<'static>, TrackId<'static>),
     AddToLibrary(Item),
     DeleteFromLibrary(ItemId),
+    ConnectDevice(Option<String>),
     Player(PlayerRequest),
     GetCurrentUserQueue,
     #[cfg(feature = "lyric-finder")]

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -52,7 +52,6 @@ pub enum ClientRequest {
     DeleteTrackFromPlaylist(PlaylistId<'static>, TrackId<'static>),
     AddToLibrary(Item),
     DeleteFromLibrary(ItemId),
-    ConnectDevice(Option<String>),
     Player(PlayerRequest),
     GetCurrentUserQueue,
     #[cfg(feature = "lyric-finder")]

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -277,6 +277,11 @@ fn main() -> Result<()> {
             // initialize the application's log
             init_logging(&cache_folder).context("failed to initialize application's logging")?;
 
+            // log the application's configurations
+            tracing::info!("General configurations: {:?}", state.app_config);
+            tracing::info!("Theme configurations: {:?}", state.theme_config);
+            tracing::info!("Keymap configurations: {:?}", state.keymap_config);
+
             #[cfg(feature = "daemon")]
             {
                 let is_daemon = args.get_flag("daemon");

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -72,7 +72,7 @@ async fn init_spotify(
     if state.app_config.enable_streaming {
         client
             .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
-            .context("failed to create a new streaming connection")?;
+            .await;
     }
 
     // initialize the playback state
@@ -156,7 +156,7 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
         #[cfg(feature = "streaming")]
         client
             .new_streaming_connection(streaming_sub.clone(), client_pub.clone())
-            .context("failed to create a new streaming connection")?;
+            .await;
     } else {
         init_spotify(&client_pub, &streaming_sub, &client, &state)
             .await

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -268,13 +268,10 @@ fn main() -> Result<()> {
         std::fs::create_dir_all(&cache_image_folder)?;
     }
 
-    // initialize the application's log
-    init_logging(&cache_folder).context("failed to initialize application's logging")?;
-
     // initialize the application state
     let state = {
         let mut state = state::State {
-            cache_folder,
+            cache_folder: cache_folder.clone(),
             ..state::State::default()
         };
         // parse config options from the config files into application's state
@@ -284,6 +281,9 @@ fn main() -> Result<()> {
 
     match args.subcommand() {
         None => {
+            // initialize the application's log
+            init_logging(&cache_folder).context("failed to initialize application's logging")?;
+
             #[cfg(feature = "daemon")]
             {
                 let is_daemon = args.get_flag("daemon");

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -145,7 +145,7 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
 
     // create a spotify API client
     let client = client::Client::new(
-        session.clone(),
+        session,
         state.app_config.device.clone(),
         state.app_config.client_id.clone(),
     );

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -77,7 +77,7 @@ async fn init_spotify(
 
     if state.player.read().playback.is_none() {
         tracing::info!("No playback found on startup, trying to connect to an available device...");
-        client.connect_device(state, None).await;
+        client_pub.send(event::ClientRequest::ConnectDevice(None))?;
     }
 
     // request user data

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -43,13 +43,8 @@ impl State {
         if let Some(theme) = theme {
             self.app_config.theme = theme.to_owned();
         };
-        tracing::info!("General configurations: {:?}", self.app_config);
-
         self.theme_config.parse_config_file(config_folder)?;
-        tracing::info!("Theme configurations: {:?}", self.theme_config);
-
         self.keymap_config.parse_config_file(config_folder)?;
-        tracing::info!("Keymap configurations: {:?}", self.keymap_config);
 
         if let Some(theme) = self.theme_config.find_theme(&self.app_config.theme) {
             // update the UI theme based on the `theme` config option

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -1,5 +1,4 @@
 use crate::{config, event::ClientRequest};
-use anyhow::{Context, Result};
 use librespot_connect::spirc::Spirc;
 use librespot_core::{
     config::{ConnectConfig, DeviceType},
@@ -18,8 +17,7 @@ pub fn new_connection(
     session: Session,
     device: config::DeviceConfig,
     client_pub: flume::Sender<ClientRequest>,
-    streaming_sub: flume::Receiver<()>,
-) -> Result<()> {
+) -> Spirc {
     // librespot volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
     // So we need to convert from one format to another
@@ -42,8 +40,7 @@ pub fn new_connection(
         Box::new(mixer::softmixer::SoftMixer::open(MixerConfig::default())) as Box<dyn Mixer>;
     mixer.set_volume(volume);
 
-    let backend =
-        audio_backend::find(None).with_context(|| "unable to find an audio backend".to_string())?;
+    let backend = audio_backend::find(None).expect("should be able to find an audio backend");
     let player_config = PlayerConfig {
         bitrate: device
             .bitrate
@@ -80,17 +77,7 @@ pub fn new_connection(
     tracing::info!("Starting an integrated Spotify player using librespot's spirc protocol");
 
     let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer);
-    tokio::task::spawn({
-        async move {
-            tokio::select! {
-                _ = spirc_task => {}
-                _ = streaming_sub.recv_async() => {
-                    tracing::info!("Got a shutdown request, shutdown the current streaming connection...");
-                    spirc.shutdown();
-                }
-            }
-        }
-    });
+    tokio::task::spawn(spirc_task);
 
-    Ok(())
+    spirc
 }

--- a/spotify_player/src/token.rs
+++ b/spotify_player/src/token.rs
@@ -35,6 +35,7 @@ pub async fn get_token(session: &Session, client_id: &str) -> Result<Token> {
     // converts the token returned by librespot `get_token` function to a `rspotify::Token`
 
     let expires_in = Duration::from_std(std::time::Duration::from_secs(token.expires_in as u64))?;
+    // let expires_in = Duration::from_std(std::time::Duration::from_secs(5))?;
     let expires_at = Utc::now() + expires_in;
 
     let token = Token {


### PR DESCRIPTION
Resolves #150 

## Summary 

This PR adds new changes that make `spotify_player` more robust to network errors, which allows the application to re-initialize a new Spotify session and reconnect to a new streaming connection after the network errors are resolved.

## Changes

- make the client/application more robust to network errors by
    - re-authenticating and initializing a new session if invalid before handling any client requests
    - creating/connecting to a new streaming connection upon a session re-authentication
    - avoiding panics in third-party codes
- update how the application creates a new streaming connection
- update client socket's result/error sending logic
- update the authentication codes to allow code reuse and better error messages
- disable logging when handling CLI commands