### PR TITLE
Allow shuffling context playback from CLI

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -319,7 +319,7 @@ async fn handle_playback_request(
         Command::StartContext {
             context_type,
             id_or_name,
-            random,
+            shuffle,
         } => {
             let sid = get_spotify_id(client, context_type.into(), id_or_name).await?;
             let context_id = match sid {
@@ -329,7 +329,7 @@ async fn handle_playback_request(
                 _ => unreachable!(),
             };
 
-            PlayerRequest::StartPlayback(Playback::Context(context_id, None), Some(random))
+            PlayerRequest::StartPlayback(Playback::Context(context_id, None), Some(shuffle))
         }
         Command::PlayPause => PlayerRequest::ResumePause,
         Command::Next => PlayerRequest::NextTrack,

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -295,7 +295,7 @@ async fn handle_playback_request(
 
             PlayerRequest::StartPlayback(
                 Playback::URIs(tracks.into_iter().map(|t| t.id).collect(), None),
-                false,
+                None,
             )
         }
         Command::StartLikedTracks { limit, random } => {
@@ -314,9 +314,13 @@ async fn handle_playback_request(
             .map(|t| t.id.to_owned())
             .collect();
 
-            PlayerRequest::StartPlayback(Playback::URIs(ids, None), false)
+            PlayerRequest::StartPlayback(Playback::URIs(ids, None), None)
         }
-        Command::StartContext { context_type, id_or_name, random} => {
+        Command::StartContext {
+            context_type,
+            id_or_name,
+            random,
+        } => {
             let sid = get_spotify_id(client, context_type.into(), id_or_name).await?;
             let context_id = match sid {
                 ItemId::Playlist(id) => ContextId::Playlist(id),
@@ -325,7 +329,7 @@ async fn handle_playback_request(
                 _ => unreachable!(),
             };
 
-            PlayerRequest::StartPlayback(Playback::Context(context_id, None), random)
+            PlayerRequest::StartPlayback(Playback::Context(context_id, None), Some(random))
         }
         Command::PlayPause => PlayerRequest::ResumePause,
         Command::Next => PlayerRequest::NextTrack,

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -293,10 +293,10 @@ async fn handle_playback_request(
             let sid = get_spotify_id(client, item_type, id_or_name).await?;
             let tracks = client.radio_tracks(sid.uri()).await?;
 
-            PlayerRequest::StartPlayback(Playback::URIs(
-                tracks.into_iter().map(|t| t.id).collect(),
-                None,
-            ))
+            PlayerRequest::StartPlayback(
+                Playback::URIs(tracks.into_iter().map(|t| t.id).collect(), None),
+                false,
+            )
         }
         Command::StartLikedTracks { limit, random } => {
             let mut tracks = client.current_user_saved_tracks().await?;
@@ -314,9 +314,9 @@ async fn handle_playback_request(
             .map(|t| t.id.to_owned())
             .collect();
 
-            PlayerRequest::StartPlayback(Playback::URIs(ids, None))
+            PlayerRequest::StartPlayback(Playback::URIs(ids, None), false)
         }
-        Command::StartContext(context_type, id_or_name) => {
+        Command::StartContext { context_type, id_or_name, random} => {
             let sid = get_spotify_id(client, context_type.into(), id_or_name).await?;
             let context_id = match sid {
                 ItemId::Playlist(id) => ContextId::Playlist(id),
@@ -325,7 +325,7 @@ async fn handle_playback_request(
                 _ => unreachable!(),
             };
 
-            PlayerRequest::StartPlayback(Playback::Context(context_id, None))
+            PlayerRequest::StartPlayback(Playback::Context(context_id, None), random)
         }
         Command::PlayPause => PlayerRequest::ResumePause,
         Command::Next => PlayerRequest::NextTrack,

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -37,6 +37,13 @@ fn init_playback_start_subcommand() -> Command {
                     Arg::new("context_type")
                         .value_parser(EnumValueParser::<ContextType>::new())
                         .required(true),
+                )
+                .arg(
+                    Arg::new("random")
+                        .short('r')
+                        .long("random")
+                        .action(ArgAction::SetTrue)
+                        .help("Shuffle tracks within the launched playback"),
                 ),
         ))
         .subcommand(

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -39,9 +39,9 @@ fn init_playback_start_subcommand() -> Command {
                         .required(true),
                 )
                 .arg(
-                    Arg::new("random")
-                        .short('r')
-                        .long("random")
+                    Arg::new("shuffle")
+                        .short('s')
+                        .long("shuffle")
                         .action(ArgAction::SetTrue)
                         .help("Shuffle tracks within the launched playback"),
                 ),

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -80,13 +80,13 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<(
                     .get_one::<ContextType>("context_type")
                     .expect("context_type is required")
                     .to_owned();
-                let random = args.get_flag("random");
+                let shuffle = args.get_flag("shuffle");
 
                 let id_or_name = get_id_or_name(args)?;
                 Command::StartContext {
                     context_type,
                     id_or_name,
-                    random,
+                    shuffle,
                 }
             }
             Some(("liked", args)) => {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -81,9 +81,13 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<(
                     .expect("context_type is required")
                     .to_owned();
                 let random = args.get_flag("random");
-                    
+
                 let id_or_name = get_id_or_name(args)?;
-                Command::StartContext { context_type, id_or_name, random }
+                Command::StartContext {
+                    context_type,
+                    id_or_name,
+                    random,
+                }
             }
             Some(("liked", args)) => {
                 let limit = *args

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -80,8 +80,10 @@ fn handle_playback_subcommand(args: &ArgMatches, socket: &UdpSocket) -> Result<(
                     .get_one::<ContextType>("context_type")
                     .expect("context_type is required")
                     .to_owned();
+                let random = args.get_flag("random");
+                    
                 let id_or_name = get_id_or_name(args)?;
-                Command::StartContext(context_type, id_or_name)
+                Command::StartContext { context_type, id_or_name, random }
             }
             Some(("liked", args)) => {
                 let limit = *args

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -87,7 +87,7 @@ pub enum Command {
     StartContext {
         context_type: ContextType,
         id_or_name: IdOrName,
-        random: bool,
+        shuffle: bool,
     },
     StartLikedTracks {
         limit: usize,

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -84,15 +84,25 @@ pub enum PlaylistCommand {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Command {
-    StartContext(ContextType, IdOrName),
-    StartLikedTracks { limit: usize, random: bool },
+    StartContext {
+        context_type: ContextType,
+        id_or_name: IdOrName,
+        random: bool,
+    },
+    StartLikedTracks {
+        limit: usize,
+        random: bool,
+    },
     StartRadio(ItemType, IdOrName),
     PlayPause,
     Next,
     Previous,
     Shuffle,
     Repeat,
-    Volume { percent: i8, is_offset: bool },
+    Volume {
+        percent: i8,
+        is_offset: bool,
+    },
     Seek(i64),
 }
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -199,10 +199,9 @@ impl Client {
 
                 state.player.write().mute_state = new_mute_state;
             }
-            PlayerRequest::StartPlayback(p, random) => {
-                match random {
-                    Some(random) => playback.shuffle_state = random,
-                    None => (),
+            PlayerRequest::StartPlayback(p, shuffle) => {
+                if let Some(shuffle) = shuffle {
+                    playback.shuffle_state = shuffle;
                 }
                 self.start_playback(p, device_id).await?;
                 // for some reasons, when starting a new playback, the integrated `spotify_player`

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -200,8 +200,10 @@ impl Client {
                 state.player.write().mute_state = new_mute_state;
             }
             PlayerRequest::StartPlayback(p, random) => {
-                println!("random: {} ", random);
-                playback.shuffle_state = random;
+                match random {
+                    Some(random) => playback.shuffle_state = random,
+                    None => ()
+                }
                 self.start_playback(p, device_id).await?;
                 // for some reasons, when starting a new playback, the integrated `spotify_player`
                 // client doesn't respect the initial shuffle state, so we need to manually update the state

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -202,7 +202,7 @@ impl Client {
             PlayerRequest::StartPlayback(p, random) => {
                 match random {
                     Some(random) => playback.shuffle_state = random,
-                    None => ()
+                    None => (),
                 }
                 self.start_playback(p, device_id).await?;
                 // for some reasons, when starting a new playback, the integrated `spotify_player`

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -199,7 +199,9 @@ impl Client {
 
                 state.player.write().mute_state = new_mute_state;
             }
-            PlayerRequest::StartPlayback(p) => {
+            PlayerRequest::StartPlayback(p, random) => {
+                println!("random: {} ", random);
+                playback.shuffle_state = random;
                 self.start_playback(p, device_id).await?;
                 // for some reasons, when starting a new playback, the integrated `spotify_player`
                 // client doesn't respect the initial shuffle state, so we need to manually update the state

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -27,7 +27,7 @@ pub enum PlayerRequest {
     Volume(u8),
     ToggleMute,
     TransferPlayback(String, bool),
-    StartPlayback(Playback),
+    StartPlayback(Playback, bool),
 }
 
 #[derive(Debug)]

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -27,7 +27,7 @@ pub enum PlayerRequest {
     Volume(u8),
     ToggleMute,
     TransferPlayback(String, bool),
-    StartPlayback(Playback, bool),
+    StartPlayback(Playback, Option<bool>),
 }
 
 #[derive(Debug)]

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -164,12 +164,14 @@ pub fn handle_command_for_track_table_window(
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 base_playback
                     .uri_offset(tracks[id].id.uri(), state.app_config.tracks_playback_limit),
+                    false
             )))?;
         }
         Command::ChooseSelected => {
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 base_playback
                     .uri_offset(tracks[id].id.uri(), state.app_config.tracks_playback_limit),
+                    false
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {
@@ -265,6 +267,7 @@ pub fn handle_command_for_track_list_window(
             // containing all the tracks in the table.
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(vec![tracks[id].id.clone()], None),
+                false
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -164,14 +164,14 @@ pub fn handle_command_for_track_table_window(
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 base_playback
                     .uri_offset(tracks[id].id.uri(), state.app_config.tracks_playback_limit),
-                    false
+                None,
             )))?;
         }
         Command::ChooseSelected => {
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 base_playback
                     .uri_offset(tracks[id].id.uri(), state.app_config.tracks_playback_limit),
-                    false
+                None,
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {
@@ -267,7 +267,7 @@ pub fn handle_command_for_track_list_window(
             // containing all the tracks in the table.
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 Playback::URIs(vec![tracks[id].id.clone()], None),
-                false
+                None,
             )))?;
         }
         Command::ShowActionsOnSelectedItem => {


### PR DESCRIPTION
Closes https://github.com/aome510/spotify-player/issues/239 

I did this by adding an option that would change the playback context to shuffle. The other option that immediately occurred to me was to shuffle all tracks in the playback locally in the same way that `StartLikedTracks`, but that shifts computation to the client and doesn't achieve the desired result IMO 
