### PR TITLE
Allow disabling notify when client is not streaming

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,8 +38,9 @@ All configuration files should be placed inside the application's configuration 
 | `cover_image_refresh_duration_in_ms` | the duration (in ms) between two cover image refreshes (`image` feature only) | `2000`                                                     |
 | `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)    | `20`                                                       |
 | `enable_media_control`               | enable application media control support (`media-control` feature only)       | `true` (Linux), `false` (Windows and MacOS)                |
-| `enable_streaming`                   | create a device for streaming (streaming feature only)                        | `Always`                                                   |
+| `enable_streaming`                   | create a device for streaming (`streaming` feature only)                      | `Always`                                                   |
 | `enable_cover_image_cache`           | store album's cover images in the cache folder                                | `true`                                                     |
+| `notify_streaming_only`              | only notify when client is streaming (`streaming` and `notify` feature only)  | `false`                                                    |
 | `default_device`                     | the default device to connect to on startup if no playing device found        | `spotify-player`                                           |
 | `play_icon`                          | the icon to indicate playing state of a Spotify item                          | `▶`                                                       |
 | `pause_icon`                         | the icon to indicate pause state of a Spotify item                            | `▌▌`                                                       |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -15,6 +15,7 @@ page_size_in_rows = 20
 enable_media_control = false
 enable_streaming = "Always"
 enable_cover_image_cache = true
+notify_streaming_only = false
 default_device = "spotify-player"
 play_icon = "▶"
 pause_icon = "▌▌"

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1334,7 +1334,15 @@ impl Client {
 
         // notify user about the playback's change if any
         #[cfg(feature = "notify")]
-        Self::notify_new_track(track, &path, state)?;
+        {
+            #[cfg(feature = "streaming")]
+            if !state.configs.app_config.notify_streaming_only || self.stream_conn.lock().is_some()
+            {
+                Self::notify_new_track(track, &path, state)?;
+            }
+            #[cfg(not(feature = "streaming"))]
+            Self::notify_new_track(track, &path, state)?;
+        }
 
         Ok(())
     }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -77,6 +77,9 @@ pub struct AppConfig {
     pub default_device: String,
 
     pub device: DeviceConfig,
+
+    #[cfg(all(feature = "streaming", feature = "notify"))]
+    pub notify_streaming_only: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -246,6 +249,8 @@ impl Default for AppConfig {
             default_device: "spotify-player".to_string(),
 
             device: DeviceConfig::default(),
+
+            notify_streaming_only: false,
         }
     }
 }


### PR DESCRIPTION
Added `notify_streaming_only` config option. When true, client only sends notification if it has streaming connection.

Coupled with `enable_streaming` set to `DaemonOnly`, this prevents duplicate notifications from being sent when both daemon and UI to control it are running.