### PR TITLE
add explicit tags to track information

### DIFF
--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -245,7 +245,7 @@ impl Track {
     /// gets the track's name, including an explicit label
     pub fn display_name(&self) -> Cow<'_, str> {
         if self.explicit {
-            Cow::Owned(format!("{} 🅴", self.name))
+            Cow::Owned(format!("{} (E)", self.name))
         } else {
             Cow::Borrowed(self.name.as_str())
         }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -245,7 +245,7 @@ impl Track {
     /// gets the track's name, including an explicit label
     pub fn display_name(&self) -> Cow<'_, str> {
         if self.explicit {
-            Cow::Owned(format!("{} (Explicit)", self.name))
+            Cow::Owned(format!("{} 🅴", self.name))
         } else {
             Cow::Borrowed(self.name.as_str())
         }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -86,7 +86,12 @@ pub fn render_search_page(
             .map(|s| {
                 s.tracks
                     .iter()
-                    .map(|a| (format!("{} • {}", a.name, a.artists_info()), false))
+                    .map(|a| {
+                        (
+                            format!("{} • {}", a.display_name(), a.artists_info()),
+                            false,
+                        )
+                    })
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
@@ -714,7 +719,7 @@ pub fn render_track_table_window(
                     ""
                 }),
                 Cell::from(id),
-                Cell::from(t.name.clone()),
+                Cell::from(t.display_name()),
                 Cell::from(t.artists_info()),
                 Cell::from(t.album_info()),
                 Cell::from(crate::utils::format_duration(&t.duration)),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -185,7 +185,7 @@ fn render_playback_text(
                         &state.app_config.play_icon
                     },
                     if track.explicit {
-                        format!("{} (Explicit)", track.name)
+                        format!("{} 🅴", track.name)
                     } else {
                         track.name.clone()
                     }

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -185,7 +185,7 @@ fn render_playback_text(
                         &state.app_config.play_icon
                     },
                     if track.explicit {
-                        format!("{} 🅴", track.name)
+                        format!("{} (E)", track.name)
                     } else {
                         track.name.clone()
                     }

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -184,7 +184,11 @@ fn render_playback_text(
                     } else {
                         &state.app_config.play_icon
                     },
-                    track.name,
+                    if track.explicit {
+                        format!("{} (Explicit)", track.name)
+                    } else {
+                        track.name.clone()
+                    }
                 ),
                 ui.theme.playback_track(),
             ),


### PR DESCRIPTION
Fixes #96.

Adds `(Explicit)` to a track name if Spotify reports it as having explicit lyrics. This can make it easier to know if you're listening to the explicit version or the "radio" version of a song.

I originally tried to implement this functionality at the album level, using the `restrictions` field on [the Album API](https://developer.spotify.com/documentation/web-api/reference/get-an-album), but the `explicit` field was not populated in any of my tests. This seems to match the behavior of the spotify web interface, were there is no explicit marker at the album level, but there is one at the track level.

Question for @braheezy (author of #96) and @aome510: what are your thoughts on modifying the track title by appending the string `(Explicit)`? Spotify's web interface obviously handles this a bit differently, adding an `E` symbol, but I wasn't sure how to translate that to the spotify_player interface. Another possiblity could be to add another column in the track-list, populating the column with `E` for explicit tracks and leaving it blank for non-explicit tracks.

## Screenshots:

Explicit album track listing:
<img width="1552" alt="Screenshot 2023-10-22 at 8 28 10 PM" src="https://github.com/aome510/spotify-player/assets/38324289/0ee24555-6284-4fea-a666-b1cdac071fb0">

"Radio" album track listing:
<img width="1552" alt="Screenshot 2023-10-22 at 8 28 24 PM" src="https://github.com/aome510/spotify-player/assets/38324289/ac3477e5-df31-4be6-a773-d9c8a597d337">
