### PR TITLE
Create app.toml with default values if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ To move the focus from the search input to the other windows such as track resul
 
 By default, `spotify_player` will look into `$HOME/.config/spotify-player` for application's configuration files. This can be changed by either specifying `-c <FOLDER_PATH>` or `--config-folder <FOLDER_PATH>` option.
 
+If an application configuration file is not found, one will be created with default values.
+
 Please refer to [the configuration documentation](docs/config.md) for more details on the configuration options.
 
 ## Caches

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -280,9 +280,15 @@ impl Default for KeymapConfig {
 }
 
 impl KeymapConfig {
+    pub fn new(path: &std::path::Path) -> Result<Self> {
+        let mut config = Self::default();
+        config.parse_config_file(path)?;
+
+        Ok(config)
+    }
     /// parses a list of keymaps from the keymap config file in `path` folder
     /// and updates the current keymaps accordingly.
-    pub fn parse_config_file(&mut self, path: &std::path::Path) -> Result<()> {
+    fn parse_config_file(&mut self, path: &std::path::Path) -> Result<()> {
         let file_path = path.join(super::KEYMAP_CONFIG_FILE);
         match std::fs::read_to_string(&file_path) {
             Err(err) => {

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -229,7 +229,7 @@ impl Default for DeviceConfig {
 impl AppConfig {
     pub fn new(path: &Path, theme: Option<&String>) -> Result<Self> {
         let mut config = Self::default();
-        if config.parse_config_file(path)?.is_none() {
+        if !config.parse_config_file(path)? {
             config.write_config_file(path)?
         }
 
@@ -242,13 +242,14 @@ impl AppConfig {
 
     // parses configurations from an application config file in `path` folder,
     // then updates the current configurations accordingly.
-    fn parse_config_file(&mut self, path: &Path) -> Result<Option<()>> {
+    // returns false if no config file found and true otherwise
+    fn parse_config_file(&mut self, path: &Path) -> Result<bool> {
         let file_path = path.join(APP_CONFIG_FILE);
         match std::fs::read_to_string(file_path) {
             Ok(content) => self
                 .parse(toml::from_str::<toml::Value>(&content)?)
-                .map(Option::Some),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                .map(|_| true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(error.into()),
         }
     }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -11,13 +11,13 @@ use anyhow::{anyhow, Result};
 use config_parser2::*;
 use librespot_core::config::SessionConfig;
 use reqwest::Url;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 pub use keymap::*;
 pub use theme::*;
 
-#[derive(Debug, Deserialize, ConfigParse)]
+#[derive(Debug, Deserialize, Serialize, ConfigParse)]
 /// Application configurations
 pub struct AppConfig {
     pub theme: String,
@@ -80,14 +80,14 @@ pub struct AppConfig {
     pub device: DeviceConfig,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum Position {
     Top,
     Bottom,
 }
 config_parser_impl!(Position);
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum BorderType {
     Hidden,
     Plain,
@@ -97,20 +97,20 @@ pub enum BorderType {
 }
 config_parser_impl!(BorderType);
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum ProgressBarType {
     Line,
     Rectangle,
 }
 config_parser_impl!(ProgressBarType);
 
-#[derive(Debug, Deserialize, ConfigParse, Clone)]
+#[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 pub struct Command {
     pub command: String,
     pub args: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, ConfigParse, Clone)]
+#[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 /// Application device configurations
 pub struct DeviceConfig {
     pub name: String,
@@ -120,7 +120,7 @@ pub struct DeviceConfig {
     pub audio_cache: bool,
 }
 
-#[derive(Debug, Deserialize, ConfigParse, Clone)]
+#[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 #[cfg(feature = "notify")]
 pub struct NotifyFormat {
     pub summary: String,
@@ -227,14 +227,38 @@ impl Default for DeviceConfig {
 }
 
 impl AppConfig {
+    pub fn new(path: &Path, theme: Option<&String>) -> Result<Self> {
+        let mut config = Self::default();
+        if config.parse_config_file(path)?.is_none() {
+            config.write_config_file(path)?
+        }
+
+        if let Some(theme) = theme {
+            config.theme = theme.to_owned()
+        }
+
+        Ok(config)
+    }
+
     // parses configurations from an application config file in `path` folder,
     // then updates the current configurations accordingly.
-    pub fn parse_config_file(&mut self, path: &Path) -> Result<()> {
+    fn parse_config_file(&mut self, path: &Path) -> Result<Option<()>> {
         let file_path = path.join(APP_CONFIG_FILE);
-        if let Ok(content) = std::fs::read_to_string(file_path) {
-            self.parse(toml::from_str::<toml::Value>(&content)?)?;
+        match std::fs::read_to_string(file_path) {
+            Ok(content) => self
+                .parse(toml::from_str::<toml::Value>(&content)?)
+                .map(Option::Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
         }
-        Ok(())
+    }
+
+    fn write_config_file(&self, path: &Path) -> Result<()> {
+        toml::to_string_pretty(&self)
+            .map_err(From::from)
+            .and_then(|content| {
+                std::fs::write(path.join(APP_CONFIG_FILE), content).map_err(From::from)
+            })
     }
 
     pub fn session_config(&self) -> SessionConfig {

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -120,9 +120,16 @@ impl ThemeConfig {
         self.themes.iter().find(|&t| t.name == name).cloned()
     }
 
+    pub fn new(path: &std::path::Path) -> Result<Self> {
+        let mut config = Self::default();
+        config.parse_config_file(path)?;
+
+        Ok(config)
+    }
+
     /// parses configurations from a theme config file in `path` folder,
     /// then updates the current configurations accordingly.
-    pub fn parse_config_file(&mut self, path: &std::path::Path) -> Result<()> {
+    fn parse_config_file(&mut self, path: &std::path::Path) -> Result<()> {
         let file_path = path.join(super::THEME_CONFIG_FILE);
         match std::fs::read_to_string(&file_path) {
             Err(err) => {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -281,15 +281,10 @@ fn main() -> Result<()> {
     }
 
     // initialize the application state
-    let state = {
-        let mut state = state::State {
-            cache_folder: cache_folder.clone(),
-            ..state::State::default()
-        };
-        // parse config options from the config files into application's state
-        state.parse_config_files(&config_folder, args.get_one::<String>("theme"))?;
-        std::sync::Arc::new(state)
-    };
+    let state = std::sync::Arc::new(state::State::new(
+        &config_folder,
+        args.get_one::<String>("theme"),
+    )?);
 
     match args.subcommand() {
         None => {

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -34,18 +34,15 @@ pub struct State {
 impl State {
     /// parses application's configurations
     pub fn new(config_folder: &std::path::Path, theme: Option<&String>) -> Result<Self> {
-        let mut state = Self {
+        let state = Self {
             app_config: config::AppConfig::new(config_folder, theme)?,
-            keymap_config: config::KeymapConfig::default(),
-            theme_config: config::ThemeConfig::default(),
+            keymap_config: config::KeymapConfig::new(config_folder)?,
+            theme_config: config::ThemeConfig::new(config_folder)?,
             cache_folder: std::path::PathBuf::new(),
             ui: Mutex::new(UIState::default()),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(AppData::default()),
         };
-
-        state.theme_config.parse_config_file(config_folder)?;
-        state.keymap_config.parse_config_file(config_folder)?;
 
         if let Some(theme) = state.theme_config.find_theme(&state.app_config.theme) {
             // update the UI theme based on the `theme` config option

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -10,7 +10,7 @@ pub use model::*;
 pub use player::*;
 pub use ui::*;
 
-use crate::config::{self};
+use crate::config;
 use anyhow::Result;
 
 pub use parking_lot::{Mutex, RwLock};

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -10,7 +10,7 @@ pub use model::*;
 pub use player::*;
 pub use ui::*;
 
-use crate::config;
+use crate::config::{self};
 use anyhow::Result;
 
 pub use parking_lot::{Mutex, RwLock};
@@ -33,40 +33,26 @@ pub struct State {
 
 impl State {
     /// parses application's configurations
-    pub fn parse_config_files(
-        &mut self,
-        config_folder: &std::path::Path,
-        theme: Option<&String>,
-    ) -> Result<()> {
-        self.app_config.parse_config_file(config_folder)?;
-        if let Some(theme) = theme {
-            self.app_config.theme = theme.to_owned();
-        };
-        self.theme_config.parse_config_file(config_folder)?;
-        self.keymap_config.parse_config_file(config_folder)?;
-
-        if let Some(theme) = self.theme_config.find_theme(&self.app_config.theme) {
-            // update the UI theme based on the `theme` config option
-            // specified in the app's general configurations
-            self.ui.lock().theme = theme;
-        }
-
-        Ok(())
-    }
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State {
-            app_config: config::AppConfig::default(),
-            theme_config: config::ThemeConfig::default(),
+    pub fn new(config_folder: &std::path::Path, theme: Option<&String>) -> Result<Self> {
+        let mut state = Self {
+            app_config: config::AppConfig::new(config_folder, theme)?,
             keymap_config: config::KeymapConfig::default(),
-
+            theme_config: config::ThemeConfig::default(),
             cache_folder: std::path::PathBuf::new(),
-
             ui: Mutex::new(UIState::default()),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(AppData::default()),
+        };
+
+        state.theme_config.parse_config_file(config_folder)?;
+        state.keymap_config.parse_config_file(config_folder)?;
+
+        if let Some(theme) = state.theme_config.find_theme(&state.app_config.theme) {
+            // update the UI theme based on the `theme` config option
+            // specified in the app's general configurations
+            state.ui.lock().theme = theme;
         }
+
+        Ok(state)
     }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -32,7 +32,7 @@ pub struct State {
 }
 
 impl State {
-    /// parses application's configurations
+    /// creates an application's state based on files in a configuration folder and an optional pre-defined theme
     pub fn new(config_folder: &std::path::Path, theme: Option<&String>) -> Result<Self> {
         let state = Self {
             app_config: config::AppConfig::new(config_folder, theme)?,


### PR DESCRIPTION
If an application configuration file is not found, one will be created with default values in the config directory.

The configs have been refactored to use `new` constructors instead of default implementations.

closes #182 