### PR TITLE
Add support for getting track's data from CLI `get` command

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -90,8 +90,8 @@ async fn handle_socket_request(
 
     match request {
         Request::Get(GetRequest::Key(key)) => handle_get_key_request(client, key).await,
-        Request::Get(GetRequest::Item(item_type, context_id)) => {
-            handle_get_item_request(client, item_type, context_id).await
+        Request::Get(GetRequest::Item(item_type, id_or_name)) => {
+            handle_get_item_request(client, item_type, id_or_name).await
         }
         Request::Playback(command) => {
             handle_playback_request(client, state, command).await?;
@@ -187,7 +187,8 @@ async fn handle_get_key_request(client: &Client, key: Key) -> Result<Vec<u8>> {
 
 /// Get a Spotify item's ID from its `IdOrName` representation
 async fn get_spotify_id(client: &Client, typ: ItemType, id_or_name: IdOrName) -> Result<ItemId> {
-    // For `cli::ContextId::Name`, we search for the first item matching the name and return its spotify id
+    // For `IdOrName::Name`, we search for the first item matching the name and return its spotify id.
+    // The item's id is then used to retrieve the item's data.
 
     let sid = match typ {
         ItemType::Playlist => match id_or_name {
@@ -274,9 +275,9 @@ async fn get_spotify_id(client: &Client, typ: ItemType, id_or_name: IdOrName) ->
 async fn handle_get_item_request(
     client: &Client,
     item_type: ItemType,
-    context_id: IdOrName,
+    id_or_name: IdOrName,
 ) -> Result<Vec<u8>> {
-    let sid = get_spotify_id(client, item_type, context_id).await?;
+    let sid = get_spotify_id(client, item_type, id_or_name).await?;
     Ok(match sid {
         ItemId::Playlist(id) => serde_json::to_vec(&client.playlist_context(id).await?)?,
         ItemId::Album(id) => serde_json::to_vec(&client.album_context(id).await?)?,
@@ -318,8 +319,8 @@ async fn handle_playback_request(
 
             PlayerRequest::StartPlayback(Playback::URIs(ids, None))
         }
-        Command::StartContext(context_type, context_id) => {
-            let sid = get_spotify_id(client, context_type.into(), context_id).await?;
+        Command::StartContext(context_type, id_or_name) => {
+            let sid = get_spotify_id(client, context_type.into(), id_or_name).await?;
             let context_id = match sid {
                 ItemId::Playlist(id) => ContextId::Playlist(id),
                 ItemId::Album(id) => ContextId::Album(id),

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -17,8 +17,12 @@ pub fn init_get_subcommand() -> Command {
                     .required(true),
             ),
         )
-        .subcommand(add_context_args(
-            Command::new("context").about("Get context data"),
+        .subcommand(add_id_or_name_group(
+            Command::new("item").about("Get a Spotify item's data").arg(
+                Arg::new("item_type")
+                    .value_parser(EnumValueParser::<ItemType>::new())
+                    .required(true),
+            ),
         ))
 }
 
@@ -26,8 +30,14 @@ fn init_playback_start_subcommand() -> Command {
     Command::new("start")
         .about("Start a new playback")
         .subcommand_required(true)
-        .subcommand(add_context_args(
-            Command::new("context").about("Start a context playback"),
+        .subcommand(add_id_or_name_group(
+            Command::new("context")
+                .about("Start a context playback")
+                .arg(
+                    Arg::new("context_type")
+                        .value_parser(EnumValueParser::<ContextType>::new())
+                        .required(true),
+                ),
         ))
         .subcommand(
             Command::new("liked")
@@ -55,16 +65,6 @@ fn init_playback_start_subcommand() -> Command {
                 .about("Start a radio playback")
                 .arg(Arg::new("item_type").value_parser(EnumValueParser::<ItemType>::new())),
         ))
-}
-
-fn add_context_args(cmd: Command) -> Command {
-    add_id_or_name_group(
-        cmd.arg(
-            Arg::new("context_type")
-                .value_parser(EnumValueParser::<ContextType>::new())
-                .required(true),
-        ),
-    )
 }
 
 fn add_id_or_name_group(cmd: Command) -> Command {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -56,13 +56,13 @@ fn handle_get_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<()> {
                 .to_owned();
             Request::Get(GetRequest::Key(key))
         }
-        "context" => {
-            let context_type = args
-                .get_one::<ContextType>("context_type")
+        "item" => {
+            let item_type = args
+                .get_one::<ItemType>("item_type")
                 .expect("context_type is required")
                 .to_owned();
             let id_or_name = get_id_or_name(args)?;
-            Request::Get(GetRequest::Context(context_type, id_or_name))
+            Request::Get(GetRequest::Item(item_type, id_or_name))
         }
         _ => unreachable!(),
     };

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -47,7 +47,7 @@ enum ItemId {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum GetRequest {
     Key(Key),
-    Context(ContextType, IdOrName),
+    Item(ItemType, IdOrName),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1042,6 +1042,12 @@ impl Client {
         Ok(())
     }
 
+    /// gets a track data
+    pub async fn track(&self, track_id: TrackId<'_>) -> Result<Track> {
+        Track::try_from_full_track(self.spotify.track(track_id).await?)
+            .context("convert rspotify_model::FullTrack into spotify_player::state::Track")
+    }
+
     /// gets a playlist context data
     pub async fn playlist_context(&self, playlist_id: PlaylistId<'_>) -> Result<Context> {
         let playlist_uri = playlist_id.uri();


### PR DESCRIPTION
- **Breaking**: replaced `get context` CLI command with `get item` CLI command
- implemented `get item track  <--id <id>|--name <name>>` support for getting track data