### PR TITLE
Fix playback not updating when daemon playback changes

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1305,7 +1305,13 @@ impl Client {
             let new_track = prev_track_name != curr_track_name && !curr_track_name.is_empty();
             // check if we need to update the buffered playback
             let needs_update = match (&player.buffered_playback, &player.playback) {
-                (Some(bp), Some(p)) => bp.device_id != p.device.id || new_track,
+                (Some(bp), Some(p)) => {
+                    bp.device_id != p.device.id
+                        || bp.volume != p.device.volume_percent
+                        || bp.shuffle_state != p.shuffle_state
+                        || bp.repeat_state != p.repeat_state
+                        || new_track
+                }
                 (None, None) => false,
                 _ => true,
             };


### PR DESCRIPTION
To reproduce:
1. Run spotify-player as a daemon (`spotify_player -d`)
2. Connect to it with another spotify-player process (`spotify-player`) with `playback_refresh_duration_in_ms` > 0
3. Change the playback of the daemon via the terminal (`spotify_player playback shuffle`)
4. See that the shuffle state only changes in the open process when we manually reload the playback (press `r`) or on a new track