### PR TITLE
Fix a typo for homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Application's prebuilt binaries can be found in the [Releases Page](https://gith
 
 ### Homebrew
 
-Run `brew install spotify-player` to install the application.
+Run `brew install spotify_player` to install the application.
 
 ### Cargo
 


### PR DESCRIPTION
Reference: https://formulae.brew.sh/formula/spotify_player

Tested locally on macOS 13.4.1, and it works perfectly!