### PR TITLE
feat: Souvlaki 0.7.0 and Linux Dbus volume control support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,8 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "souvlaki"
-version = "0.6.0"
-source = "git+https://github.com/Sinono3/souvlaki?branch=volume#0f8e6740b262958408ddc901220c4613b3f517ca"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4c47caa3c7f792d038db6bddb29a1a322800941926d4d8bf36002309065005"
 dependencies = [
  "block",
  "cocoa",
@@ -4116,6 +4117,7 @@ dependencies = [
  "dbus-crossroads",
  "dispatch",
  "objc",
+ "thiserror",
  "windows 0.44.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,9 +4106,8 @@ dependencies = [
 
 [[package]]
 name = "souvlaki"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951a075f224d8c87bb62a08c9c27a373fd6d453407e89cae00a25e2eac74ef51"
+version = "0.6.0"
+source = "git+https://github.com/Sinono3/souvlaki?branch=volume#0f8e6740b262958408ddc901220c4613b3f517ca"
 dependencies = [
  "block",
  "cocoa",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 lyric_finder = { version = "0.1.4", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.69"
-souvlaki = { version = "0.6.1", optional = true }
+souvlaki = { git = "https://github.com/Sinono3/souvlaki", branch = "volume", optional = true }
 winit = { version = "0.29.4", optional = true }
 viuer = { version = "0.7.1", optional = true }
 image = { version = "0.24.7", optional = true }

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 lyric_finder = { version = "0.1.4", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.69"
-souvlaki = { git = "https://github.com/Sinono3/souvlaki", branch = "volume", optional = true }
+souvlaki = { version = "0.7.0", optional = true }
 winit = { version = "0.29.4", optional = true }
 viuer = { version = "0.7.1", optional = true }
 image = { version = "0.24.7", optional = true }

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -109,6 +109,11 @@ pub fn start_event_watcher(
                     .send(ClientRequest::Player(PlayerRequest::PreviousTrack))
                     .unwrap_or_default();
             }
+            MediaControlEvent::SetVolume(volume) => client_pub
+                .send(ClientRequest::Player(PlayerRequest::Volume(
+                    (volume * 100.0) as u8,
+                )))
+                .unwrap_or_default(),
             _ => {}
         }
     })?;


### PR DESCRIPTION
I guess I am just merging other people's work. As I mentioned in [souvlaki's issue for Linux volume control support](https://github.com/Sinono3/souvlaki/issues/36#issuecomment-1911409315), I tested this in my computer with

```
dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify_player /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Set string:'org.mpris.MediaPlayer2.Player' string:'Volume' variant:double:0.4
```
(of course change that final 0.4 to different values to appreciate the change in volume)