### PR TITLE
Set PulseAudio app properties using environment variables

### DIFF
--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -163,7 +163,13 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
             std::env::set_var("PULSE_PROP_application.icon_name", "spotify");
         }
         if std::env::var("PULSE_PROP_stream.description").is_err() {
-            std::env::set_var("PULSE_PROP_stream.description", "Spotify Connect endpoint");
+            std::env::set_var(
+                "PULSE_PROP_stream.description",
+                format!(
+                    "Spotify Connect endpoint ({})",
+                    state.app_config.device.name
+                ),
+            );
         }
         if std::env::var("PULSE_PROP_media.software").is_err() {
             std::env::set_var("PULSE_PROP_media.software", "Spotify");

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -153,6 +153,26 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
     // client channels
     let (client_pub, client_sub) = flume::unbounded::<event::ClientRequest>();
 
+    #[cfg(feature = "pulseaudio-backend")]
+    {
+        // set environment variables for PulseAudio
+        if std::env::var("PULSE_PROP_application.name").is_err() {
+            std::env::set_var("PULSE_PROP_application.name", "spotify-player");
+        }
+        if std::env::var("PULSE_PROP_application.icon_name").is_err() {
+            std::env::set_var("PULSE_PROP_application.icon_name", "spotify");
+        }
+        if std::env::var("PULSE_PROP_stream.description").is_err() {
+            std::env::set_var("PULSE_PROP_stream.description", "Spotify Connect endpoint");
+        }
+        if std::env::var("PULSE_PROP_media.software").is_err() {
+            std::env::set_var("PULSE_PROP_media.software", "Spotify");
+        }
+        if std::env::var("PULSE_PROP_media.role").is_err() {
+            std::env::set_var("PULSE_PROP_media.role", "music");
+        }
+    }
+
     // create a librespot session
     let auth_config = auth::AuthConfig::new(&state)?;
     let session = auth::new_session(&auth_config, !is_daemon).await?;


### PR DESCRIPTION
This allows other PulseAudio clients (like mixers etc.) to show more details about the audio stream.

For example, using the standard PulseAudio volume control (`pavucontrol`):

- before: 
![2023-09-13-10_38_34](https://github.com/aome510/spotify-player/assets/64833/0ea5a04b-7652-44d6-a206-2ab1337c7acd)
- after:
![2023-09-13-11_05_22](https://github.com/aome510/spotify-player/assets/64833/3f457180-e13b-49d7-a6f8-723575c21abb)

It would even be possible to do things like add the current track's title and artist in env variables, but I don't think anyone actually makes use of this, so it seems rather pointless to me. Instead, I decided to focus on the most useful ones.

Librespot only sets those when used as a standalone binary, but not as a library: https://github.com/librespot-org/librespot/blob/054074c920d5c6acf0210faa3cd849dc4e065828/src/main.rs#L1211-L1246

Documentation about this PulseAudio feature: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/Clients/ApplicationProperties/