### PR TITLE
Improve rendering performance for liked tracks page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3979,7 +3979,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ttl_cache",
- "unicode-width",
  "viuer",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
 members = ["spotify_player", "lyric_finder"]
+resolver = "2"
+
+[profile.release]
+debug = 1

--- a/docs/config.md
+++ b/docs/config.md
@@ -37,7 +37,6 @@ All configuration files should be placed inside the application's configuration 
 | `playback_refresh_duration_in_ms`    | the duration (in ms) between two consecutive playback refreshes               | `0`                                                        |
 | `cover_image_refresh_duration_in_ms` | the duration (in ms) between two cover image refreshes (`image` feature only) | `2000`                                                     |
 | `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)    | `20`                                                       |
-| `track_table_item_max_len`           | the maximum length of a column in a track table                               | `32`                                                       |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS)                |
 | `enable_streaming`                   | create a device for streaming (streaming feature only)                        | `Always`                                                   |
 | `enable_cover_image_cache`           | store album's cover images in the cache folder                                | `true`                                                     |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -12,7 +12,6 @@ app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 cover_image_refresh_duration_in_ms = 2000
 page_size_in_rows = 20
-track_table_item_max_len = 32
 enable_media_control = false
 enable_streaming = "Always"
 enable_cover_image_cache = true

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0.188", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["rt", "rt-multi-thread", "macros", "time"] }
 toml = "0.7.6"
 ratatui = "0.23.0"
-unicode-width = "0.1.10"
 rand = "0.8.5"
 maybe-async = "0.2.7"
 async-trait = "0.1.73"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -39,7 +39,7 @@ souvlaki = { version = "0.6.1", optional = true }
 winit = { version = "0.28.6", optional = true }
 viuer = { version = "0.6.2", optional = true }
 image = { version = "0.24.7", optional = true }
-notify-rust = { version = "4.9.0", optional = true, default_features = false, features = ["d"] }
+notify-rust = { version = "4.9.0", optional = true, default-features = false, features = ["d"] }
 flume = "0.11.0"
 serde_json = "1.0.105"
 once_cell = "1.18.0"

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -46,8 +46,6 @@ pub struct AppConfig {
 
     pub page_size_in_rows: usize,
 
-    pub track_table_item_max_len: usize,
-
     // icon configs
     pub play_icon: String,
     pub pause_icon: String,
@@ -210,8 +208,6 @@ impl Default for AppConfig {
             cover_image_refresh_duration_in_ms: 2000,
 
             page_size_in_rows: 20,
-
-            track_table_item_max_len: 32,
 
             pause_icon: "▌▌".to_string(),
             play_icon: "▶".to_string(),

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -25,7 +25,7 @@ pub struct UserData {
     pub playlists: Vec<Playlist>,
     pub followed_artists: Vec<Artist>,
     pub saved_albums: Vec<Album>,
-    pub saved_tracks: Vec<Track>,
+    pub saved_tracks: HashMap<String, Track>,
 }
 
 /// the application's caches
@@ -85,6 +85,6 @@ impl UserData {
 
     /// checks if a track is a liked track
     pub fn is_liked_track(&self, track: &Track) -> bool {
-        self.saved_tracks.iter().any(|t| t.id == track.id)
+        self.saved_tracks.contains_key(&track.id.uri())
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -684,12 +684,12 @@ pub fn render_track_table_window(
 ) -> Result<()> {
     // get the current playing track's URI to decorate such track (if exists) in the track table
     let mut playing_track_uri = "".to_string();
-    let mut active_desc = "";
+    let mut playing_id = "";
     if let Some(ref playback) = state.player.read().playback {
         if let Some(rspotify_model::PlayableItem::Track(ref track)) = playback.item {
             playing_track_uri = track.id.as_ref().map(|id| id.uri()).unwrap_or_default();
 
-            active_desc = if playback.is_playing {
+            playing_id = if playback.is_playing {
                 &state.app_config.play_icon
             } else {
                 &state.app_config.pause_icon
@@ -697,14 +697,13 @@ pub fn render_track_table_window(
         }
     }
 
-    let item_max_len = state.app_config.track_table_item_max_len;
     let n_tracks = tracks.len();
     let rows = tracks
         .into_iter()
         .enumerate()
         .map(|(id, t)| {
             let (id, style) = if playing_track_uri == t.id.uri() {
-                (active_desc.to_string(), ui.theme.current_playing())
+                (playing_id.to_string(), ui.theme.current_playing())
             } else {
                 ((id + 1).to_string(), Style::default())
             };
@@ -715,12 +714,9 @@ pub fn render_track_table_window(
                     ""
                 }),
                 Cell::from(id),
-                Cell::from(crate::utils::truncate_string(t.name.clone(), item_max_len)),
-                Cell::from(crate::utils::truncate_string(
-                    t.artists_info(),
-                    item_max_len,
-                )),
-                Cell::from(crate::utils::truncate_string(t.album_info(), item_max_len)),
+                Cell::from(t.name.clone()),
+                Cell::from(t.artists_info()),
+                Cell::from(t.album_info()),
                 Cell::from(crate::utils::format_duration(&t.duration)),
             ])
             .style(style)

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -747,6 +747,7 @@ pub fn render_track_table_window(
             Constraint::Percentage(30),
             Constraint::Percentage(20),
         ])
+        .column_spacing(2)
         .highlight_style(ui.theme.selection_style(is_active));
 
     match ui.current_page_mut() {

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -1,38 +1,11 @@
 use std::borrow::Cow;
 
 use tui::widgets::*;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// formats a time duration into a "{minutes}:{seconds}" format
 pub fn format_duration(duration: &chrono::Duration) -> String {
     let secs = duration.num_seconds();
     format!("{}:{:02}", secs / 60, secs % 60)
-}
-
-/// truncates a string whose length exceeds a given `max_len` length.
-/// Such string will be appended with `...` at the end.
-pub fn truncate_string(s: String, max_len: usize) -> String {
-    let len = UnicodeWidthStr::width(s.as_str());
-    if len > max_len {
-        // get the longest prefix of the string such that its unicode width
-        // is still within the `max_len` limit
-        let mut s: String = s
-            .chars()
-            .fold(("".to_owned(), 0_usize), |(mut cs, cw), c| {
-                let w = UnicodeWidthChar::width(c).unwrap_or(2);
-                if cw + w + 3 > max_len {
-                    (cs, cw)
-                } else {
-                    cs.push(c);
-                    (cs, cw + w)
-                }
-            })
-            .0;
-        s.push_str("...");
-        s
-    } else {
-        s
-    }
 }
 
 pub fn new_list_state() -> ListState {


### PR DESCRIPTION
Resolves #257

- enable debug for release profile
- (**BREAKING**) remove `track_table_item_max_len` config option
- improve `is_liked_track` lookup speed