### PR TITLE
docs: fixes keymap command name

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -238,7 +238,7 @@ key_sequence = "g n"
 command = "PreviousTrack"
 key_sequence = "g p"
 [[keymaps]]
-command = "SearchContext"
+command = "Search"
 key_sequence = "C-c C-x /"
 [[keymaps]]
 command = "ResumePause"


### PR DESCRIPTION
Using the example `keymap.toml` configuration spawned this issue:

```
$ spotify_player
Error: TOML parse error at line 8, column 11
  |
8 | command = "SearchContext"
  |           ^^^^^^^^^^^^^^^
unknown variant ... [[truncated]]
```

This change fixes the command name from `SearchContext` to `Search`, which runs without issue.