### PR TITLE
Support open spotify link

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,19 +22,19 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             container: rust
-            dependencies: "libssl-dev libasound2-dev libdbus-1-dev"
+            dependencies: "libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             container: rustembedded/cross:aarch64-unknown-linux-gnu
             cross_arch: "arm64"
             pkg_config_path: "/usr/lib/aarch64-linux-gnu/pkgconfig/"
-            dependencies: "libssl-dev:arm64 libasound2-dev:arm64 libdbus-1-dev:arm64"
+            dependencies: "libssl-dev:arm64 libasound2-dev:arm64 libdbus-1-dev:arm64 libxcb-shape0-dev:arm64 libxcb-xfixes0-dev:arm64"
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
             cross_arch: "armhf"
             pkg_config_path: "/usr/lib/arm-linux-gnueabihf/pkgconfig/"
             container: rustembedded/cross:armv7-unknown-linux-gnueabihf
-            dependencies: "libssl-dev:armhf libasound2-dev:armhf libdbus-1-dev:armhf"
+            dependencies: "libssl-dev:armhf libasound2-dev:armhf libdbus-1-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev
+        run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev
         if: ${{ runner.os == 'Linux' }}
 
       - name: Checkout source

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "clipboard"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
+dependencies = [
+ "clipboard-win",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "x11-clipboard",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,6 +3925,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
+ "clipboard",
  "config_parser2",
  "crossterm 0.27.0",
  "daemonize",
@@ -5014,6 +5037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11-clipboard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
+dependencies = [
+ "xcb",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5022,6 +5054,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xcb"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ List of supported commands:
 | `SearchPage`                   | go to the search page                                                   | `g s`              |
 | `BrowsePage`                   | go to the browse page                                                   | `g b`              |
 | `PreviousPage`                 | go to the previous page                                                 | `backspace`, `C-q` |
+| `OpenSpotifyLinkFromClipboard` | open a Spotify link from clipboard                                      | `O`                |
 | `SortTrackByTitle`             | sort the track table (if any) by track's title                          | `s t`              |
 | `SortTrackByArtists`           | sort the track table (if any) by track's artists                        | `s a`              |
 | `SortTrackByAlbum`             | sort the track table (if any) by track's album                          | `s A`              |

--- a/README.md
+++ b/README.md
@@ -93,14 +93,10 @@ A Spotify Premium account is **required**.
 ##### Linux
 
 - [Rust and cargo](https://www.rust-lang.org/tools/install) as the build dependencies
-- `openssl`, `alsa-lib` (`streaming` feature), `libdbus` (`media-control` feature) system libraries.
-  - On Debian based systems, run the below command to install application's dependencies:
+- install `openssl`, `alsa-lib` (`streaming` feature), `libdbus` (`media-control` feature), `libxcb` system libraries.
+  - For example, on Debian based systems, run the below command to install application's dependencies:
     ```shell
-    sudo apt install libssl-dev libasound2-dev libdbus-1-dev
-    ```
-  - On Fedora based systems, run the below command to install application's dependencies:
-    ```shell
-    sudo yum install openssl-devel alsa-lib-devel dbus-devel
+    sudo apt install libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev
     ```
 
 ### Binaries
@@ -386,8 +382,8 @@ List of supported commands:
 | `SortTrackByTitle`             | sort the track table (if any) by track's title                          | `s t`              |
 | `SortTrackByArtists`           | sort the track table (if any) by track's artists                        | `s a`              |
 | `SortTrackByAlbum`             | sort the track table (if any) by track's album                          | `s A`              |
-| `SortTrackByDuration`          | sort the track table (if any) by track's duration                       | `s d`              |
 | `SortTrackByAddedDate`         | sort the track table (if any) by track's added date                     | `s D`              |
+| `SortTrackByDuration`          | sort the track table (if any) by track's duration                       | `s d`              |
 | `ReverseOrder`                 | reverse the order of the track table (if any)                           | `s r`              |
 | `MovePlaylistItemUp`           | move playlist item up one position                                      | `C-k`              |
 | `MovePlaylistItemDown`         | move playlist item down one position                                    | `C-j`              |

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -46,6 +46,7 @@ once_cell = "1.18.0"
 regex = "1.9.6"
 daemonize = { version = "0.5.0", optional = true }
 ttl_cache = "0.5.1"
+clipboard = "0.5.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.44"

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -62,6 +62,7 @@ pub enum Command {
     SearchPage,
     BrowsePage,
     PreviousPage,
+    OpenSpotifyLinkFromClipboard,
 
     SortTrackByTitle,
     SortTrackByArtists,
@@ -198,6 +199,7 @@ impl Command {
             Self::SearchPage => "go to the search page",
             Self::BrowsePage => "go to the browse page",
             Self::PreviousPage => "go to the previous page",
+            Self::OpenSpotifyLinkFromClipboard => "open a Spotify link from clipboard",
             Self::SortTrackByTitle => "sort the track table (if any) by track's title",
             Self::SortTrackByArtists => "sort the track table (if any) by track's artists",
             Self::SortTrackByAlbum => "sort the track table (if any) by track's album",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -183,6 +183,10 @@ impl Default for KeymapConfig {
                     command: Command::PreviousPage,
                 },
                 Keymap {
+                    key_sequence: "O".into(),
+                    command: Command::OpenSpotifyLinkFromClipboard,
+                },
+                Keymap {
                     key_sequence: "?".into(),
                     command: Command::OpenCommandHelp,
                 },

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -7,7 +7,8 @@ use crate::{
 
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
+use clipboard::{ClipboardContext, ClipboardProvider};
 
 mod page;
 mod popup;
@@ -360,7 +361,52 @@ fn handle_global_command(
             }
         }
         Command::OpenSpotifyLinkFromClipboard => {
-            todo!()
+            let content = get_clipboard_content().context("get clipboard's content")?;
+            let re = regex::Regex::new(
+                r"https://open.spotify.com/(?P<type>.*?)/(?P<id>[[:alnum:]]*).*",
+            )?;
+            if let Some(cap) = re.captures(&content) {
+                let typ = cap.name("type").expect("valid capture").as_str();
+                let id = cap.name("id").expect("valid capture").as_str();
+                match typ {
+                    // for track link, play the song
+                    "track" => {
+                        let id = TrackId::from_id(id)?.into_static();
+                        client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                            Playback::URIs(vec![id], None),
+                            None,
+                        )))?;
+                    }
+                    // for playlist/artist/album link, go to the corresponding context page
+                    "playlist" => {
+                        let id = PlaylistId::from_id(id)?.into_static();
+                        ui.create_new_page(PageState::Context {
+                            id: None,
+                            context_page_type: ContextPageType::Browsing(ContextId::Playlist(id)),
+                            state: None,
+                        });
+                    }
+                    "artist" => {
+                        let id = ArtistId::from_id(id)?.into_static();
+                        ui.create_new_page(PageState::Context {
+                            id: None,
+                            context_page_type: ContextPageType::Browsing(ContextId::Artist(id)),
+                            state: None,
+                        });
+                    }
+                    "album" => {
+                        let id = AlbumId::from_id(id)?.into_static();
+                        ui.create_new_page(PageState::Context {
+                            id: None,
+                            context_page_type: ContextPageType::Browsing(ContextId::Album(id)),
+                            state: None,
+                        });
+                    }
+                    e => anyhow::bail!("unsupported Spotify type {e}!"),
+                }
+            } else {
+                tracing::warn!("clipboard's content ({content}) is not a valid Spotify link!");
+            }
         }
         #[cfg(feature = "lyric-finder")]
         Command::LyricPage => {
@@ -414,4 +460,16 @@ fn handle_global_command(
         _ => return Ok(false),
     }
     Ok(true)
+}
+
+fn get_clipboard_content() -> Result<String> {
+    let mut clipboard_ctx: ClipboardContext = match ClipboardProvider::new() {
+        Ok(ctx) => ctx,
+        Err(err) => anyhow::bail!("{err:#}"),
+    };
+    let content = match clipboard_ctx.get_contents() {
+        Ok(content) => content,
+        Err(err) => anyhow::bail!("{err:#}"),
+    };
+    Ok(content)
 }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -359,6 +359,9 @@ fn handle_global_command(
                 ui.popup = None;
             }
         }
+        Command::OpenSpotifyLinkFromClipboard => {
+            todo!()
+        }
         #[cfg(feature = "lyric-finder")]
         Command::LyricPage => {
             if let Some(track) = state.player.read().current_playing_track() {


### PR DESCRIPTION
Resolves #218 

This PR adds support for opening track/playlist/album/artist Spotify link from `spotify_player` by calling `OpenSpotifyLinkFromClipboard` command. The application will
- open a corresponding context page for playlist/album/artist link
- play the song for track link

## Changes
- add `clipboard` crate as a dependency
- add `OpenSpotifyLinkFromClipboard` command (default keymap: `O`)