### PR TITLE
Use ttl cache instead of lru

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,17 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,15 +1497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
 name = "headers"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2220,6 +2200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,15 +2226,6 @@ name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
-
-[[package]]
-name = "lru"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
-dependencies = [
- "hashbrown 0.13.2",
-]
 
 [[package]]
 name = "lyric_finder"
@@ -3917,7 +3894,6 @@ dependencies = [
  "librespot-core",
  "librespot-playback",
  "log",
- "lru",
  "lyric_finder",
  "maybe-async",
  "notify-rust",
@@ -3936,6 +3912,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ttl_cache",
  "unicode-width",
  "viuer",
  "winit",
@@ -4427,6 +4404,15 @@ name = "ttf-parser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
+
+[[package]]
+name = "ttl_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "typenum"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -19,7 +19,6 @@ librespot-connect = { version = "0.4.2", optional = true }
 librespot-playback = { version = "0.4.2", optional = true }
 librespot-core = "0.4.2"
 log = "0.4.18"
-lru = "0.10.0"
 chrono = "0.4.26"
 reqwest = { version = "0.11.18", features = ["json"] }
 rpassword = "7.2.0"
@@ -47,6 +46,7 @@ serde_json = "1.0.96"
 once_cell = "1.17.2"
 regex = "1.8.3"
 daemonize = { version = "0.5.0", optional = true }
+ttl_cache = "0.5.1"
 
 [features]
 alsa-backend = ["streaming", "librespot-playback/alsa-backend"]

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -178,7 +178,7 @@ pub async fn start_player_event_watchers(
 
                     // request new context's data if not found in memory
                     if let Some(id) = id {
-                        if !state.data.read().caches.context.contains(&id.uri()) {
+                        if !state.data.read().caches.context.contains_key(&id.uri()) {
                             client_pub
                                 .send(ClientRequest::GetContext(id.clone()))
                                 .unwrap_or_default();

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -152,7 +152,7 @@ pub fn handle_key_sequence_for_search_page(
     };
 
     let data = state.data.read();
-    let search_results = data.caches.search.peek(current_query);
+    let search_results = data.caches.search.get(current_query);
 
     match focus_state {
         SearchFocusState::Input => anyhow::bail!("user's search input should be handled before"),

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -55,7 +55,7 @@ pub fn handle_command_for_focused_context_window(
 
     let data = state.data.read();
 
-    match data.caches.context.peek(&context_id.uri()) {
+    match data.caches.context.get(&context_id.uri()) {
         Some(context) => match context {
             Context::Artist {
                 top_tracks,

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -19,7 +19,6 @@ pub use parking_lot::{Mutex, RwLock};
 pub type SharedState = std::sync::Arc<State>;
 
 /// Application's state
-#[derive(Debug)]
 pub struct State {
     pub app_config: config::AppConfig,
     pub keymap_config: config::KeymapConfig,

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -25,7 +25,7 @@ pub fn render_search_page(
         s => anyhow::bail!("expect a search page state, found {s:?}"),
     };
 
-    let search_results = data.caches.search.peek(current_query);
+    let search_results = data.caches.search.get(current_query);
 
     // 2. Construct the page's layout
     let rect = construct_and_render_block("Search", &ui.theme, state, Borders::ALL, frame, rect);
@@ -229,7 +229,7 @@ pub fn render_context_page(
     };
 
     let data = state.data.read();
-    match data.caches.context.peek(&id.uri()) {
+    match data.caches.context.get(&id.uri()) {
         Some(context) => {
             // render context description
             let chunks = Layout::default()
@@ -511,7 +511,7 @@ pub fn render_lyric_page(
         s => anyhow::bail!("expect a lyric page state, found {s:?}"),
     };
 
-    let (desc, lyric) = match data.caches.lyrics.peek(&format!("{track} {artists}")) {
+    let (desc, lyric) = match data.caches.lyrics.get(&format!("{track} {artists}")) {
         None => {
             frame.render_widget(Paragraph::new("Loading..."), rect);
             return Ok(());

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -275,7 +275,7 @@ fn render_playback_cover_image(
     }
 
     let data = state.data.read();
-    if let Some(image) = data.caches.images.peek(&url) {
+    if let Some(image) = data.caches.images.get(&url) {
         ui.last_cover_image_render_info = Some((url, std::time::Instant::now()));
 
         // `viuer` renders image using `sixel` in a different scale compared to other methods.


### PR DESCRIPTION
Replace `lru` cache with `ttl` cache.

## Context

Using `ttl` cache avoids the problem that the cached Spotify data becomes invalid after sometimes. For example, daily mix playlist changes the list of tracks everyday, hence playing a song from the cached playlist won't work.