### PR TITLE
fix warnings when building without any features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,14 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Cargo clippy
+      - name: Cargo clippy with all features
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --no-default-features --features ${{ env.RUST_FEATURES }} -- -D warnings
+
+      - name: Cargo clippy without features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-default-features -- -D warnings

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -58,6 +58,9 @@ impl Client {
         }
     }
 
+    // unused variables:
+    // - `state` when the `streaming` feature is not enabled
+    #[allow(unused_variables)]
     pub async fn new_session(&self, state: &SharedState) -> Result<()> {
         let session = crate::auth::new_session(&self.spotify.auth_config, false).await?;
         *self.spotify.session.lock().await = Some(session);
@@ -126,12 +129,15 @@ impl Client {
         match request {
             PlayerRequest::NextTrack => self.spotify.next_track(device_id).await?,
             PlayerRequest::PreviousTrack => self.spotify.previous_track(device_id).await?,
+            #[cfg(feature = "media-control")]
             PlayerRequest::Resume => {
                 if !playback.is_playing {
                     self.spotify.resume_playback(device_id, None).await?;
                     playback.is_playing = true;
                 }
             }
+
+            #[cfg(feature = "media-control")]
             PlayerRequest::Pause => {
                 if playback.is_playing {
                     self.spotify.pause_playback(device_id).await?;

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -7,7 +7,9 @@ use crate::{
 
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
-use anyhow::{Context as _, Result};
+#[cfg(feature = "clipboard")]
+use anyhow::Context as _;
+use anyhow::Result;
 #[cfg(feature = "clipboard")]
 use copypasta::{ClipboardContext, ClipboardProvider};
 
@@ -20,7 +22,9 @@ mod window;
 pub enum PlayerRequest {
     NextTrack,
     PreviousTrack,
+    #[cfg(feature = "media-control")]
     Resume,
+    #[cfg(feature = "media-control")]
     Pause,
     ResumePause,
     SeekTrack(chrono::Duration),

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -67,6 +67,9 @@ fn init_app_cli_arguments() -> Result<clap::ArgMatches> {
     Ok(cmd.get_matches())
 }
 
+// unused variables:
+// - `is_daemon` when the `streaming` feature is not enabled
+#[allow(unused_variables)]
 async fn init_spotify(
     client_pub: &flume::Sender<event::ClientRequest>,
     client: &client::Client,


### PR DESCRIPTION
- fix warnings when building with `--no-default-features`
- update `ci.yaml` to add a step to check `cargo clippy --no-default-features`