### PR TITLE
chore: update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
+        toolchain: [stable]
+        include:
+          - os: ubuntu-latest
+            toolchain: beta
 
     runs-on: ${{ matrix.os }}
 
@@ -27,44 +31,32 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
 
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache cargo deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-          override: true
-          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --features ${{ env.RUST_FEATURES }}
-
       - name: Cargo format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
+
+      - name: Cargo test
+        run: cargo test --no-default-features --features ${{ env.RUST_FEATURES }}
 
       - name: Cargo clippy with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features --features ${{ env.RUST_FEATURES }} -- -D warnings
+        run: cargo clippy --no-default-features --features ${{ env.RUST_FEATURES }} -- -D warnings
 
       - name: Cargo clippy without features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features -- -D warnings
+        run: cargo clippy --no-default-features -- -D warnings
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        id: install_toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy, rustfmt
+
       - name: Cache cargo deps
         uses: actions/cache@v3
         with:
@@ -40,13 +47,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: clippy, rustfmt
+          key: ${{ runner.os }}-rustc-${{ steps.install_toolchain.outputs.cachekey }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rustc-${{ steps.install_toolchain.outputs.cachekey }}
 
       - name: Cargo format
         run: cargo fmt --all -- --check

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,21 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/spotify_player:latest


### PR DESCRIPTION
Summary of changes:
- Update several actions to the latest version (actions/checkout, docker/{buildx, login, setup-buildx, build-push-action}
- Migrated actions from actions-rs to dtolnay/rust-toolchain. The former has been archived, the latter has become popular with many larger projects. actions-rs/cargo migrated to run steps.
- Add one rust beta toolchain to CI testing. I only included Ubuntu, figured once is enough. This can be discarded if you want, really. Just to make sure there are no compiler bugs that would soon become an obstable to building the project.
- Add rustc version to actions/cache cache-key, add a restore-keys argument for increased cache hits. Given that target/ is not cached really you can make it hit cache everytime, I think.

I have tested in my own repo the CI and the docker deployment actions. 

IMPORTANT NOTES: 
- the docker/login-action documentation now plain asks, rather than recommends, using a token for access instead of the password. I gather it will still work with a password, though. 
- The CD workflow breaks when updating either the checkout action or the toolchain action. This results in the ubuntu machines cross compiling (and these are the only affected) to break. I've left this as is, but it may be that the containers are not updated anymore; last update was 2 years ago: [link to rustembedded dockerhub page](https://hub.docker.com/r/rustembedded/cross/tags).

Other information: about those warnings in the actions log:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/