### PR TITLE
map media control Pause and Resume to PlayerRequests

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -130,6 +130,20 @@ impl Client {
         match request {
             PlayerRequest::NextTrack => self.spotify.next_track(device_id).await?,
             PlayerRequest::PreviousTrack => self.spotify.previous_track(device_id).await?,
+            PlayerRequest::Resume => {
+                if !playback.is_playing {
+                    self.spotify.resume_playback(device_id, None).await?;
+                    playback.is_playing = true;
+                    state.player.write().buffered_playback = Some(playback);
+                }
+            }
+            PlayerRequest::Pause => {
+                if playback.is_playing {
+                    self.spotify.pause_playback(device_id).await?;
+                    playback.is_playing = false;
+                    state.player.write().buffered_playback = Some(playback);
+                }
+            }
             PlayerRequest::ResumePause => {
                 if !playback.is_playing {
                     self.spotify.resume_playback(device_id, None).await?

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -18,6 +18,8 @@ mod window;
 pub enum PlayerRequest {
     NextTrack,
     PreviousTrack,
+    Resume,
+    Pause,
     ResumePause,
     SeekTrack(chrono::Duration),
     Repeat,

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -77,7 +77,17 @@ pub fn start_event_watcher(
     controls.attach(move |e| {
         tracing::info!("Got a media control event: {e:?}");
         match e {
-            MediaControlEvent::Play | MediaControlEvent::Pause | MediaControlEvent::Toggle => {
+            MediaControlEvent::Play => {
+                client_pub
+                    .send(ClientRequest::Player(PlayerRequest::Resume))
+                    .unwrap_or_default();
+            }
+            MediaControlEvent::Pause => {
+                client_pub
+                    .send(ClientRequest::Player(PlayerRequest::Pause))
+                    .unwrap_or_default();
+            }
+            MediaControlEvent::Toggle => {
                 client_pub
                     .send(ClientRequest::Player(PlayerRequest::ResumePause))
                     .unwrap_or_default();


### PR DESCRIPTION
Fixes #271.

Currently, all of MediaControlEvent::{Play, Pause, Toggle} get mapped to PlayerRequest::ResumePause, which means the playback is toggled. In some cases, this means that the media player might send a `Pause` event, but playback is resumed, because the playback was already paused.

I ran into this issue in #271 where I would disconnect my bluetooth headphones when the playback was already paused, and the player would then resume playback through my computer speakers. Based on the logs, it appears to me that the headphones disconnecting generates a `MediaControlEvent::Pause`. Instead of resuming the playback, this PR now updates the code to ensure that playback stays paused.
