### PR TITLE
Clamped progress bars to solve problems with -ve numbers

### DIFF
--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -228,11 +228,16 @@ fn render_playback_progress_bar(
     track: &rspotify_model::FullTrack,
     rect: Rect,
 ) {
+    // Negative numbers can sometimes appear from progress.num_seconds() so this stops
+    // them coming through into the ratios
+    let ratio = (progress.num_seconds() as f64 / track.duration.num_seconds() as f64)
+        .clamp(0.0, 1.0);
+
     match state.app_config.progress_bar_type {
         config::ProgressBarType::Line => frame.render_widget(
             LineGauge::default()
                 .gauge_style(ui.theme.playback_progress_bar())
-                .ratio(progress.num_seconds() as f64 / track.duration.num_seconds() as f64)
+                .ratio(ratio)
                 .label(Span::styled(
                     format!(
                         "{}/{}",
@@ -246,7 +251,7 @@ fn render_playback_progress_bar(
         config::ProgressBarType::Rectangle => frame.render_widget(
             Gauge::default()
                 .gauge_style(ui.theme.playback_progress_bar())
-                .ratio(progress.num_seconds() as f64 / track.duration.num_seconds() as f64)
+                .ratio(ratio)
                 .label(Span::styled(
                     format!(
                         "{}/{}",

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -230,8 +230,8 @@ fn render_playback_progress_bar(
 ) {
     // Negative numbers can sometimes appear from progress.num_seconds() so this stops
     // them coming through into the ratios
-    let ratio = (progress.num_seconds() as f64 / track.duration.num_seconds() as f64)
-        .clamp(0.0, 1.0);
+    let ratio =
+        (progress.num_seconds() as f64 / track.duration.num_seconds() as f64).clamp(0.0, 1.0);
 
     match state.app_config.progress_bar_type {
         config::ProgressBarType::Line => frame.render_widget(


### PR DESCRIPTION
Resolves #273 

Negative numbers were sometimes appearing in progress.num_seconds() which would cause a panic, as the ui elements would only accept positive ratios. Clamped the numbers from 0.0 to 1.0 to prevent this happening. Seems to have solved the panics, but no idea where the negative numbers are coming from.