### PR TITLE
Add Mute command

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ List of supported commands:
 | `Shuffle`                      | toggle the shuffle mode                                                 | `C-s`              |
 | `VolumeUp`                     | increase playback volume by 5%                                          | `+`                |
 | `VolumeDown`                   | decrease playback volume by 5%                                          | `-`                |
+| `Mute`                         | toggle playback volume between 0% and previous level                    | `_`                |
 | `SeekForward`                  | seek forward by 5s                                                      | `>`                |
 | `SeekBackward`                 | seek backward by 5s                                                     | `<`                |
 | `Quit`                         | quit the application                                                    | `C-c`, `q`         |

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -170,7 +170,7 @@ impl Client {
             }
             PlayerRequest::ToggleMute(volume) => {
                 if volume == 0 {
-                    state.player.write().mute_state = None;    
+                    state.player.write().mute_state = None;
                 } else {
                     state.player.write().mute_state = Some(volume);
                 }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -168,6 +168,13 @@ impl Client {
                 playback.volume = Some(volume as u32);
                 state.player.write().buffered_playback = Some(playback);
             }
+            PlayerRequest::ToggleMute(volume) => {
+                if volume == 0 {
+                    state.player.write().mute_state = None;    
+                } else {
+                    state.player.write().mute_state = Some(volume);
+                }
+            }
             PlayerRequest::StartPlayback(p) => {
                 self.start_playback(p, device_id).await?;
                 // for some reasons, when starting a new playback, the integrated `spotify_player`

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -14,6 +14,7 @@ pub enum Command {
     Shuffle,
     VolumeUp,
     VolumeDown,
+    Mute,
     SeekForward,
     SeekBackward,
 
@@ -149,6 +150,7 @@ impl Command {
             Self::Shuffle => "toggle the shuffle mode",
             Self::VolumeUp => "increase playback volume by 5%",
             Self::VolumeDown => "decrease playback volume by 5%",
+            Self::Mute => "set playback volume to 0%",
             Self::SeekForward => "seek forward by 5s",
             Self::SeekBackward => "seek backward by 5s",
             Self::Quit => "quit the application",

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -150,7 +150,7 @@ impl Command {
             Self::Shuffle => "toggle the shuffle mode",
             Self::VolumeUp => "increase playback volume by 5%",
             Self::VolumeDown => "decrease playback volume by 5%",
-            Self::Mute => "set playback volume to 0%",
+            Self::Mute => "toggle playback volume between 0% and previous level",
             Self::SeekForward => "seek forward by 5s",
             Self::SeekBackward => "seek backward by 5s",
             Self::Quit => "quit the application",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -56,6 +56,10 @@ impl Default for KeymapConfig {
                     command: Command::VolumeDown,
                 },
                 Keymap {
+                    key_sequence: "_".into(),
+                    command: Command::Mute,
+                },
+                Keymap {
                     key_sequence: ">".into(),
                     command: Command::SeekForward,
                 },

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -242,12 +242,9 @@ fn handle_global_command(
                 if let Some(volume) = state.player.read().mute_state {
                     client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(0)))?;
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
-                } else {
-                    if let Some(volume) = playback.volume {
-                        client_pub
-                            .send(ClientRequest::Player(PlayerRequest::ToggleMute(volume)))?;
-                        client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
-                    }
+                } else if let Some(volume) = playback.volume {
+                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(volume)))?;
+                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
                 }
             }
         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -23,7 +23,7 @@ pub enum PlayerRequest {
     Repeat,
     Shuffle,
     Volume(u8),
-    ToggleMute(u32),
+    ToggleMute,
     TransferPlayback(String, bool),
     StartPlayback(Playback),
 }
@@ -238,15 +238,7 @@ fn handle_global_command(
             }
         }
         Command::Mute => {
-            if let Some(ref playback) = state.player.read().buffered_playback {
-                if let Some(volume) = state.player.read().mute_state {
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
-                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(0)))?;
-                } else if let Some(volume) = playback.volume {
-                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(volume)))?;
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
-                }
-            }
+            client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute))?;
         }
         Command::SeekForward => {
             if let Some(progress) = state.player.read().playback_progress() {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -23,6 +23,7 @@ pub enum PlayerRequest {
     Repeat,
     Shuffle,
     Volume(u8),
+    ToggleMute(u32),
     TransferPlayback(String, bool),
     StartPlayback(Playback),
 }
@@ -237,7 +238,18 @@ fn handle_global_command(
             }
         }
         Command::Mute => {
-            client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
+            if let Some(ref playback) = state.player.read().buffered_playback {
+                if let Some(volume) = state.player.read().mute_state {
+                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(0)))?;
+                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
+                } else {
+                    if let Some(volume) = playback.volume {
+                        client_pub
+                            .send(ClientRequest::Player(PlayerRequest::ToggleMute(volume)))?;
+                        client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
+                    }
+                }
+            }
         }
         Command::SeekForward => {
             if let Some(progress) = state.player.read().playback_progress() {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -236,6 +236,9 @@ fn handle_global_command(
                 }
             }
         }
+        Command::Mute => {
+            client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;
+        }
         Command::SeekForward => {
             if let Some(progress) = state.player.read().playback_progress() {
                 client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -240,8 +240,8 @@ fn handle_global_command(
         Command::Mute => {
             if let Some(ref playback) = state.player.read().buffered_playback {
                 if let Some(volume) = state.player.read().mute_state {
-                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(0)))?;
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
+                    client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(0)))?;
                 } else if let Some(volume) = playback.volume {
                     client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute(volume)))?;
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(0)))?;

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -12,7 +12,7 @@ pub struct PlayerState {
     pub buffered_playback: Option<SimplifiedPlayback>,
 
     pub queue: Option<rspotify_model::CurrentUserQueue>,
-    
+
     pub mute_state: Option<u32>,
 }
 

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -12,6 +12,8 @@ pub struct PlayerState {
     pub buffered_playback: Option<SimplifiedPlayback>,
 
     pub queue: Option<rspotify_model::CurrentUserQueue>,
+    
+    pub mute_state: Option<u32>,
 }
 
 impl PlayerState {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -154,10 +154,10 @@ fn render_playback_text(
     let re = regex::Regex::new(r"\{.*?\}|\n").unwrap();
 
     // build the volume string (vol% when unmuted, old_vol% (muted) if currently muted)
-    let mut volume = format!("{}%", playback.volume.unwrap_or_default());
-    if mute_state.is_some() {
-        volume = format!("{}% (muted)", mute_state.unwrap_or_default());
-    }
+    let volume = match mute_state {
+        Some(volume) => format!("{volume}% (muted)"),
+        None => format!("{}%", playback.volume.unwrap_or_default()),
+    };
 
     let mut ptr = 0;
     for m in re.find_iter(format_str) {


### PR DESCRIPTION
Resolves https://github.com/aome510/spotify-player/issues/243.

Add the ability to immediately set volume to 0% as requested in #243. I bound it to _ since "Shift + -" made sense to me, as it's basically super volume decrease.