### PR TITLE
Add player event hook command

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -4,6 +4,8 @@
 
 - [General](#general)
   - [Notes](#notes)
+  - [Media control](#media-control)
+  - [Player event hook command](#player-event-hook-command)
   - [Device configurations](#device-configurations)
 - [Themes](#themes)
   - [Use script to add theme](#use-script-to-add-theme)
@@ -72,7 +74,7 @@ All configuration files should be placed inside the application's configuration 
   **Note**: the above list might not be up-to-date.
 
 - An example of event that triggers a playback update is the one happening when the current track ends.
-- `copy_command` is represented by a struct with 2 fields `command` and `args`. For example, `copy_command = { command = "xclip", args = ["-sel", "c"] }`. The copy command should read input from **standard input**.
+- `copy_command` is represented by a struct with two fields `command` and `args`. For example, `copy_command = { command = "xclip", args = ["-sel", "c"] }`. The copy command should read input from **standard input**.
 - `enable_streaming` can be either `Always`, `Never` or `DaemonOnly`. For backwards compatibility, `true` and `false` are still accepted as aliases for `Always` and `Never`.
 - `playback_window_position` can only be either `Top` or `Bottom`.
 - `border_type` can be either `Hidden`, `Plain`, `Rounded`, `Double` or `Thick`.
@@ -84,18 +86,18 @@ Media control support (`enable_media_control` option) is enabled by default on L
 
 MacOS and Windows require **an open window** to listen to OS media event. As a result, `spotify_player` needs to spawn an invisible window on startup, which may steal focus from the running terminal. To interact with `spotify_player`, which is run on the terminal, user will need to re-focus the terminal. Because of this extra re-focus step, the media control support is disabled by default on MacOS and Windows to avoid possible confusion for first-time users.
 
-### Player hook event command
+### Player event hook command
 
-Similar to `copy_command`, if specified, `player_event_hook_command` should a struct with 2 fields `command` and `args`. When there is a new player event, `player_event_hook_command` is executed with the event as the **standard input**.
+Similar to `copy_command`, if specified, `player_event_hook_command` should be a struct with two fields `command` and `args`. Each time `spotify_player` receives a new player event, `player_event_hook_command` is executed with the event as the **standard input**.
 
-Player event is a json string with either of the following values:
+A player event is a `json` string with either of the following values:
 
 - `{ Changed: { old_track_id: String, new_track_id: String } }`
 - `{ Playing: { track_id: String, position_ms: Number, duration_ms: Number } }`
 - `{ Paused: { track_id: String, position_ms: Number, duration_ms: Number } }`
 - `{ EndOfTrack: { track_id: String } }`
 
-Example `player_event_hook_command` script, which reads the event from **stdin**, parse the event as a `json` string, and write the parsed event into a file:
+Example `player_event_hook_command` script, which reads the event from **stdin**, parses the event as a `json` string, and writes the parsed event into a file:
 
 ```python
 #!/usr/bin/python3

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -5,7 +5,7 @@ tracks_playback_limit = 50
 playback_format = "{track} • {artists}\n{album}\n{metadata}"
 notify_format = { summary = "{track} • {artists}", body = "{album}" }
 # the default `copy_command` is based on the OS
-copy_command = { command = "pbcopy", args = [] } # macos
+# copy_command = { command = "pbcopy", args = [] } # macos
 # copy_command = { command = "xclip", args = ["-sel", "c"] } # linux
 # copy_command = { command = "clip", args = [] } # windows
 app_refresh_duration_in_ms = 32

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -82,6 +82,7 @@ impl Client {
             session,
             state.app_config.device.clone(),
             self.client_pub.clone(),
+            state.app_config.player_event_hook_command.clone(),
         );
 
         let mut stream_conn = self.stream_conn.lock();

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -26,6 +26,7 @@ pub struct AppConfig {
     pub client_port: u16,
 
     pub copy_command: Command,
+    pub player_event_hook_command: Option<Command>,
 
     pub playback_format: String,
     #[cfg(feature = "notify")]
@@ -196,6 +197,8 @@ impl Default for AppConfig {
                 command: "clip".to_string(),
                 args: vec![],
             },
+
+            player_event_hook_command: None,
 
             proxy: None,
             ap_port: None,

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -3,14 +3,90 @@ use librespot_connect::spirc::Spirc;
 use librespot_core::{
     config::{ConnectConfig, DeviceType},
     session::Session,
+    spotify_id,
 };
 use librespot_playback::mixer::MixerConfig;
 use librespot_playback::{
     audio_backend,
     config::{AudioFormat, Bitrate, PlayerConfig},
     mixer::{self, Mixer},
-    player::Player,
+    player,
 };
+use rspotify::model::TrackId;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+enum PlayerEvent {
+    Changed {
+        old_track_id: TrackId<'static>,
+        new_track_id: TrackId<'static>,
+    },
+    Playing {
+        track_id: TrackId<'static>,
+        position_ms: u32,
+        duration_ms: u32,
+    },
+    Paused {
+        track_id: TrackId<'static>,
+        position_ms: u32,
+        duration_ms: u32,
+    },
+    EndOfTrack {
+        track_id: TrackId<'static>,
+    },
+    VolumeSet {
+        volume_percent: u8,
+    },
+}
+
+fn spotify_id_to_track_id(id: spotify_id::SpotifyId) -> anyhow::Result<TrackId<'static>> {
+    let uri = id.to_uri()?;
+    Ok(TrackId::from_uri(&uri)?.into_static())
+}
+
+impl PlayerEvent {
+    pub fn from_librespot_player_event(e: player::PlayerEvent) -> anyhow::Result<Option<Self>> {
+        Ok(match e {
+            player::PlayerEvent::Changed {
+                old_track_id,
+                new_track_id,
+            } => Some(PlayerEvent::Changed {
+                old_track_id: spotify_id_to_track_id(old_track_id)?,
+                new_track_id: spotify_id_to_track_id(new_track_id)?,
+            }),
+            player::PlayerEvent::Playing {
+                track_id,
+                position_ms,
+                duration_ms,
+                ..
+            } => Some(PlayerEvent::Playing {
+                track_id: spotify_id_to_track_id(track_id)?,
+                position_ms,
+                duration_ms,
+            }),
+            player::PlayerEvent::Paused {
+                track_id,
+                position_ms,
+                duration_ms,
+                ..
+            } => Some(PlayerEvent::Paused {
+                track_id: spotify_id_to_track_id(track_id)?,
+                position_ms,
+                duration_ms,
+            }),
+            player::PlayerEvent::EndOfTrack { track_id, .. } => Some(PlayerEvent::EndOfTrack {
+                track_id: spotify_id_to_track_id(track_id)?,
+            }),
+            // `librespot` volume is a u16 number ranging from 0 to 65535,
+            // convert it to a percentage format (from 0 to 100)
+            player::PlayerEvent::VolumeSet { volume } => {
+                let volume_percent = ((volume as f64) * 100.0 / 65535.0).round() as u8;
+                Some(PlayerEvent::VolumeSet { volume_percent })
+            }
+            _ => None,
+        })
+    }
+}
 
 /// Create a new streaming connection
 pub fn new_connection(
@@ -18,10 +94,10 @@ pub fn new_connection(
     device: config::DeviceConfig,
     client_pub: flume::Sender<ClientRequest>,
 ) -> Spirc {
-    // librespot volume is a u16 number ranging from 0 to 65535,
+    // `librespot` volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
     // So we need to convert from one format to another
-    let volume = (std::cmp::min(device.volume, 100_u8) as f64 / 100.0 * 65535_f64).round() as u16;
+    let volume = (std::cmp::min(device.volume, 100_u8) as f64 / 100.0 * 65535.0).round() as u16;
 
     let connect_config = ConnectConfig {
         name: device.name,
@@ -55,7 +131,7 @@ pub fn new_connection(
         session.device_id()
     );
 
-    let (player, mut channel) = Player::new(
+    let (player, mut channel) = player::Player::new(
         player_config,
         session.clone(),
         mixer.get_soft_volume(),
@@ -65,11 +141,20 @@ pub fn new_connection(
     let player_event_task = tokio::task::spawn({
         async move {
             while let Some(event) = channel.recv().await {
-                tracing::info!("Got an event from the integrated player: {:?}", event);
-                client_pub
-                    .send_async(ClientRequest::GetCurrentPlayback)
-                    .await
-                    .unwrap_or_default();
+                match PlayerEvent::from_librespot_player_event(event) {
+                    Err(err) => {
+                        tracing::warn!("Failed to convert a `librespot` player event into `spotify_player` player event: {err:#}");
+                    }
+                    Ok(Some(event)) => {
+                        tracing::info!("Got a new player event: {event:?}");
+
+                        client_pub
+                            .send_async(ClientRequest::GetCurrentPlayback)
+                            .await
+                            .unwrap_or_default();
+                    }
+                    Ok(None) => {}
+                }
             }
         }
     });


### PR DESCRIPTION
Resolves #190. 
Resolves #103.

Added `player_event_hook_command` as a config option. Each time the application receives a player event, `player_event_hook_command ` is executed with the event json string as the standard input.