### PR TITLE
Implement UI for creating new playlists

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -392,6 +392,24 @@ impl Client {
                 )
                 .await?;
             }
+            ClientRequest::CreatePlaylist {
+                playlist_name,
+                public,
+                collab,
+                desc,
+            } => {
+                let user_id = state.data.read().user_data.user.to_owned().unwrap().id;
+                let _ = self
+                    .create_new_playlist(
+                        state,
+                        user_id.clone(),
+                        playlist_name.as_str(),
+                        public,
+                        collab,
+                        desc.as_str(),
+                    )
+                    .await?;
+            }
         };
 
         tracing::info!(
@@ -1280,6 +1298,37 @@ impl Client {
         Self::notify_new_track(track, &path, state)?;
 
         Ok(())
+    }
+
+    pub async fn create_new_playlist(
+        &self,
+        state: &SharedState,
+        user_id: UserId<'static>,
+        playlist_name: &str,
+        public: bool,
+        collab: bool,
+        desc: &str,
+    ) -> Result<PlaylistId> {
+        let resp = self
+            .spotify
+            .user_playlist_create(
+                user_id.to_owned(),
+                playlist_name,
+                Some(public),
+                Some(collab),
+                Some(desc),
+            )
+            .await?;
+        state.data.write().user_data.playlists.insert(
+            0,
+            Playlist {
+                id: resp.id.to_owned(),
+                collaborative: collab,
+                name: playlist_name.to_string(),
+                owner: ("".into(), user_id),
+            },
+        );
+        Ok(resp.id)
     }
 
     #[cfg(feature = "notify")]

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -71,6 +71,8 @@ pub enum Command {
 
     MovePlaylistItemUp,
     MovePlaylistItemDown,
+
+    CreatePlaylist,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -204,6 +206,8 @@ impl Command {
             Self::ReverseTrackOrder => "reverse the order of the track table (if any)",
             Self::MovePlaylistItemUp => "move playlist item up one position",
             Self::MovePlaylistItemDown => "move playlist item down one position",
+
+            Self::CreatePlaylist => "create new playlist",
         }
     }
 }

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -282,6 +282,10 @@ impl Default for KeymapConfig {
                     key_sequence: "C-j".into(),
                     command: Command::MovePlaylistItemDown,
                 },
+                Keymap {
+                    key_sequence: "N".into(),
+                    command: Command::CreatePlaylist,
+                },
             ],
         }
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -69,6 +69,12 @@ pub enum ClientRequest {
     },
     #[cfg(feature = "streaming")]
     NewStreamingConnection,
+    CreatePlaylist {
+        playlist_name: String,
+        public: bool,
+        collab: bool,
+        desc: String,
+    },
 }
 
 /// starts a terminal event handler (key pressed, mouse clicked, etc)

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -22,10 +22,15 @@ pub fn handle_key_sequence_for_popup(
     // handle popups that need reading the raw key sequence instead of the matched command
     match popup {
         PopupState::Search { .. } => {
-            // NOTE: the `drop(ui)` is important as the handle function for search
+            // NOTE: the `drop(ui)` is important as the handle function for the popup
             // re-acquire the UI lock, so we need to drop the current UI lock to avoid a deadlock.
             drop(ui);
             return handle_key_sequence_for_search_popup(key_sequence, client_pub, state);
+        }
+        PopupState::PlaylistCreate { .. } => {
+            // NOTE: same here.
+            drop(ui);
+            return handle_key_sequence_for_create_playlist_popup(key_sequence, client_pub, state);
         }
         PopupState::ActionList(item, ..) => {
             return handle_key_sequence_for_action_list_popup(
@@ -49,6 +54,9 @@ pub fn handle_key_sequence_for_popup(
 
     match popup {
         PopupState::Search { .. } => anyhow::bail!("search popup should be handled before"),
+        PopupState::PlaylistCreate { .. } => {
+            anyhow::bail!("create playlist popup should be handled before")
+        }
         PopupState::ActionList(..) => {
             anyhow::bail!("action list popup should be handled before")
         }
@@ -257,6 +265,100 @@ fn handle_command_for_queue_popup(
         _ => return Ok(false),
     }
     Ok(true)
+}
+
+fn handle_key_sequence_for_create_playlist_popup(
+    key_sequence: &KeySequence,
+    client_pub: &flume::Sender<ClientRequest>,
+    state: &SharedState,
+) -> Result<bool> {
+    {
+        let mut ui = state.ui.lock();
+        let (name, desc, current_field) = match ui.popup {
+            Some(PopupState::PlaylistCreate {
+                ref mut name,
+                ref mut desc,
+                ref mut current_field,
+            }) => (name, desc, current_field),
+            _ => return Ok(false),
+        };
+        if key_sequence.keys.len() == 1 {
+            if let Key::None(c) = key_sequence.keys[0] {
+                match c {
+                    crossterm::event::KeyCode::Char(c) => {
+                        match &current_field {
+                            PlaylistCreateCurrentField::Name => {
+                                name.push(c);
+                            }
+                            PlaylistCreateCurrentField::Desc => {
+                                desc.push(c);
+                            }
+                        }
+                        return Ok(true);
+                    }
+                    crossterm::event::KeyCode::Backspace => {
+                        match &current_field {
+                            PlaylistCreateCurrentField::Name => {
+                                if !name.is_empty() {
+                                    name.pop().unwrap();
+                                }
+                            }
+                            PlaylistCreateCurrentField::Desc => {
+                                if !desc.is_empty() {
+                                    desc.pop().unwrap();
+                                }
+                            }
+                        }
+                        return Ok(true);
+                    }
+                    crossterm::event::KeyCode::Tab => {
+                        *current_field = match &current_field {
+                            PlaylistCreateCurrentField::Name => PlaylistCreateCurrentField::Desc,
+                            PlaylistCreateCurrentField::Desc => PlaylistCreateCurrentField::Name,
+                        };
+                        return Ok(true);
+                    }
+                    crossterm::event::KeyCode::Enter => {
+                        client_pub.send(ClientRequest::CreatePlaylist {
+                            playlist_name: name.to_owned(),
+                            public: false,
+                            collab: false,
+                            desc: desc.to_owned(),
+                        })?;
+                        ui.popup = None;
+                        return Ok(true);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let command = state
+        .keymap_config
+        .find_command_from_key_sequence(key_sequence);
+    if let Some(Command::ClosePopup) = command {
+        state.ui.lock().popup = None;
+        return Ok(true);
+    }
+
+    let page_type = state.ui.lock().current_page().page_type();
+    match page_type {
+        PageType::Library => page::handle_key_sequence_for_library_page(key_sequence, state),
+        PageType::Search => {
+            page::handle_key_sequence_for_search_page(key_sequence, client_pub, state)
+        }
+        PageType::Context => {
+            page::handle_key_sequence_for_context_page(key_sequence, client_pub, state)
+        }
+        PageType::Browse => {
+            page::handle_key_sequence_for_browse_page(key_sequence, client_pub, state)
+        }
+        #[cfg(feature = "lyric-finder")]
+        PageType::Lyric => {
+            page::handle_key_sequence_for_lyric_page(key_sequence, client_pub, state)
+        }
+    }
 }
 
 /// handles a key sequence for a context search popup

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -423,6 +423,13 @@ pub fn handle_command_for_playlist_list_window(
                 new_list_state(),
             ));
         }
+        Command::CreatePlaylist => {
+            ui.popup = Some(PopupState::PlaylistCreate {
+                name: "".into(),
+                desc: "".into(),
+                current_field: PlaylistCreateCurrentField::Name,
+            });
+        }
         _ => return Ok(false),
     }
     Ok(true)

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -2,9 +2,19 @@ use crate::{command, state::model::*};
 use tui::widgets::ListState;
 
 #[derive(Debug)]
+pub enum PlaylistCreateCurrentField {
+    Name,
+    Desc,
+}
+
+#[derive(Debug)]
 pub enum PopupState {
-    CommandHelp { scroll_offset: usize },
-    Search { query: String },
+    CommandHelp {
+        scroll_offset: usize,
+    },
+    Search {
+        query: String,
+    },
     UserPlaylistList(PlaylistPopupAction, ListState),
     UserFollowedArtistList(ListState),
     UserSavedAlbumList(ListState),
@@ -12,7 +22,14 @@ pub enum PopupState {
     ArtistList(ArtistPopupAction, Vec<Artist>, ListState),
     ThemeList(Vec<crate::config::Theme>, ListState),
     ActionList(ActionListItem, ListState),
-    Queue { scroll_offset: usize },
+    Queue {
+        scroll_offset: usize,
+    },
+    PlaylistCreate {
+        name: String,
+        desc: String,
+        current_field: PlaylistCreateCurrentField,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -48,7 +65,10 @@ impl PopupState {
             Self::ArtistList(.., list_state) => Some(list_state),
             Self::ThemeList(.., list_state) => Some(list_state),
             Self::ActionList(.., list_state) => Some(list_state),
-            Self::CommandHelp { .. } | Self::Search { .. } | Self::Queue { .. } => None,
+            Self::CommandHelp { .. }
+            | Self::Search { .. }
+            | Self::Queue { .. }
+            | Self::PlaylistCreate { .. } => None,
         }
     }
 
@@ -62,7 +82,10 @@ impl PopupState {
             Self::ArtistList(.., list_state) => Some(list_state),
             Self::ThemeList(.., list_state) => Some(list_state),
             Self::ActionList(.., list_state) => Some(list_state),
-            Self::CommandHelp { .. } | Self::Search { .. } | Self::Queue { .. } => None,
+            Self::CommandHelp { .. }
+            | Self::Search { .. }
+            | Self::Queue { .. }
+            | Self::PlaylistCreate { .. } => None,
         }
     }
 

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -28,6 +28,43 @@ pub fn render_popup(
     match ui.popup {
         None => (rect, true),
         Some(ref popup) => match popup {
+            PopupState::PlaylistCreate {
+                name,
+                desc,
+                current_field: _,
+            } => {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(0), Constraint::Length(3)].as_ref())
+                    .split(rect);
+
+                let popup_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                    .split(chunks[1]);
+
+                let name_input = construct_and_render_block(
+                    "Enter Name for New Playlist:",
+                    &ui.theme,
+                    state,
+                    Borders::ALL,
+                    frame,
+                    popup_chunks[0],
+                );
+
+                let desc_input = construct_and_render_block(
+                    "Enter Description for New Playlist",
+                    &ui.theme,
+                    state,
+                    Borders::ALL,
+                    frame,
+                    popup_chunks[1],
+                );
+
+                frame.render_widget(Paragraph::new(name.to_string()), name_input);
+                frame.render_widget(Paragraph::new(desc.to_string()), desc_input);
+                (chunks[0], true)
+            }
             PopupState::Search { query } => {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)


### PR DESCRIPTION
This attempts to implement a rudimentary UI flow for creating a new playlist.

Resolves #87.

**Usage:**
While focused on the playlist window, pressing `N` will show a pop-up prompting user to enter the name and the description of the new playlist to be created. Pressing `Tab` here will switch focus between the two fields.

**Limitation:**
For simplicity, the `public` and `collab` statuses will be omitted. ~The `desc` field looks to be broken upstream in `rspotify` - the new playlist does not seem to have this informatino attached. Both of these limitations are also observed in the CLI implementation (#222).~ This seems to be a misobservation.

I'm also relatively new to Rust, so I mainly focused on submitting a purely functioning implementation, without much regard to the DRYness of code - once there are more instances of the pop-up with input prompt (similar to both `Search` and `PlaylistCreate` here), it should be abstracted.

Suggestions and critics are of course more than welcome and would help me a lot getting started in my Rust journey.