### PR TITLE
chore(docs): Remove unneeded explicit link

### DIFF
--- a/lyric_finder/src/lib.rs
+++ b/lyric_finder/src/lib.rs
@@ -1,6 +1,6 @@
 //! # lyric_finder
 //!
-//! This crate provides a [`Client`](Client) struct for retrieving a song's lyric.
+//! This crate provides a [`Client`] struct for retrieving a song's lyric.
 //!
 //! It ultilizes the [Genius](https://genius.com) website and its APIs to get lyric data.
 //!


### PR DESCRIPTION
The lyric_finder docs have a warning when running `cargo doc`. Just what it says on the tin