### PR TITLE
Fix memory leak issue when rendering images in `iTerm2`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -21,38 +21,37 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify_player` uses `app.toml` to configure general application configurations:
 
-| Option                               | Description                                                                              | Default                                                    |
-| ------------------------------------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `client_id`                          | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                         |
-| `client_port`                        | the port that the application's client is running on to handle CLI commands              | `8080`                                                     |
-| `tracks_playback_limit`              | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                       |
-| `playback_format`                    | the format of the text in the playback's window                                          | `{track} • {artists}\n{album}\n{metadata}`                 |
-| `notify_format`                      | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }`    |
-| `copy_command`                       | the command used to execute a copy-to-clipboard action                                   | `xclip -sel c` (Linux), `pbcopy` (MacOS), `clip` (Windows) |
-| `player_event_hook_command`          | the hook command executed when there is a new player event                               | `None`                                                     |
-| `ap_port`                            | the application's Spotify session connection port                                        | `None`                                                     |
-| `proxy`                              | the application's Spotify session connection proxy                                       | `None`                                                     |
-| `theme`                              | the application's theme                                                                  | `default`                                                  |
-| `app_refresh_duration_in_ms`         | the duration (in ms) between two consecutive application refreshes                       | `32`                                                       |
-| `playback_refresh_duration_in_ms`    | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                        |
-| `cover_image_refresh_duration_in_ms` | the duration (in ms) between two cover image refreshes (`image` feature only)            | `2000`                                                     |
-| `page_size_in_rows`                  | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                       |
-| `enable_media_control`               | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)                |
-| `enable_streaming`                   | enable streaming (`streaming` feature only)                                              | `Always`                                                   |
-| `enable_notify`                      | enable notification (`notify` feature only)                                              | `true`                                                     |
-| `enable_cover_image_cache`           | store album's cover images in the cache folder                                           | `true`                                                     |
-| `notify_streaming_only`              | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                    |
-| `default_device`                     | the default device to connect to on startup if no playing device found                   | `spotify-player`                                           |
-| `play_icon`                          | the icon to indicate playing state of a Spotify item                                     | `▶`                                                       |
-| `pause_icon`                         | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                       |
-| `liked_icon`                         | the icon to indicate the liked state of a song                                           | `♥`                                                       |
-| `border_type`                        | the type of the application's borders                                                    | `Plain`                                                    |
-| `progress_bar_type`                  | the type of the playback progress bar                                                    | `Rectangle`                                                |
-| `playback_window_position`           | the position of the playback window                                                      | `Top`                                                      |
-| `playback_window_width`              | the width of the playback window                                                         | `6`                                                        |
-| `cover_img_width`                    | the width of the cover image (`image` feature only)                                      | `5`                                                        |
-| `cover_img_length`                   | the length of the cover image (`image` feature only)                                     | `9`                                                        |
-| `cover_img_scale`                    | the scale of the cover image (`image` feature only)                                      | `1.0`                                                      |
+| Option                            | Description                                                                              | Default                                                    |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                         |
+| `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                     |
+| `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                       |
+| `playback_format`                 | the format of the text in the playback's window                                          | `{track} • {artists}\n{album}\n{metadata}`                 |
+| `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }`    |
+| `copy_command`                    | the command used to execute a copy-to-clipboard action                                   | `xclip -sel c` (Linux), `pbcopy` (MacOS), `clip` (Windows) |
+| `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                     |
+| `ap_port`                         | the application's Spotify session connection port                                        | `None`                                                     |
+| `proxy`                           | the application's Spotify session connection proxy                                       | `None`                                                     |
+| `theme`                           | the application's theme                                                                  | `default`                                                  |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes                       | `32`                                                       |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                        |
+| `page_size_in_rows`               | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                       |
+| `enable_media_control`            | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)                |
+| `enable_streaming`                | enable streaming (`streaming` feature only)                                              | `Always`                                                   |
+| `enable_notify`                   | enable notification (`notify` feature only)                                              | `true`                                                     |
+| `enable_cover_image_cache`        | store album's cover images in the cache folder                                           | `true`                                                     |
+| `notify_streaming_only`           | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                    |
+| `default_device`                  | the default device to connect to on startup if no playing device found                   | `spotify-player`                                           |
+| `play_icon`                       | the icon to indicate playing state of a Spotify item                                     | `▶`                                                       |
+| `pause_icon`                      | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                       |
+| `liked_icon`                      | the icon to indicate the liked state of a song                                           | `♥`                                                       |
+| `border_type`                     | the type of the application's borders                                                    | `Plain`                                                    |
+| `progress_bar_type`               | the type of the playback progress bar                                                    | `Rectangle`                                                |
+| `playback_window_position`        | the position of the playback window                                                      | `Top`                                                      |
+| `playback_window_width`           | the width of the playback window                                                         | `6`                                                        |
+| `cover_img_width`                 | the width of the cover image (`image` feature only)                                      | `5`                                                        |
+| `cover_img_length`                | the length of the cover image (`image` feature only)                                     | `9`                                                        |
+| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                      | `1.0`                                                      |
 
 ### Notes
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -10,7 +10,6 @@ notify_format = { summary = "{track} • {artists}", body = "{album}" }
 # copy_command = { command = "clip", args = [] } # windows
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
-cover_image_refresh_duration_in_ms = 2000
 page_size_in_rows = 20
 enable_media_control = false
 enable_streaming = "Always"

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -41,8 +41,6 @@ pub struct AppConfig {
     // duration configs
     pub app_refresh_duration_in_ms: u64,
     pub playback_refresh_duration_in_ms: u64,
-    #[cfg(feature = "image")]
-    pub cover_image_refresh_duration_in_ms: u64,
 
     pub page_size_in_rows: usize,
 
@@ -209,9 +207,6 @@ impl Default for AppConfig {
             ap_port: None,
             app_refresh_duration_in_ms: 32,
             playback_refresh_duration_in_ms: 0,
-
-            #[cfg(feature = "image")]
-            cover_image_refresh_duration_in_ms: 2000,
 
             page_size_in_rows: 20,
 

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -25,7 +25,7 @@ pub struct UIState {
     pub playback_progress_bar_rect: tui::layout::Rect,
 
     #[cfg(feature = "image")]
-    pub last_cover_image_render_info: Option<(String, std::time::Instant)>,
+    pub last_cover_image_render_info: Option<(String, tui::layout::Rect)>,
 }
 
 impl UIState {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -15,6 +15,8 @@ pub fn run(state: SharedState) -> Result<()> {
 
     let ui_refresh_duration =
         std::time::Duration::from_millis(state.configs.app_config.app_refresh_duration_in_ms);
+    let mut last_terminal_size = None;
+
     loop {
         {
             let mut ui = state.ui.lock();
@@ -23,12 +25,35 @@ pub fn run(state: SharedState) -> Result<()> {
                 std::process::exit(0);
             }
 
-            if let Err(err) = terminal.draw(|frame| {
-                // set the background and foreground colors for the application
-                let block = Block::default().style(ui.theme.app_style());
-                frame.render_widget(block, frame.size());
+            let terminal_size = terminal.size()?;
+            if Some(terminal_size) != last_terminal_size {
+                last_terminal_size = Some(terminal_size);
+                #[cfg(feature = "image")]
+                {
+                    // redraw the cover image when the terminal's size changes
+                    ui.last_cover_image_render_info = None;
+                }
+            }
 
-                if let Err(err) = render_application(frame, &state, &mut ui, frame.size()) {
+            if let Err(err) = terminal.draw(|frame| {
+                #[cfg(feature = "image")]
+                {
+                    for x in 1..state.configs.app_config.cover_img_length + 1 {
+                        for y in 1..state.configs.app_config.cover_img_width + 1 {
+                            frame
+                                .buffer_mut()
+                                .get_mut(x as u16, y as u16)
+                                .set_skip(true);
+                        }
+                    }
+                }
+
+                // set the background and foreground colors for the application
+                let rect = frame.size();
+                let block = Block::default().style(ui.theme.app_style());
+                frame.render_widget(block, rect);
+
+                if let Err(err) = render_application(frame, &state, &mut ui, rect) {
                     tracing::error!("Failed to render the application: {err:#}");
                 }
             }) {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -101,12 +101,25 @@ pub fn render_playback_window(
             tracing::warn!("Got a non-track playable item: {:?}", playback.item);
         }
     } else {
-        // Previously rendered image can result in weird rendering text,
-        // clear the widget area before rendering the text.
+        // Previously rendered image can result in a weird rendering text,
+        // clear the previous widget's area before rendering the text.
         #[cfg(feature = "image")]
-        if ui.last_cover_image_render_info.is_some() {
-            frame.render_widget(Clear, rect);
-            ui.last_cover_image_render_info = None;
+        {
+            if ui.last_cover_image_render_info.is_some() {
+                frame.render_widget(Clear, rect);
+                ui.last_cover_image_render_info = None;
+            }
+
+            // reset the `skip` state of cells in cover image area
+            // to render the "No playback found" message
+            for x in 1..state.configs.app_config.cover_img_length + 1 {
+                for y in 1..state.configs.app_config.cover_img_width + 1 {
+                    frame
+                        .buffer_mut()
+                        .get_mut(x as u16, y as u16)
+                        .set_skip(false);
+                }
+            }
         }
 
         frame.render_widget(


### PR DESCRIPTION
Resolves #318 

## Changes
- remove `cover_image_refresh_duration_in_ms` config option
- update image rendering logic to only trigger when the state changes (previously render periodically)