### PR TITLE
Wait for the copy command to exit.

### DIFF
--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -466,14 +466,16 @@ fn execute_copy_command(cmd: &config::Command, text: String) -> Result<()> {
         .stdout(std::process::Stdio::piped())
         .spawn()?;
 
-    let mut stdin = match child.stdin.take() {
-        Some(stdin) => stdin,
-        None => anyhow::bail!("no stdin found in the child command"),
+    let result = match child.stdin.take() {
+        Some(mut stdin) => {
+            stdin.write_all(text.as_bytes()).map_err(anyhow::Error::from)
+        }
+        None => Err(anyhow::anyhow!("no stdin found in the child command"))
     };
 
-    stdin.write_all(text.as_bytes())?;
+    child.wait()?;
 
-    Ok(())
+    result
 }
 
 /// handles a key sequence for an action list popup

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -467,10 +467,10 @@ fn execute_copy_command(cmd: &config::Command, text: String) -> Result<()> {
         .spawn()?;
 
     let result = match child.stdin.take() {
-        Some(mut stdin) => {
-            stdin.write_all(text.as_bytes()).map_err(anyhow::Error::from)
-        }
-        None => Err(anyhow::anyhow!("no stdin found in the child command"))
+        Some(mut stdin) => stdin
+            .write_all(text.as_bytes())
+            .map_err(anyhow::Error::from),
+        None => Err(anyhow::anyhow!("no stdin found in the child command")),
     };
 
     child.wait()?;


### PR DESCRIPTION
There's a bit of jank in the error handling to make sure it waits for the child to exit on all possible paths, and it suppresses the stdin error if ``.wait()`` fails, but I couldn't think of a nicer way. Very open to fixing this.

Closes #345.
