### PR TITLE
Add block-image feature which forces rendering images using half blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ cargo install spotify_player --features image
 
 `spotify_player` also supports rendering images with `sixel` behind `sixel` feature flag, which also enables `image` feature:
 
+To disable full resolution images rendering, `spotify_player` needs to be built with `block-image` feature enabled.
+In that case, the images would be rendered using half-blocks.
+This feature enables `image` feature.
 ```shell
 cargo install spotify_player --features sixel
 ```

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -62,6 +62,7 @@ lyric-finder = ["lyric_finder"]
 media-control = ["souvlaki", "winit"]
 image = ["viuer", "dep:image"]
 sixel = ["image", "viuer/sixel"]
+block-image = ["image"]
 notify = ["notify-rust"]
 daemon = ["daemonize"]
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -137,7 +137,7 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
 #[tokio::main]
 async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
     if !is_daemon {
-        #[cfg(feature = "image")]
+        #[cfg(all(feature = "image", not(feature = "block-image")))]
         {
             // initialize `viuer` supports for kitty, iterm2, and sixel
             viuer::get_kitty_support();

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -287,16 +287,25 @@ fn render_playback_cover_image(
         let width = (rect.width as f32 * scale).round() as u32;
         let height = (rect.height as f32 * scale).round() as u32;
 
-        if let Err(err) = viuer::print(
-            image,
-            &viuer::Config {
-                x: rect.x,
-                y: rect.y as i16,
-                width: Some(width),
-                height: Some(height),
-                ..Default::default()
-            },
-        ) {
+        #[cfg(not(feature = "block-image"))]
+        let config = viuer::Config {
+            x: rect.x,
+            y: rect.y as i16,
+            width: Some(width),
+            height: Some(height),
+            ..Default::default()
+        };
+        #[cfg(feature = "block-image")]
+        let config = viuer::Config {
+            x: rect.x,
+            y: rect.y as i16,
+            width: Some(width),
+            height: Some(height),
+            use_kitty: false,
+            use_iterm: false,
+            ..Default::default()
+        };
+        if let Err(err) = viuer::print(image, &config) {
             tracing::error!("Failed to render the image: {err:#}",);
         }
     }


### PR DESCRIPTION
`spotify-player` with enabled `image` cannot run in `zellij` in `kitty` - it hangs on `viuer::get_kitty_support()`. To enable running `spotify-player` in `zellij` I added feature `block-image` which forces rendering images using half-blocks.