### PR TITLE
Cache user's data into files (liked tracks, saved albums, followed artists, etc)

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -272,14 +272,18 @@ impl Client {
             }
             ClientRequest::GetUserPlaylists => {
                 let playlists = self.current_user_playlists().await?;
-                store_data_into_cache("user_playlists", &state.configs.cache_folder, &playlists)
-                    .context("store user's playlists into the cache folder")?;
+                store_data_into_file_cache(
+                    FileCacheKey::Playlists,
+                    &state.configs.cache_folder,
+                    &playlists,
+                )
+                .context("store user's playlists into the cache folder")?;
                 state.data.write().user_data.playlists = playlists;
             }
             ClientRequest::GetUserFollowedArtists => {
                 let artists = self.current_user_followed_artists().await?;
-                store_data_into_cache(
-                    "user_followed_artists",
+                store_data_into_file_cache(
+                    FileCacheKey::FollowedArtists,
                     &state.configs.cache_folder,
                     &artists,
                 )
@@ -288,8 +292,12 @@ impl Client {
             }
             ClientRequest::GetUserSavedAlbums => {
                 let albums = self.current_user_saved_albums().await?;
-                store_data_into_cache("user_saved_albums", &state.configs.cache_folder, &albums)
-                    .context("store user's saved albums into the cache folder")?;
+                store_data_into_file_cache(
+                    FileCacheKey::SavedAlbums,
+                    &state.configs.cache_folder,
+                    &albums,
+                )
+                .context("store user's saved albums into the cache folder")?;
                 state.data.write().user_data.saved_albums = albums;
             }
             ClientRequest::GetUserTopTracks => {
@@ -312,8 +320,12 @@ impl Client {
                     .iter()
                     .map(|t| (t.id.uri(), t.clone()))
                     .collect::<HashMap<_, _>>();
-                store_data_into_cache("user_saved_tracks", &state.configs.cache_folder, &tracks_hm)
-                    .context("store user's saved tracks into the cache folder")?;
+                store_data_into_file_cache(
+                    FileCacheKey::SavedTracks,
+                    &state.configs.cache_folder,
+                    &tracks_hm,
+                )
+                .context("store user's saved tracks into the cache folder")?;
 
                 let mut data = state.data.write();
                 data.user_data.saved_tracks = tracks_hm;

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -238,7 +238,7 @@ impl Client {
                         .write()
                         .caches
                         .lyrics
-                        .insert(query, result, *CACHE_DURATION);
+                        .insert(query, result, *TTL_CACHE_DURATION);
                 }
             }
             ClientRequest::ConnectDevice(id) => {
@@ -310,7 +310,7 @@ impl Client {
                             tracks,
                             desc: "User's top tracks".to_string(),
                         },
-                        *CACHE_DURATION,
+                        *TTL_CACHE_DURATION,
                     );
                 }
             }
@@ -335,7 +335,7 @@ impl Client {
                         tracks,
                         desc: "User's liked tracks".to_string(),
                     },
-                    *CACHE_DURATION,
+                    *TTL_CACHE_DURATION,
                 );
             }
             ClientRequest::GetUserRecentlyPlayedTracks => {
@@ -348,7 +348,7 @@ impl Client {
                             tracks,
                             desc: "User's recently played tracks".to_string(),
                         },
-                        *CACHE_DURATION,
+                        *TTL_CACHE_DURATION,
                     );
                 }
             }
@@ -373,7 +373,7 @@ impl Client {
                         .write()
                         .caches
                         .context
-                        .insert(uri, context, *CACHE_DURATION);
+                        .insert(uri, context, *TTL_CACHE_DURATION);
                 }
             }
             ClientRequest::Search(query) => {
@@ -385,7 +385,7 @@ impl Client {
                         .write()
                         .caches
                         .search
-                        .insert(query, results, *CACHE_DURATION);
+                        .insert(query, results, *TTL_CACHE_DURATION);
                 }
             }
             ClientRequest::GetRadioTracks {
@@ -402,7 +402,7 @@ impl Client {
                             tracks,
                             desc: format!("{name} Radio"),
                         },
-                        *CACHE_DURATION,
+                        *TTL_CACHE_DURATION,
                     );
                 }
             }
@@ -1357,7 +1357,7 @@ impl Client {
                 .write()
                 .caches
                 .images
-                .insert(url.to_owned(), image, *CACHE_DURATION);
+                .insert(url.to_owned(), image, *TTL_CACHE_DURATION);
         }
 
         // notify user about the playback's change if any

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -327,7 +327,7 @@ fn main() -> Result<()> {
             // log the application's configurations
             tracing::info!("Configurations: {:?}", configs);
 
-            let state = std::sync::Arc::new(state::State::new(configs));
+            let state = std::sync::Arc::new(state::State::new(configs)?);
 
             #[cfg(feature = "daemon")]
             {

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -15,8 +15,8 @@ pub enum FileCacheKey {
     SavedTracks,
 }
 
-// cache duration, which is default to be 3h
-pub static CACHE_DURATION: Lazy<std::time::Duration> =
+/// default time-to-live cache duration
+pub static TTL_CACHE_DURATION: Lazy<std::time::Duration> =
     Lazy::new(|| std::time::Duration::from_secs(60 * 60 * 3));
 
 /// the application's data
@@ -47,6 +47,7 @@ pub struct MemoryCaches {
 }
 
 #[derive(Default, Debug)]
+/// Spotify browse data
 pub struct BrowseData {
     pub categories: Vec<Category>,
     pub category_playlists: HashMap<String, Vec<Playlist>>,

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Write, path::Path};
 
 use once_cell::sync::Lazy;
+use serde::Serialize;
 
 use super::model::*;
 
@@ -87,4 +88,18 @@ impl UserData {
     pub fn is_liked_track(&self, track: &Track) -> bool {
         self.saved_tracks.contains_key(&track.id.uri())
     }
+}
+
+pub fn store_data_into_cache<T: Serialize>(
+    name: &str,
+    cache_folder: &Path,
+    data: &T,
+) -> std::io::Result<()> {
+    let path = cache_folder.join(name);
+    let mut f = std::fs::File::create(path)?;
+
+    let data = serde_json::to_string(&data)?;
+    f.write_all(data.as_bytes())?;
+
+    Ok(())
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -48,7 +48,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(configs: Configs) -> Self {
+    pub fn new(configs: Configs) -> Result<Self> {
         let mut ui = UIState::default();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {
@@ -56,11 +56,13 @@ impl State {
             ui.theme = theme;
         }
 
-        Self {
+        let app_data = AppData::new(&configs.cache_folder)?;
+
+        Ok(Self {
             configs,
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
-            data: RwLock::new(AppData::new(&configs.cache_folder)),
-        }
+            data: RwLock::new(app_data),
+        })
     }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -60,7 +60,7 @@ impl State {
             configs,
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
-            data: RwLock::new(AppData::default()),
+            data: RwLock::new(AppData::new(&configs.cache_folder)),
         }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -2,8 +2,8 @@ pub use rspotify::model as rspotify_model;
 use rspotify::model::CurrentPlaybackContext;
 pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
 
-use crate::utils::{format_duration, map_join};
-use serde::Serialize;
+use crate::utils::map_join;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 #[derive(Serialize, Clone, Debug)]
@@ -112,28 +112,20 @@ pub struct Device {
     pub name: String,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify track
 pub struct Track {
     pub id: TrackId<'static>,
     pub name: String,
     pub artists: Vec<Artist>,
     pub album: Option<Album>,
-    #[serde(serialize_with = "serialize_duration")]
-    pub duration: chrono::Duration,
+    pub duration: std::time::Duration,
     pub explicit: bool,
     #[serde(skip)]
     pub added_at: u64,
 }
 
-pub fn serialize_duration<S>(dur: &chrono::Duration, s: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    s.serialize_str(&format_duration(dur))
-}
-
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify album
 pub struct Album {
     pub id: AlbumId<'static>,
@@ -142,14 +134,14 @@ pub struct Album {
     pub artists: Vec<Artist>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify artist
 pub struct Artist {
     pub id: ArtistId<'static>,
     pub name: String,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify playlist
 pub struct Playlist {
     pub id: PlaylistId<'static>,
@@ -265,7 +257,7 @@ impl Track {
                 name: track.name,
                 artists: from_simplified_artists_to_artists(track.artists),
                 album: None,
-                duration: track.duration,
+                duration: track.duration.to_std().expect("valid chrono duration"),
                 explicit: track.explicit,
                 added_at: 0,
             })
@@ -286,7 +278,7 @@ impl Track {
                 name: track.name,
                 artists: from_simplified_artists_to_artists(track.artists),
                 album: Album::try_from_simplified_album(track.album),
-                duration: track.duration,
+                duration: track.duration.to_std().expect("valid chrono duration"),
                 explicit: track.explicit,
                 added_at: 0,
             })

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -722,7 +722,11 @@ pub fn render_track_table_window(
                 Cell::from(t.display_name()),
                 Cell::from(t.artists_info()),
                 Cell::from(t.album_info()),
-                Cell::from(crate::utils::format_duration(&t.duration)),
+                Cell::from(format!(
+                    "{}:{:02}",
+                    t.duration.as_secs() / 60,
+                    t.duration.as_secs() % 60,
+                )),
             ])
             .style(style)
         })

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -320,11 +320,12 @@ pub fn render_queue_popup(
     rect: Rect,
 ) {
     use rspotify::model::{FullEpisode, FullTrack, PlayableItem};
-    fn get_playable_name(item: &PlayableItem) -> &str {
+    fn get_playable_name(item: &PlayableItem) -> String {
         match item {
             PlayableItem::Track(FullTrack { ref name, .. }) => name,
             PlayableItem::Episode(FullEpisode { ref name, .. }) => name,
         }
+        .to_string()
     }
     fn get_playable_artists(item: &PlayableItem) -> String {
         match item {
@@ -372,9 +373,9 @@ pub fn render_queue_popup(
                 .map(|(i, x)| {
                     Row::new(vec![
                         Cell::from(format!("{}", i + 1)),
-                        Cell::from(get_playable_name(x).to_string()),
-                        Cell::from(get_playable_artists(x).to_string()),
-                        Cell::from(get_playable_duration(x).to_string()),
+                        Cell::from(get_playable_name(x)),
+                        Cell::from(get_playable_artists(x)),
+                        Cell::from(get_playable_duration(x)),
                     ])
                 })
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
Resolves #291 
Resolves #235 

- implement `store_data_into_file_cache` to save user's data into a file upon receiving Spotify API's response
- implement `load_data_from_file_cache` to load user's data from a file upon initializing the application's state
- and other small code improvements