### PR TITLE
Migrate to `ratatui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce841e0486e7c2412c3740168ede33adeba8e154a15107b879d8162d77c7174e"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm 0.26.1",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +3921,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rand",
+ "ratatui",
  "regex",
  "reqwest",
  "rpassword",
@@ -3919,7 +3933,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tui",
  "unicode-width",
  "viuer",
  "winit",
@@ -4411,19 +4424,6 @@ name = "ttf-parser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
-]
 
 [[package]]
 name = "typenum"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -27,7 +27,7 @@ rspotify = "0.11.7"
 serde = { version = "1.0.163", features = ["derive"] }
 tokio = { version = "1.28.1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 toml = "0.7.3"
-tui = "0.19.0"
+ratatui = "0.21.0"
 unicode-width = "0.1.10"
 rand = "0.8.5"
 maybe-async = "0.2.7"

--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -128,7 +128,8 @@ pub async fn new_session(auth_config: &AuthConfig, reauth: bool) -> Result<Sessi
                 }
                 Err(err) => match err {
                     SessionError::AuthenticationError(err) => {
-                        let msg = format!("Failed to authenticate using cached credentials: {err}");
+                        let msg =
+                            format!("Failed to authenticate using cached credentials: {err:#}");
                         if reauth {
                             eprintln!("{msg}");
                             new_session_with_new_creds(auth_config).await

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -25,13 +25,13 @@ pub async fn start_socket(client: Client, state: SharedState) -> Result<()> {
     let mut buf = [0; 4096];
     loop {
         match socket.recv_from(&mut buf).await {
-            Err(err) => tracing::warn!("Failed to receive from the socket: {err}"),
+            Err(err) => tracing::warn!("Failed to receive from the socket: {err:#}"),
             Ok((n_bytes, dest_addr)) => {
                 let req_buf = &buf[0..n_bytes];
                 let request: Request = match serde_json::from_slice(req_buf) {
                     Ok(v) => v,
                     Err(err) => {
-                        tracing::error!("Cannot deserialize the socket request: {err}");
+                        tracing::error!("Cannot deserialize the socket request: {err:#}");
                         continue;
                     }
                 };
@@ -39,7 +39,7 @@ pub async fn start_socket(client: Client, state: SharedState) -> Result<()> {
                 tracing::info!("Handling socket request: {request:?}...");
                 let response = match handle_socket_request(&client, &state, request).await {
                     Err(err) => {
-                        tracing::error!("Failed to handle socket request: {err}");
+                        tracing::error!("Failed to handle socket request: {err:#}");
                         let msg = format!("Bad request: {err}");
                         Response::Err(msg.into_bytes())
                     }

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -16,7 +16,7 @@ pub async fn start_client_handler(
         if client.spotify.session().await.is_invalid() {
             tracing::info!("Spotify client's session is invalid, re-creating a new session...");
             if let Err(err) = client.new_session(&state).await {
-                tracing::error!("Failed to create a new session: {err}");
+                tracing::error!("Failed to create a new session: {err:#}");
                 continue;
             }
         }
@@ -128,10 +128,10 @@ pub async fn start_player_event_watchers(
                 tokio::time::sleep(refresh_duration).await;
 
                 if let Err(err) = handle_track_end_event(&state, &client_pub).await {
-                    tracing::error!("Encountered error when handling track end event: {err}");
+                    tracing::error!("Encountered error when handling track end event: {err:#}");
                 }
                 if let Err(err) = handle_queue_change_event(&state, &client_pub).await {
-                    tracing::error!("Encountered error when handling queue change event: {err}");
+                    tracing::error!("Encountered error when handling queue change event: {err:#}");
                 }
             }
         }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -387,7 +387,7 @@ impl Client {
                             None
                         }
                         Err(err) => {
-                            tracing::error!("Failed to find an available device: {err}");
+                            tracing::error!("Failed to find an available device: {err:#}");
                             None
                         }
                     }
@@ -397,7 +397,7 @@ impl Client {
             if let Some(id) = id {
                 tracing::info!("Trying to connect to device (id={id})");
                 if let Err(err) = self.spotify.transfer_playback(&id, Some(false)).await {
-                    tracing::warn!("Connection failed (device_id={id}): {err}");
+                    tracing::warn!("Connection failed (device_id={id}): {err:#}");
                 } else {
                     tracing::info!("Connection succeeded (device_id={id})!");
                     // upon new connection, reset the buffered playback

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -239,7 +239,7 @@ impl AppConfig {
             .as_ref()
             .and_then(|proxy| match Url::parse(proxy) {
                 Err(err) => {
-                    tracing::warn!("failed to parse proxy url {proxy}: {err}");
+                    tracing::warn!("failed to parse proxy url {proxy}: {err:#}");
                     None
                 }
                 Ok(url) => Some(url),

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -174,7 +174,7 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
         let state = state.clone();
         async move {
             if let Err(err) = cli::start_socket(client, state).await {
-                tracing::warn!("Failed to run client socket for CLI: {err}");
+                tracing::warn!("Failed to run client socket for CLI: {err:#}");
             }
         }
     }));
@@ -223,7 +223,7 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
             move || {
                 if let Err(err) = media_control::start_event_watcher(state, client_pub) {
                     tracing::error!(
-                        "Failed to start the application's media control event watcher: err={err:?}"
+                        "Failed to start the application's media control event watcher: err={err:#?}"
                     );
                 }
             }
@@ -318,7 +318,7 @@ fn main() -> Result<()> {
                     daemonize.start()?;
                 }
                 if let Err(err) = start_app(state, is_daemon) {
-                    tracing::error!("Encountered an error when running the application: {err}");
+                    tracing::error!("Encountered an error when running the application: {err:#}");
                 }
                 Ok(())
             }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -14,6 +14,9 @@ mod token;
 mod ui;
 mod utils;
 
+// as `tui` is not actively maintained, we migrate to use `ratatui`
+extern crate ratatui as tui;
+
 use anyhow::{Context, Result};
 use std::io::Write;
 

--- a/spotify_player/src/token.rs
+++ b/spotify_player/src/token.rs
@@ -30,7 +30,7 @@ pub async fn get_token(session: &Session, client_id: &str) -> Result<Token> {
 
     let token = keymaster::get_token(session, client_id, &SCOPES.join(","))
         .await
-        .map_err(|err| anyhow!(format!("failed to get token: {err:?}")))?;
+        .map_err(|err| anyhow!(format!("failed to get token: {err:#?}")))?;
 
     // converts the token returned by librespot `get_token` function to a `rspotify::Token`
 

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -43,12 +43,13 @@ pub fn render_search_page(
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
         .split(rect)
-        .into_iter()
+        .iter()
         .flat_map(|rect| {
             Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-                .split(rect)
+                .split(*rect)
+                .to_vec()
         })
         .collect::<Vec<_>>();
 

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -271,7 +271,7 @@ fn render_playback_cover_image(
     }
 
     if let Err(err) = remove_temp_files() {
-        tracing::error!("Failed to remove temp files: {err}");
+        tracing::error!("Failed to remove temp files: {err:#}");
     }
 
     let data = state.data.read();
@@ -297,7 +297,7 @@ fn render_playback_cover_image(
                 ..Default::default()
             },
         ) {
-            tracing::error!("Failed to render the image: {err}",);
+            tracing::error!("Failed to render the image: {err:#}",);
         }
     }
 }

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -158,7 +158,7 @@ fn render_playback_text(
             "\n" => {
                 let mut tmp = vec![];
                 std::mem::swap(&mut tmp, &mut spans);
-                playback_text.lines.push(Spans::from(tmp));
+                playback_text.lines.push(Line::from(tmp));
                 continue;
             }
             "{track}" => (
@@ -197,7 +197,7 @@ fn render_playback_text(
         spans.push(Span::raw(format_str[ptr..].to_string()));
     }
     if !spans.is_empty() {
-        playback_text.lines.push(Spans::from(spans));
+        playback_text.lines.push(Line::from(spans));
     }
 
     let playback_desc = Paragraph::new(playback_text).wrap(Wrap { trim: true });


### PR DESCRIPTION
## Changes

- migrated to [`ratatui`](https://github.com/tui-rs-revival/ratatui) from `tui`
- used pretty print format for error logging