### PR TITLE
Support handling CLI commands without a running application instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,10 @@ You can run the application as a daemon by specifying the `-d` or `--daemon` opt
 
 For more details, run `spotify_player -h` or `spotify_player {command} -h`, in which `{command}` is a CLI command.
 
-**Note**: when using CLIs for the first time, you'll need to run `spotify_player authenticate` to authenticate the application and store cached credentials beforehand.
+**Notes**
+
+- When using the CLI for the first time, you'll need to run `spotify_player authenticate` to authenticate the application beforehand.
+- Under the hood, CLI command is handled by sending requests to a `spotify_player` client socket running on port `client_port`, [a general application configuration](https://github.com/aome510/spotify-player/blob/master/docs/config.md#general) with a default value of `8080`. If there is no running application's instance, a new client will be created upon handling the CLI commands, which increases the latency of the command.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -314,11 +314,7 @@ You can run the application as a daemon by specifying the `-d` or `--daemon` opt
 
 ### CLI Commands
 
-`spotify_player` offers several CLI commands to interact with **a running `spotify_player` instance**.
-
-Under the hood, the application handles a CLI command by sending requests to a `spotify_player` instance's client socket running on the `client_port` port, a general application configuration with a default value `8080`.
-
-Lists of CLI commands:
+`spotify_player` offers several CLI commands to interact with Spotify:
 
 - `get`: Get Spotify data (playlist/album/artist data, user's data, etc)
 - `playback`: Interact with the playback (start a playback, play-pause, next, etc)
@@ -328,6 +324,8 @@ Lists of CLI commands:
 - `playlist`: Playlist editing (new, delete, import, fork, etc)
 
 For more details, run `spotify_player -h` or `spotify_player {command} -h`, in which `{command}` is a CLI command.
+
+**Note**: when using CLIs for the first time, you'll need to run `spotify_player authenticate` to authenticate the application and store cached credentials beforehand.
 
 ## Commands
 

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -313,7 +313,8 @@ async fn handle_playback_request(
             )
         }
         Command::StartLikedTracks { limit, random } => {
-            let mut tracks = client.current_user_saved_tracks().await?;
+            let data = state.data.read();
+            let mut tracks = data.user_data.saved_tracks.values().collect::<Vec<_>>();
 
             if random {
                 let mut rng = rand::thread_rng();

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -419,8 +419,10 @@ async fn handle_playback_request(
             let client = client.clone();
             let state = state.clone();
             async move {
-                match client.handle_player_request(&state, player_request).await {
-                    Ok(()) => {
+                let playback = state.player.read().buffered_playback.clone();
+                match client.handle_player_request(player_request, playback).await {
+                    Ok(playback) => {
+                        state.player.write().buffered_playback = playback;
                         client.update_playback(&state);
                     }
                     Err(err) => {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -91,13 +91,11 @@ async fn init_spotify(
     }
 
     // request user data
-    if !is_daemon {
-        client_pub.send(event::ClientRequest::GetCurrentUser)?;
-        client_pub.send(event::ClientRequest::GetUserPlaylists)?;
-        client_pub.send(event::ClientRequest::GetUserFollowedArtists)?;
-        client_pub.send(event::ClientRequest::GetUserSavedAlbums)?;
-        client_pub.send(event::ClientRequest::GetUserSavedTracks)?;
-    }
+    client_pub.send(event::ClientRequest::GetCurrentUser)?;
+    client_pub.send(event::ClientRequest::GetUserPlaylists)?;
+    client_pub.send(event::ClientRequest::GetUserFollowedArtists)?;
+    client_pub.send(event::ClientRequest::GetUserSavedAlbums)?;
+    client_pub.send(event::ClientRequest::GetUserSavedTracks)?;
 
     Ok(())
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -201,7 +201,9 @@ async fn start_app(state: state::SharedState, is_daemon: bool) -> Result<()> {
         let client = client.clone();
         let state = state.clone();
         async move {
-            if let Err(err) = cli::start_socket(client, state).await {
+            if let Err(err) =
+                cli::start_socket(client, state.configs.app_config.client_port, Some(state)).await
+            {
                 tracing::warn!("Failed to run client socket for CLI: {err:#}");
             }
         }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -1,4 +1,5 @@
 pub use rspotify::model as rspotify_model;
+use rspotify::model::CurrentPlaybackContext;
 pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
 
 use crate::utils::{format_duration, map_join};

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -101,6 +101,7 @@ pub struct SimplifiedPlayback {
     pub is_playing: bool,
     pub repeat_state: rspotify_model::RepeatState,
     pub shuffle_state: bool,
+    pub mute_state: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -464,6 +465,20 @@ impl Playback {
 
                 Playback::URIs(ids, Some(rspotify_model::Offset::Uri(uri)))
             }
+        }
+    }
+}
+
+impl SimplifiedPlayback {
+    pub fn from_playback(p: &CurrentPlaybackContext) -> Self {
+        Self {
+            device_name: p.device.name.clone(),
+            device_id: p.device.id.clone(),
+            is_playing: p.is_playing,
+            volume: p.device.volume_percent,
+            repeat_state: p.repeat_state,
+            shuffle_state: p.shuffle_state,
+            mute_state: None,
         }
     }
 }

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -12,8 +12,6 @@ pub struct PlayerState {
     pub buffered_playback: Option<SimplifiedPlayback>,
 
     pub queue: Option<rspotify_model::CurrentUserQueue>,
-
-    pub mute_state: Option<u32>,
 }
 
 impl PlayerState {

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -17,37 +17,6 @@ pub struct PlayerState {
 }
 
 impl PlayerState {
-    /// gets the current playback state
-    ///
-    /// # Note
-    /// Because playback data stored inside the player state is buffered and cached,
-    /// this function tries to estimate the current playback based on the available state data.
-    pub fn current_playback(&self) -> Option<rspotify_model::CurrentPlaybackContext> {
-        let mut playback = self.playback.clone()?;
-
-        // update the playback's progress based on the `playback_last_updated_time`
-        playback.progress = playback.progress.map(|d| {
-            d + if playback.is_playing {
-                chrono::Duration::from_std(self.playback_last_updated_time.unwrap().elapsed())
-                    .unwrap()
-            } else {
-                chrono::Duration::zero()
-            }
-        });
-
-        // update the playback's metadata based on the `buffered_playback` metadata
-        if let Some(ref p) = self.buffered_playback {
-            playback.device.name = p.device_name.clone();
-            playback.device.id = p.device_id.clone();
-            playback.is_playing = p.is_playing;
-            playback.device.volume_percent = p.volume;
-            playback.repeat_state = p.repeat_state;
-            playback.shuffle_state = p.shuffle_state;
-        }
-
-        Some(playback)
-    }
-
     /// gets the current playing track
     pub fn current_playing_track(&self) -> Option<&rspotify_model::FullTrack> {
         match self.playback {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -96,15 +96,7 @@ pub fn render_playback_window(
             };
 
             if let Some(ref playback) = player.buffered_playback {
-                render_playback_text(
-                    frame,
-                    state,
-                    ui,
-                    metadata_rect,
-                    track,
-                    playback,
-                    player.mute_state,
-                );
+                render_playback_text(frame, state, ui, metadata_rect, track, playback);
             }
 
             let progress = std::cmp::min(
@@ -147,7 +139,6 @@ fn render_playback_text(
     rect: Rect,
     track: &rspotify_model::FullTrack,
     playback: &SimplifiedPlayback,
-    mute_state: Option<u32>,
 ) {
     // Construct a "styled" text (`playback_text`) from playback's data
     // based on a user-configurable format string (app_config.playback_format)
@@ -160,7 +151,7 @@ fn render_playback_text(
     let re = regex::Regex::new(r"\{.*?\}|\n").unwrap();
 
     // build the volume string (vol% when unmuted, old_vol% (muted) if currently muted)
-    let volume = match mute_state {
+    let volume = match playback.mute_state {
         Some(volume) => format!("{volume}% (muted)"),
         None => format!("{}%", playback.volume.unwrap_or_default()),
     };


### PR DESCRIPTION
Resolves #279 

## Changes
- initialize a new client and spawn a separate thread for handling CLI commands without a running `spotify_player` instance
- update CLI client code to support handling requests without the application's state
- move `mute_state` from `PlayerState` struct to `SimplifiedPlayback` struct

## Benchmarks

### Without a running instance

* `playback next`
```
$ time test_spotify_player playback next
________________________________________________________
Executed in    1.15 secs      fish           external
   usr time   28.03 millis    0.23 millis   27.80 millis
   sys time   18.36 millis    1.83 millis   16.54 millis
```
* `get key playback`

```
> time test_spotify_player get key playback
________________________________________________________
Executed in    1.27 secs      fish           external
   usr time   29.29 millis    0.25 millis   29.04 millis
   sys time   23.85 millis    2.13 millis   21.71 millis
```

## With a running instance

* `playback next`
```
> time test_spotify_player playback next
________________________________________________________
Executed in   14.94 millis    fish           external
   usr time    7.58 millis    0.19 millis    7.39 millis
   sys time    5.54 millis    1.54 millis    4.00 millis
```
* `get key playback`

```
> time test_spotify_player get key playback
________________________________________________________
Executed in   16.28 millis    fish           external
   usr time    7.54 millis    0.19 millis    7.35 millis
   sys time    5.90 millis    1.63 millis    4.27 millis
```
