### PR TITLE
Add custom text input widget with cursor, to use in search page

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     command::{self, Command},
     key::{Key, KeySequence},
     state::*,
+    ui::single_line_input::LineInput,
     utils::new_list_state,
 };
 
@@ -344,7 +345,7 @@ fn handle_global_command(
         }
         Command::SearchPage => {
             ui.create_new_page(PageState::Search {
-                input: String::new(),
+                line_input: LineInput::default(),
                 current_query: String::new(),
                 state: SearchPageUIState::new(),
             });

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -278,7 +278,7 @@ fn main() -> Result<()> {
             // log the application's configurations
             tracing::info!("Configurations: {:?}", configs);
 
-            let state = std::sync::Arc::new(state::State::new(configs)?);
+            let state = std::sync::Arc::new(state::State::new(configs));
 
             #[cfg(feature = "daemon")]
             {

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -67,12 +67,12 @@ impl MemoryCaches {
 }
 
 impl AppData {
-    pub fn new(cache_folder: &Path) -> anyhow::Result<Self> {
-        Ok(Self {
-            user_data: UserData::new_from_file_caches(cache_folder)?,
+    pub fn new(cache_folder: &Path) -> Self {
+        Self {
+            user_data: UserData::new_from_file_caches(cache_folder),
             caches: MemoryCaches::new(),
             browse: BrowseData::default(),
-        })
+        }
     }
 
     pub fn get_tracks_by_id_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
@@ -89,8 +89,8 @@ impl AppData {
 
 impl UserData {
     /// constructs a new user data based on file caches
-    pub fn new_from_file_caches(cache_folder: &Path) -> anyhow::Result<Self> {
-        Ok(Self {
+    pub fn new_from_file_caches(cache_folder: &Path) -> Self {
+        Self {
             user: None,
             playlists: load_data_from_file_cache(FileCacheKey::Playlists, cache_folder)
                 .unwrap_or_default(),
@@ -103,7 +103,7 @@ impl UserData {
                 .unwrap_or_default(),
             saved_tracks: load_data_from_file_cache(FileCacheKey::SavedTracks, cache_folder)
                 .unwrap_or_default(),
-        })
+        }
     }
 
     /// returns a list of playlists that are **possibly** modifiable by user

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -48,7 +48,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(configs: Configs) -> Result<Self> {
+    pub fn new(configs: Configs) -> Self {
         let mut ui = UIState::default();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {
@@ -56,13 +56,13 @@ impl State {
             ui.theme = theme;
         }
 
-        let app_data = AppData::new(&configs.cache_folder)?;
+        let app_data = AppData::new(&configs.cache_folder);
 
-        Ok(Self {
+        Self {
             configs,
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(app_data),
-        })
+        }
     }
 }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -1,4 +1,4 @@
-use crate::{state::model::*, utils};
+use crate::{state::model::*, ui::single_line_input::LineInput, utils};
 use tui::widgets::{ListState, TableState};
 
 #[derive(Clone, Debug)]
@@ -12,7 +12,7 @@ pub enum PageState {
         state: Option<ContextPageUIState>,
     },
     Search {
-        input: String,
+        line_input: LineInput,
         current_query: String,
         state: SearchPageUIState,
     },

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -7,6 +7,7 @@ type Terminal = tui::Terminal<tui::backend::CrosstermBackend<std::io::Stdout>>;
 mod page;
 mod playback;
 mod popup;
+pub mod single_line_input;
 mod utils;
 
 /// run the application UI

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -16,12 +16,12 @@ pub fn render_search_page(
     // 1. Get the data
     let data = state.data.read();
 
-    let (focus_state, current_query, input) = match ui.current_page() {
+    let (focus_state, current_query, line_input) = match ui.current_page() {
         PageState::Search {
             state,
             current_query,
-            input,
-        } => (state.focus, current_query, input),
+            line_input,
+        } => (state.focus, current_query, line_input),
         s => anyhow::bail!("expect a search page state, found {s:?}"),
     };
 
@@ -149,10 +149,7 @@ pub fn render_search_page(
     // 4. Render the page's widgets
     // Render the query input box
     frame.render_widget(
-        Paragraph::new(input.clone()).style(
-            ui.theme
-                .selection_style(is_active && focus_state == SearchFocusState::Input),
-        ),
+        line_input.widget(is_active && focus_state == SearchFocusState::Input),
         search_input_rect,
     );
 

--- a/spotify_player/src/ui/single_line_input.rs
+++ b/spotify_player/src/ui/single_line_input.rs
@@ -10,8 +10,6 @@ pub struct LineInput {
     // cursor. Otherwise, you have to shuffle back and forth between String and String::chars().
     line: Vec<char>,
     cursor: u16,
-    style: Style,
-    cursor_line_style: Style,
 }
 
 pub enum InputEffect {
@@ -33,8 +31,6 @@ impl LineInput {
         Self {
             line: str,
             cursor: 0,
-            style: Style::default(),
-            cursor_line_style: Style::default().add_modifier(Modifier::UNDERLINED),
         }
     }
 

--- a/spotify_player/src/ui/single_line_input.rs
+++ b/spotify_player/src/ui/single_line_input.rs
@@ -1,0 +1,122 @@
+use crossterm::event::KeyCode;
+use tui::widgets::Widget;
+
+use super::*;
+use crate::key::{Key, KeySequence};
+
+#[derive(Debug, Clone)]
+pub struct LineInput {
+    // This is less space-efficient than String, but it's easier to work with text manipulation at the
+    // cursor. Otherwise, you have to shuffle back and forth between String and String::chars().
+    line: Vec<char>,
+    cursor: u16,
+    style: Style,
+    cursor_line_style: Style,
+}
+
+pub enum InputEffect {
+    TextChanged,
+    CursorMoved,
+    // Sometimes a given input has no effect, but it is should still be considered as 'consumed' by
+    // the input element. For instance, pressing backspace when there is no text.
+    Ack,
+}
+
+impl Default for LineInput {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+impl LineInput {
+    pub fn new(str: Vec<char>) -> Self {
+        Self {
+            line: str,
+            cursor: 0,
+            style: Style::default(),
+            cursor_line_style: Style::default().add_modifier(Modifier::UNDERLINED),
+        }
+    }
+
+    pub fn input(&mut self, key_sequence: &KeySequence) -> Option<InputEffect> {
+        return match key_sequence.keys[0] {
+            Key::None(c) => match c {
+                KeyCode::Char(c) => {
+                    if self.cursor as usize == self.line.len() {
+                        self.line.push(c);
+                    } else {
+                        self.line.insert(self.cursor.into(), c);
+                    }
+                    self.cursor += 1;
+                    Some(InputEffect::TextChanged)
+                }
+                KeyCode::Backspace => {
+                    if self.line.len() == 0 || self.cursor == 0 {
+                        Some(InputEffect::Ack)
+                    } else {
+                        // Perform the decrement first.
+                        self.cursor -= 1;
+                        self.line.remove(self.cursor.into());
+                        Some(InputEffect::TextChanged)
+                    }
+                }
+                KeyCode::Left => {
+                    if self.cursor == 0 {
+                        Some(InputEffect::Ack)
+                    } else {
+                        self.cursor -= 1;
+                        Some(InputEffect::CursorMoved)
+                    }
+                }
+                KeyCode::Right => {
+                    if self.cursor as usize == self.line.len() {
+                        Some(InputEffect::Ack)
+                    } else {
+                        self.cursor += 1;
+                        Some(InputEffect::CursorMoved)
+                    }
+                }
+                _ => None,
+            },
+            _ => None,
+        };
+    }
+
+    pub fn widget(&self, is_active: bool) -> impl Widget {
+        if !is_active {
+            let converted_str: String = self.line.iter().collect();
+            return Paragraph::new(converted_str);
+        }
+
+        let mut before_cursor = String::new();
+        // Default cursor to be an empty space. This ensures it's displayed even if the cursor is
+        // at the end of the string.
+        let mut cursor = " ".to_string();
+        let mut after_cursor = String::new();
+        for (idx, chr) in self.line.iter().enumerate() {
+            let chr = *chr;
+            match idx.cmp(&(self.cursor as usize)) {
+                std::cmp::Ordering::Less => before_cursor.push(chr),
+                std::cmp::Ordering::Equal => cursor = chr.to_string(),
+                std::cmp::Ordering::Greater => after_cursor.push(chr),
+            }
+        }
+        let text_style = Style::default();
+        let cursor_style = Style::default().add_modifier(Modifier::REVERSED);
+        let formatted_line = Line::from(vec![
+            Span::styled(before_cursor, text_style),
+            Span::styled(cursor, cursor_style),
+            Span::styled(after_cursor, text_style),
+        ]);
+
+        Paragraph::new(formatted_line)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.line.is_empty()
+    }
+
+    pub fn get_text(&self) -> String {
+        self.line.iter().collect()
+    }
+}


### PR DESCRIPTION
I found using the search bar to be a confusing experience without a cursor. This adds a very simple implementation. You can type, delete with backspace, and navigate with left/right arrows. This can be easily extended in the future to support some basic Emacs-style navigation: by word, end of line etc.

Short video containing usage:
https://github.com/aome510/spotify-player/assets/12721457/5a342c28-d447-4696-ac48-e3d4f0b283bc

