### PR TITLE
Allow removing a keybind

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -182,7 +182,7 @@ selection = { modifiers = ["Bold", "Reversed"] }
 
 ## Keymaps
 
-`spotify_player` uses `keymap.toml` to add or override new key mappings in additional to [the default key mappings](../README.md#commands). To define a new key mapping, simply add a `keymaps` entry. For example,
+`spotify_player` uses `keymap.toml` to add or override new key mappings in additional to [the default key mappings](../README.md#commands). To define a new key mapping, simply add a `keymaps` entry. To remove a key mapping, set its command to `None`. For example,
 
 ```toml
 [[keymaps]]
@@ -197,4 +197,7 @@ key_sequence = "C-c C-x /"
 [[keymaps]]
 command = "ResumePause"
 key_sequence = "M-enter"
+[[keymaps]]
+command = "None"
+key_sequence = "q"
 ```

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 /// Application's command
 pub enum Command {
+    None,
+
     NextTrack,
     PreviousTrack,
     ResumePause,
@@ -135,6 +137,7 @@ pub fn construct_track_actions(track: &Track, data: &DataReadGuard) -> Vec<Track
 impl Command {
     pub fn desc(&self) -> &'static str {
         match self {
+            Self::None => "do nothing",
             Self::NextTrack => "next track",
             Self::PreviousTrack => "previous track",
             Self::ResumePause => "resume/pause based on the current playback",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -333,6 +333,12 @@ impl KeymapConfig {
     }
 }
 
+impl Keymap {
+    pub fn include_in_help_screen(&self) -> bool {
+        !matches!(&self.command, Command::None)
+    }
+}
+
 impl From<&str> for Key {
     /// converts a string into a `Key`.
     /// # Panics

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -255,18 +255,23 @@ pub fn render_commands_help_popup(
     let rect = construct_and_render_block("Commands", &ui.theme, state, Borders::ALL, frame, rect);
 
     let mut map = BTreeMap::new();
-    state.keymap_config.keymaps.iter().for_each(|km| {
-        let v = map.entry(km.command);
-        match v {
-            Entry::Vacant(v) => {
-                v.insert(format!("\"{}\"", km.key_sequence));
+    state
+        .keymap_config
+        .keymaps
+        .iter()
+        .filter(|km| km.include_in_help_screen())
+        .for_each(|km| {
+            let v = map.entry(km.command);
+            match v {
+                Entry::Vacant(v) => {
+                    v.insert(format!("\"{}\"", km.key_sequence));
+                }
+                Entry::Occupied(mut v) => {
+                    let desc = format!("{}, \"{}\"", v.get(), km.key_sequence);
+                    *v.get_mut() = desc;
+                }
             }
-            Entry::Occupied(mut v) => {
-                let desc = format!("{}, \"{}\"", v.get(), km.key_sequence);
-                *v.get_mut() = desc;
-            }
-        }
-    });
+        });
 
     let scroll_offset = match ui.popup {
         Some(PopupState::CommandHelp {


### PR DESCRIPTION
This is done by introducing a new `Command::None`, which does nothing and also doesn't appear in the help menu.

To remove a default or any previously defined keybind, simply set its command like this:
```toml
[[keymaps]]
command = "None"
key_sequence = "q"
```