### PR TITLE
Add docs for new features and improve CLI/daemon codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   - [Image](#image)
   - [Notify](#notify)
   - [Mouse support](#mouse-support)
+  - [Daemon](#daemon)
+  - [CLI commands](#cli-commands)
 - [Commands](#commands)
 - [Configurations](#configurations)
 - [Caches](#caches)
@@ -22,12 +24,12 @@
 
 ## Introduction
 
-`spotify_player` is a fast, easy to use, and [configurable](docs/config.md) terminal music player.
+`spotify_player` is a fast, easy to use, and configurable terminal music player.
 
 **Features**
 
 - Minimalist UI with an intuitive paging and popup system.
-- Highly configurable, allow to easily customize application's shortcuts or theme/color scheme.
+- Highly [configurable](docs/config.md)
 - Feature parity with the official Spotify application.
 - Support remote control with [Spotify Connect](#spotify-connect).
 - Support [streaming](#streaming) songs directly from the terminal.
@@ -35,6 +37,8 @@
 - Support [cross-platform media control](#media-control).
 - Support [image rendering](#image).
 - Support [desktop notification](#notify).
+- Support running the application as [a daemon](#daemon)
+- Offer a wide range of [CLI commands](#cli-commands)
 
 ## Examples
 
@@ -275,6 +279,33 @@ cargo install --features notify
 ### Mouse support
 
 Currently, the only supported use case for mouse is to seek to a position of the current playback by left-clicking to such position in the playback's progress bar.
+
+### Daemon
+
+To enable a [daemon](<https://en.wikipedia.org/wiki/Daemon_(computing)>) support,`spotify_player` needs to be built/installed with `daemon` feature (**disabled** by default). To install the application with `daemon` feature included, run:
+
+```shell
+cargo install --features daemon
+```
+
+You can run the application as a daemon by specifying the `-d` or `--daemon` option: `spotify_player -d`.
+
+**Notes**:
+
+- `daemon` feature requires the `streaming` feature to be enabled and the application to be built with [an audio backend](#audio-backend)
+- because of the OS's restrictions, `daemon` feature doesn't work with the `media-control` feature on Windows and MacOS, which is **enabled by default**. In other words, if you want to use the `daemon` feature on Windows or MacOS, you must install the application with `media-control` feature disabled:
+
+```shell
+cargo install --no-default-features --features daemon,rodio-backend
+```
+
+### CLI Commands
+
+`spotify_player` offers several CLI commands to interact with **a running `spotify_player` instance**.
+
+Under the hood, the application handles a CLI command by sending requests to a `spotify_player` instance's client socket running on the `client_port` port, a general application configuration - default value: `8080`.
+
+For more details, run `spotify_player -h` or `spotify_player {command} -h`, in which `{command}` is a CLI command.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ Currently, the only supported use case for mouse is to seek to a position of the
 
 ### Daemon
 
-To enable a [daemon](<https://en.wikipedia.org/wiki/Daemon_(computing)>) support,`spotify_player` needs to be built/installed with `daemon` feature (**disabled** by default). To install the application with `daemon` feature included, run:
+To enable a [daemon](<https://en.wikipedia.org/wiki/Daemon_(computing)>) support, `spotify_player` needs to be built/installed with `daemon` feature (**disabled** by default). To install the application with `daemon` feature included, run:
 
 ```shell
-cargo install --features daemon
+cargo install spotify_player --features daemon
 ```
 
 You can run the application as a daemon by specifying the `-d` or `--daemon` option: `spotify_player -d`.
@@ -293,11 +293,11 @@ You can run the application as a daemon by specifying the `-d` or `--daemon` opt
 **Notes**:
 
 - `daemon` feature requires the `streaming` feature to be enabled and the application to be built with [an audio backend](#audio-backend)
-- because of the OS's restrictions, `daemon` feature doesn't work with the `media-control` feature on Windows and MacOS, which is **enabled by default**. In other words, if you want to use the `daemon` feature on Windows or MacOS, you must install the application with `media-control` feature disabled:
+- because of the OS's restrictions, `daemon` feature doesn't work with the `media-control` feature on Windows and MacOS, which is **enabled by default**. In other words, if you want to use the `daemon` feature on Windows or MacOS, you must install the application with `media-control` feature **disabled**:
 
-```shell
-cargo install --no-default-features --features daemon,rodio-backend
-```
+  ```shell
+  cargo install spotify_player --no-default-features --features daemon,rodio-backend
+  ```
 
 ### CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ You can run the application as a daemon by specifying the `-d` or `--daemon` opt
 
 `spotify_player` offers several CLI commands to interact with **a running `spotify_player` instance**.
 
-Under the hood, the application handles a CLI command by sending requests to a `spotify_player` instance's client socket running on the `client_port` port, a general application configuration - default value: `8080`.
+Under the hood, the application handles a CLI command by sending requests to a `spotify_player` instance's client socket running on the `client_port` port, a general application configuration with a default value `8080`.
 
 For more details, run `spotify_player -h` or `spotify_player {command} -h`, in which `{command}` is a CLI command.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,8 @@ All configuration files should be placed inside the application's configuration 
 
 ## General
 
+**The default `app.toml` can be found in the example [`app.toml`](../examples/app.toml) file.**
+
 `spotify_player` uses `app.toml` to configure general application configurations:
 
 | Option                               | Description                                                                   | Default                                                    |
@@ -45,8 +47,6 @@ All configuration files should be placed inside the application's configuration 
 | `cover_img_width`                    | the width of the cover image (`image` feature only)                           | `5`                                                        |
 | `cover_img_length`                   | the length of the cover image (`image` feature only)                          | `9`                                                        |
 | `cover_img_scale`                    | the scale of the cover image (`image` feature only)                           | `1.0`                                                      |
-
-The default `app.toml` can be found in the example [`app.toml`](../examples/app.toml) file
 
 ### Notes
 
@@ -98,13 +98,13 @@ More details on the above configuration options can be found under the [Librespo
 
 `spotify_player` uses `theme.toml` to look for user-defined themes.
 
+**An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file.**
+
 The application's theme can be modified by setting the `theme` option in `app.toml` or by specifying the `-t <THEME>` (`--theme <THEME>`) option when running the player.
 
 A theme has three main components: `name` (the theme's name), `palette` (the theme's color palette), `component_style` (a list of pre-defined styles for application's components).
 
 `name` is required when defining a new theme. If `palette` is not set, a palette based on the terminal's colorscheme will be used. If `component_style` is not specified, a default value will be used.
-
-An example of user-defined themes can be found in the example [`theme.toml`](../examples/theme.toml) file
 
 ### Use script to add theme
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,7 @@ All configuration files should be placed inside the application's configuration 
 | Option                               | Description                                                                   | Default                                                    |
 | ------------------------------------ | ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | `client_id`                          | the Spotify client's ID                                                       | `65b708073fc0480ea92a077233ca87bd`                         |
+| `client_port`                        | the port that the application's client is running on to handle CLI commands   | `8080`                                                     |
 | `playback_format`                    | the format of the text in the playback's window                               | `{track} • {artists}\n{album}\n{metadata}`                 |
 | `notify_format`                      | the format of a notification (`notify` feature only)                          | `{ summary = "{track} • {artists}", body = "{album}" }`    |
 | `copy_command`                       | the command used to execute a copy-to-clipboard action                        | `xclip -sel c` (Linux), `pbcopy` (MacOS), `clip` (Windows) |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -1,5 +1,6 @@
 theme = "default"
 client_id = "65b708073fc0480ea92a077233ca87bd"
+client_port = 8080
 playack_format = "{track} • {artists}\n{album}\n{metadata}"
 notify_format = { summary = "{track} • {artists}", body = "{album}" }
 # the default `copy_command` is based on the OS

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.71"
-clap = { version = "4.2.7", features = ["derive"] }
+clap = { version = "4.2.7", features = ["derive", "string"] }
 config_parser2 = "0.1.4"
 crossterm = "0.26.1"
 dirs-next = "2.0.0"

--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -105,7 +105,7 @@ pub async fn new_session(auth_config: &AuthConfig, reauth: bool) -> Result<Sessi
         None => {
             let msg = "No cached credentials found, please authenticate the application first.";
             if reauth {
-                eprint!("{msg}");
+                eprintln!("{msg}");
                 new_session_with_new_creds(auth_config).await
             } else {
                 anyhow::bail!(msg);

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -110,6 +110,26 @@ async fn handle_socket_request(
             client.spotify.transfer_playback(&id, None).await?;
             Ok(Vec::new())
         }
+        Request::Like { unlike } => {
+            let id = state
+                .player
+                .read()
+                .current_playing_track()
+                .and_then(|t| t.id.to_owned());
+
+            if let Some(id) = id {
+                if unlike {
+                    client
+                        .spotify
+                        .current_user_saved_tracks_delete([id])
+                        .await?;
+                } else {
+                    client.spotify.current_user_saved_tracks_add([id]).await?;
+                }
+            }
+
+            Ok(Vec::new())
+        }
     }
 }
 
@@ -323,24 +343,6 @@ async fn handle_playback_request(
                 }
             };
             PlayerRequest::SeekTrack(progress + chrono::Duration::milliseconds(position_offset_ms))
-        }
-        Command::Like { unlike } => {
-            todo!()
-            // if let Some(t) = state.player.read().current_playing_track() {
-            //     if let Some(ref id) = t.id {
-            //         let id = id.to_owned();
-            //         if unlike {
-            //             client
-            //                 .spotify
-            //                 .current_user_saved_tracks_delete([id])
-            //                 .await?;
-            //         } else {
-            //             client.spotify.current_user_saved_tracks_add([id]).await?;
-            //         }
-            //     }
-            // }
-
-            // return Ok(());
         }
     };
 

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -9,7 +9,8 @@ use rspotify::{model::*, prelude::OAuthClient};
 use crate::{
     cli::{ContextType, Request},
     client::Client,
-    state::SharedState,
+    event::PlayerRequest,
+    state::{ContextId, Playback, SharedState},
 };
 
 use super::*;
@@ -254,33 +255,20 @@ async fn handle_get_context_request(
     Ok(serde_json::to_vec(&context)?)
 }
 
-async fn handle_playback_request(client: &Client, command: Command) -> Result<()> {
-    let playback = match client
-        .spotify
-        .current_playback(None, None::<Vec<_>>)
-        .await?
-    {
-        Some(playback) => playback,
-        None => {
-            anyhow::bail!("No playback found!");
-        }
-    };
-    let device_id = playback.device.id.as_deref();
-
-    match command {
+async fn handle_playback_request(
+    client: &Client,
+    state: &SharedState,
+    command: Command,
+) -> Result<()> {
+    let player_request = match command {
         Command::StartRadio(item_type, id_or_name) => {
             let sid = get_spotify_id(client, item_type, id_or_name).await?;
             let tracks = client.radio_tracks(sid.uri()).await?;
 
-            client
-                .spotify
-                .start_uris_playback(
-                    tracks.into_iter().map(|t| PlayableId::from(t.id)),
-                    device_id,
-                    None,
-                    None,
-                )
-                .await?;
+            PlayerRequest::StartPlayback(Playback::URIs(
+                tracks.into_iter().map(|t| t.id).collect(),
+                None,
+            ))
         }
         Command::StartLikedTracks { limit, random } => {
             let mut tracks = client.current_user_saved_tracks().await?;
@@ -295,107 +283,68 @@ async fn handle_playback_request(client: &Client, command: Command) -> Result<()
             } else {
                 tracks.iter()
             }
-            .map(|t| PlayableId::from(t.id.to_owned()));
+            .map(|t| t.id.to_owned())
+            .collect();
 
-            client
-                .spotify
-                .start_uris_playback(ids, device_id, None, None)
-                .await?;
+            PlayerRequest::StartPlayback(Playback::URIs(ids, None))
         }
         Command::StartContext(context_type, context_id) => {
             let sid = get_spotify_id(client, context_type.into(), context_id).await?;
             let context_id = match sid {
-                ItemId::Playlist(id) => PlayContextId::Playlist(id),
-                ItemId::Album(id) => PlayContextId::Album(id),
-                ItemId::Artist(id) => PlayContextId::Artist(id),
+                ItemId::Playlist(id) => ContextId::Playlist(id),
+                ItemId::Album(id) => ContextId::Album(id),
+                ItemId::Artist(id) => ContextId::Artist(id),
                 _ => unreachable!(),
             };
 
-            client
-                .spotify
-                .start_context_playback(context_id, device_id, None, None)
-                .await?;
-
-            // for some reasons, when starting a new playback, the integrated `spotify-player`
-            // client doesn't respect the initial shuffle state, so we need to manually update the state
-            client
-                .spotify
-                .shuffle(playback.shuffle_state, device_id)
-                .await?
+            PlayerRequest::StartPlayback(Playback::Context(context_id, None))
         }
-        Command::PlayPause => {
-            if playback.is_playing {
-                client.spotify.pause_playback(device_id).await?;
-            } else {
-                client.spotify.resume_playback(device_id, None).await?;
+        Command::PlayPause => PlayerRequest::ResumePause,
+        Command::Next => PlayerRequest::NextTrack,
+        Command::Previous => PlayerRequest::PreviousTrack,
+        Command::Shuffle => PlayerRequest::Shuffle,
+        Command::Repeat => PlayerRequest::Repeat,
+        Command::Volume { percent, is_offset } => match state.player.read().buffered_playback {
+            Some(ref playback) => {
+                let percent = if is_offset {
+                    std::cmp::max(0, (playback.volume.unwrap_or_default() as i8) + percent)
+                } else {
+                    percent
+                };
+                PlayerRequest::Volume(percent.try_into()?)
             }
-        }
-        Command::Next => {
-            client.spotify.next_track(device_id).await?;
-        }
-        Command::Previous => {
-            client.spotify.previous_track(device_id).await?;
-        }
-        Command::Shuffle => {
-            client
-                .spotify
-                .shuffle(!playback.shuffle_state, device_id)
-                .await?;
-        }
-        Command::Repeat => {
-            let next_repeat_state = match playback.repeat_state {
-                RepeatState::Off => RepeatState::Track,
-                RepeatState::Track => RepeatState::Context,
-                RepeatState::Context => RepeatState::Off,
-            };
-
-            client.spotify.repeat(next_repeat_state, device_id).await?;
-        }
-        Command::Volume { percent, is_offset } => {
-            let percent = if is_offset {
-                std::cmp::max(
-                    0,
-                    (playback.device.volume_percent.unwrap_or_default() as i8) + percent,
-                )
-            } else {
-                percent
-            };
-
-            client
-                .spotify
-                .volume(percent.try_into()?, device_id)
-                .await?;
-        }
+            None => anyhow::bail!("No playback found!"),
+        },
         Command::Seek(position_offset_ms) => {
-            let progress = match playback.progress {
+            let progress = match state.player.read().playback_progress() {
                 Some(progress) => progress,
                 None => {
                     anyhow::bail!("Playback has no progress!");
                 }
             };
-            client
-                .spotify
-                .seek_track(
-                    progress + chrono::Duration::milliseconds(position_offset_ms),
-                    device_id,
-                )
-                .await?;
+            PlayerRequest::SeekTrack(progress + chrono::Duration::milliseconds(position_offset_ms))
         }
         Command::Like { unlike } => {
-            if let Some(PlayableItem::Track(t)) = playback.item {
-                if let Some(id) = t.id {
-                    if unlike {
-                        client
-                            .spotify
-                            .current_user_saved_tracks_delete([id])
-                            .await?;
-                    } else {
-                        client.spotify.current_user_saved_tracks_add([id]).await?;
-                    }
-                }
-            }
-        }
-    }
+            todo!()
+            // if let Some(t) = state.player.read().current_playing_track() {
+            //     if let Some(ref id) = t.id {
+            //         let id = id.to_owned();
+            //         if unlike {
+            //             client
+            //                 .spotify
+            //                 .current_user_saved_tracks_delete([id])
+            //                 .await?;
+            //         } else {
+            //             client.spotify.current_user_saved_tracks_add([id]).await?;
+            //         }
+            //     }
+            // }
 
+            // return Ok(());
+        }
+    };
+
+    client.handle_player_request(state, player_request).await?;
+    client.update_playback(state);
     Ok(())
 }

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -124,3 +124,7 @@ pub fn init_like_command() -> Command {
                 .help("Unlike the currently playing track"),
         )
 }
+
+pub fn init_authenticate_command() -> Command {
+    Command::new("authenticate").about("Authenticate the application")
+}

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -111,15 +111,16 @@ pub fn init_playback_subcommand() -> Command {
                         .required(true),
                 ),
         )
-        .subcommand(
-            Command::new("like")
-                .about("Like the currently playing track")
-                .arg(
-                    Arg::new("unlike")
-                        .long("unlike")
-                        .short('u')
-                        .action(ArgAction::SetTrue)
-                        .help("Unlike the currently playing track"),
-                ),
+}
+
+pub fn init_like_command() -> Command {
+    Command::new("like")
+        .about("Like currently playing track")
+        .arg(
+            Arg::new("unlike")
+                .long("unlike")
+                .short('u')
+                .action(ArgAction::SetTrue)
+                .help("Unlike the currently playing track"),
         )
 }

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -153,7 +153,7 @@ fn handle_like_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
 pub fn handle_cli_subcommand(
     cmd: &str,
     args: &ArgMatches,
-    state: state::SharedState,
+    state: &state::SharedState,
 ) -> Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
     socket.connect(("127.0.0.1", state.app_config.client_port))?;
@@ -164,7 +164,7 @@ pub fn handle_cli_subcommand(
         "connect" => handle_connect_subcommand(args, &socket)?,
         "like" => handle_like_subcommand(args, &socket)?,
         "authenticate" => {
-            let auth_config = AuthConfig::new(&state)?;
+            let auth_config = AuthConfig::new(state)?;
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(new_session_with_new_creds(&auth_config))?;
             std::process::exit(0);
@@ -174,11 +174,11 @@ pub fn handle_cli_subcommand(
 
     match receive_response(&socket)? {
         Response::Err(err) => {
-            eprint!("{}", String::from_utf8_lossy(&err));
+            eprintln!("{}", String::from_utf8_lossy(&err));
             std::process::exit(1);
         }
         Response::Ok(data) => {
-            print!("{}", String::from_utf8_lossy(&data));
+            println!("{}", String::from_utf8_lossy(&data));
             std::process::exit(0);
         }
     }

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::{ArgMatches, Id};
 use std::net::UdpSocket;
 
-fn receive_data(socket: &UdpSocket) -> Result<Vec<u8>> {
+fn receive_response(socket: &UdpSocket) -> Result<Response> {
     // read response from the server's socket, which can be splitted into
     // smaller chunks of data
     let mut data = Vec::new();
@@ -17,7 +17,7 @@ fn receive_data(socket: &UdpSocket) -> Result<Vec<u8>> {
         data.extend_from_slice(&buf[..n_bytes]);
     }
 
-    Ok(data)
+    Ok(serde_json::from_slice(&data)?)
 }
 
 fn get_id_or_name(args: &ArgMatches) -> Result<IdOrName> {
@@ -40,7 +40,7 @@ fn get_id_or_name(args: &ArgMatches) -> Result<IdOrName> {
     }
 }
 
-fn handle_get_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()> {
+fn handle_get_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
     let (cmd, args) = args.subcommand().expect("playback subcommand is required");
 
     let request = match cmd {
@@ -63,13 +63,10 @@ fn handle_get_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()> {
     };
 
     socket.send(&serde_json::to_vec(&request)?)?;
-    let data = receive_data(&socket)?;
-    println!("{}", String::from_utf8_lossy(&data));
-
     Ok(())
 }
 
-fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()> {
+fn handle_playback_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
     let (cmd, args) = args.subcommand().expect("playback subcommand is required");
     let command = match cmd {
         "start" => match args.subcommand() {
@@ -134,7 +131,7 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()
     Ok(())
 }
 
-fn handle_connect_subcommand(args: &ArgMatches, socket: UdpSocket) -> Result<()> {
+fn handle_connect_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
     let id_or_name = get_id_or_name(args)?;
 
     let request = Request::Connect(id_or_name);
@@ -148,9 +145,20 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches, client_port: u16) -> 
     socket.connect(("127.0.0.1", client_port))?;
 
     match cmd {
-        "get" => handle_get_subcommand(args, socket),
-        "playback" => handle_playback_subcommand(args, socket),
-        "connect" => handle_connect_subcommand(args, socket),
+        "get" => handle_get_subcommand(args, &socket)?,
+        "playback" => handle_playback_subcommand(args, &socket)?,
+        "connect" => handle_connect_subcommand(args, &socket)?,
         _ => unreachable!(),
+    }
+
+    match receive_response(&socket)? {
+        Response::Err(err) => {
+            eprint!("{}", String::from_utf8_lossy(&err));
+            std::process::exit(1);
+        }
+        Response::Ok(data) => {
+            print!("{}", String::from_utf8_lossy(&data));
+            std::process::exit(0);
+        }
     }
 }

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -118,10 +118,6 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<(
                 .expect("position_offset_ms is required");
             Command::Seek(*position_offset_ms)
         }
-        "like" => {
-            let unlike = args.get_flag("unlike");
-            Command::Like { unlike }
-        }
         _ => unreachable!(),
     };
 
@@ -140,6 +136,15 @@ fn handle_connect_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()
     Ok(())
 }
 
+fn handle_like_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
+    let unlike = args.get_flag("unlike");
+
+    let request = Request::Like { unlike };
+    socket.send(&serde_json::to_vec(&request)?)?;
+
+    Ok(())
+}
+
 pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches, client_port: u16) -> Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
     socket.connect(("127.0.0.1", client_port))?;
@@ -148,6 +153,7 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches, client_port: u16) -> 
         "get" => handle_get_subcommand(args, &socket)?,
         "playback" => handle_playback_subcommand(args, &socket)?,
         "connect" => handle_connect_subcommand(args, &socket)?,
+        "like" => handle_like_subcommand(args, &socket)?,
         _ => unreachable!(),
     }
 

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -78,6 +78,12 @@ pub enum Request {
     Connect(IdOrName),
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Response {
+    Ok(Vec<u8>),
+    Err(Vec<u8>),
+}
+
 impl From<ContextType> for ItemType {
     fn from(value: ContextType) -> Self {
         match value {

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -6,7 +6,7 @@ use rspotify::model::*;
 use serde::{Deserialize, Serialize};
 
 pub use client::start_socket;
-pub use commands::{init_connect_subcommand, init_get_subcommand, init_playback_subcommand};
+pub use commands::*;
 pub use handlers::handle_cli_subcommand;
 
 #[derive(Debug, Serialize, Deserialize, clap::ValueEnum, Clone)]
@@ -68,7 +68,6 @@ pub enum Command {
     Repeat,
     Volume { percent: i8, is_offset: bool },
     Seek(i64),
-    Like { unlike: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -76,6 +75,7 @@ pub enum Request {
     Get(GetRequest),
     Playback(Command),
     Connect(IdOrName),
+    Like { unlike: bool },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -101,7 +101,7 @@ impl Client {
     }
 
     /// handles a player request
-    async fn handle_player_request(
+    pub async fn handle_player_request(
         &self,
         state: &SharedState,
         request: PlayerRequest,
@@ -121,7 +121,7 @@ impl Client {
         let mut playback = match state.player.read().buffered_playback {
             Some(ref playback) => playback.clone(),
             None => {
-                anyhow::bail!("failed to handle the player request: there is no active playback");
+                anyhow::bail!("failed to handle the player request: no playback found");
             }
         };
         let device_id = playback.device_id.as_deref();

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -138,7 +138,7 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
 
     // create a librespot session
     let auth_config = auth::AuthConfig::new(&state)?;
-    let session = auth::new_session(&auth_config, true).await?;
+    let session = auth::new_session(&auth_config, !is_daemon).await?;
 
     // create a spotify API client
     let client = client::Client::new(
@@ -306,7 +306,10 @@ fn main() -> Result<()> {
                     let daemonize = daemonize::Daemonize::new();
                     daemonize.start()?;
                 }
-                start_app(state, is_daemon)
+                if let Err(err) = start_app(state, is_daemon) {
+                    tracing::error!("Encountered an error when running the application: {err}");
+                }
+                Ok(())
             }
 
             #[cfg(not(feature = "daemon"))]

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -315,6 +315,18 @@ fn main() -> Result<()> {
             #[cfg(not(feature = "daemon"))]
             start_app(state, false)
         }
-        Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args, state),
+        Some((cmd, args)) => match cli::handle_cli_subcommand(cmd, args, &state) {
+            Err(err) => match err.downcast_ref::<std::io::Error>() {
+                None => Err(err),
+                Some(io_err) => match io_err.kind() {
+                    std::io::ErrorKind::ConnectionRefused => {
+                        eprintln!("Error: {err}\nPlease make sure that there is a running `spotify_player` instance with a client socket running on port {}.", state.app_config.client_port);
+                        std::process::exit(1)
+                    }
+                    _ => Err(err),
+                },
+            },
+            Ok(()) => Ok(()),
+        },
     }
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -28,6 +28,7 @@ fn init_app_cli_arguments() -> Result<clap::ArgMatches> {
         .subcommand(cli::init_get_subcommand())
         .subcommand(cli::init_playback_subcommand())
         .subcommand(cli::init_connect_subcommand())
+        .subcommand(cli::init_like_command())
         .arg(
             clap::Arg::new("theme")
                 .short('t')

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -29,6 +29,7 @@ fn init_app_cli_arguments() -> Result<clap::ArgMatches> {
         .subcommand(cli::init_playback_subcommand())
         .subcommand(cli::init_connect_subcommand())
         .subcommand(cli::init_like_command())
+        .subcommand(cli::init_authenticate_command())
         .arg(
             clap::Arg::new("theme")
                 .short('t')
@@ -311,6 +312,6 @@ fn main() -> Result<()> {
             #[cfg(not(feature = "daemon"))]
             start_app(state, false)
         }
-        Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args, state.app_config.client_port),
+        Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args, state),
     }
 }


### PR DESCRIPTION
## Changes

- add docs for **CLI commands** and **daemon**
- add `authenticate` and `like` CLI commands (replace `playback like` command)
- update handling logic for `playback` commands to rely on  the`client::Client::handle_player_request` function
- improve errors/logs reporting