### PR TITLE
build: use `cross` for cross-compilation, locally and in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,49 +21,33 @@ jobs:
             target: aarch64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            container: rust
             dependencies: "libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev"
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            container: rustembedded/cross:aarch64-unknown-linux-gnu
-            cross_arch: "arm64"
-            pkg_config_path: "/usr/lib/aarch64-linux-gnu/pkgconfig/"
-            dependencies: "libssl-dev:arm64 libasound2-dev:arm64 libdbus-1-dev:arm64 libxcb-shape0-dev:arm64 libxcb-xfixes0-dev:arm64"
+            cross_arch: true
           - os: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
-            cross_arch: "armhf"
-            pkg_config_path: "/usr/lib/arm-linux-gnueabihf/pkgconfig/"
-            container: rustembedded/cross:armv7-unknown-linux-gnueabihf
-            dependencies: "libssl-dev:armhf libasound2-dev:armhf libdbus-1-dev:armhf libxcb-shape0-dev:armhf libxcb-xfixes0-dev:armhf"
+            cross_arch: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
-
-      - name: Set up cross compilation
-        if: matrix.cross_arch
-        run: |
-          dpkg --add-architecture ${{ matrix.cross_arch }}
-          echo "PKG_CONFIG_PATH=${{ matrix.pkg_config_path }}" >> $GITHUB_ENV
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+        uses: actions/checkout@v4
 
       - name: Install Linux dependencies
         if: matrix.dependencies
-        run: apt update && apt install -y ${{ matrix.dependencies }}
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.dependencies }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
+          use-cross: ${{ matrix.cross_arch }}
           command: build
           args: --locked --release --target ${{ matrix.target }}
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,12 @@
+[build.env]
+passthrough = [
+  "CROSS_DEBUG",
+  "RUST_BACKTRACE",
+]
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "./ci/Dockerfile-cross"
+
+[target.armv7-unknown-linux-gnueabihf]
+dockerfile = "./ci/Dockerfile-cross"
+

--- a/ci/Dockerfile-cross
+++ b/ci/Dockerfile-cross
@@ -1,0 +1,8 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+ARG CROSS_DEB_ARCH
+RUN dpkg --add-architecture $CROSS_DEB_ARCH && \
+    apt-get update && \
+    apt-get install -y libssl-dev:$CROSS_DEB_ARCH libasound2-dev:$CROSS_DEB_ARCH libdbus-1-dev:$CROSS_DEB_ARCH libxcb-shape0-dev:$CROSS_DEB_ARCH libxcb-xfixes0-dev:$CROSS_DEB_ARCH
+


### PR DESCRIPTION
TL;DR: of each commit is in order:
1. Enables local cross compilation from Linux (at least x86_64) to Linux both aarch64 or armv7 by using `cross`.
2. Leverages cross and applies it to the CD workflow to build the release binaries.

Major significant benefit it actually just using current images - the FROM in the Dockerfile resolves to `ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest`. That by itself could have been a PR.

By the way, to see that TLDR in the code I recommend checking each commit individually. Both together it just looks like a mess 🙃 