### PR TITLE
Add miscellaneous UI code changes

### DIFF
--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -156,7 +156,7 @@ impl ThemeConfig {
 }
 
 impl Theme {
-    pub fn app_style(&self) -> style::Style {
+    pub fn app(&self) -> style::Style {
         let mut style = style::Style::default();
         if let Some(ref c) = self.palette.background {
             style = style.bg(c.color);
@@ -167,7 +167,7 @@ impl Theme {
         style
     }
 
-    pub fn selection_style(&self, is_active: bool) -> style::Style {
+    pub fn selection(&self, is_active: bool) -> style::Style {
         if is_active {
             match &self.component_style.selection {
                 None => style::Style::default()
@@ -178,24 +178,6 @@ impl Theme {
         } else {
             style::Style::default()
         }
-    }
-
-    pub fn _text_with_style<'a, S>(
-        &self,
-        content: S,
-        style: tui::style::Style,
-    ) -> tui::text::Span<'a>
-    where
-        S: Into<String>,
-    {
-        tui::text::Span::styled(content.into(), style)
-    }
-
-    pub fn block_title_with_style<'a, S>(&self, content: S) -> tui::text::Span<'a>
-    where
-        S: Into<String>,
-    {
-        tui::text::Span::styled(content.into(), self.block_title())
     }
 
     pub fn block_title(&self) -> tui::style::Style {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -39,7 +39,7 @@ pub fn run(state: SharedState) -> Result<()> {
             if let Err(err) = terminal.draw(|frame| {
                 // set the background and foreground colors for the application
                 let rect = frame.size();
-                let block = Block::default().style(ui.theme.app_style());
+                let block = Block::default().style(ui.theme.app());
                 frame.render_widget(block, rect);
 
                 if let Err(err) = render_application(frame, &state, &mut ui, rect) {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -88,13 +88,14 @@ fn render_application(
     ui: &mut UIStateGuard,
     rect: Rect,
 ) -> Result<()> {
-    // playback window is the window that is always displayed on the screen,
-    // hence it's rendered first
-    let (playback_rect, rect) = playback::split_rect_for_playback_window(rect, state);
-    playback::render_playback_window(frame, state, ui, playback_rect)?;
+    // rendering order: help popup -> other popups -> playback window -> main layout
 
     let rect = popup::render_shortcut_help_popup(frame, state, ui, rect);
+
     let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
+
+    let (playback_rect, rect) = playback::split_rect_for_playback_window(rect, state);
+    playback::render_playback_window(frame, state, ui, playback_rect)?;
 
     render_main_layout(is_active, frame, state, ui, rect)?;
     Ok(())

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -31,7 +31,7 @@ pub fn render_search_page(
     let rect = construct_and_render_block("Search", &ui.theme, state, Borders::ALL, frame, rect);
 
     // search input's layout
-    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
     let search_input_rect = chunks[0];
     let rect = chunks[1];
 
@@ -227,7 +227,7 @@ pub fn render_context_page(
     match data.caches.context.get(&id.uri()) {
         Some(context) => {
             // render context description
-            let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
+            let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
             frame.render_widget(
                 Paragraph::new(context.description()).style(ui.theme.page_desc()),
                 chunks[0],
@@ -483,7 +483,7 @@ pub fn render_lyric_page(
 
     // 2. Construct the app's layout
     let rect = construct_and_render_block("Lyric", &ui.theme, state, Borders::ALL, frame, rect);
-    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
 
     // 3. Construct the app's widgets
     let (track, artists, scroll_offset) = match ui.current_page_mut() {
@@ -561,7 +561,7 @@ fn render_artist_context_page_windows(
 
     // 2. Construct the app's layout
     // top tracks window
-    let chunks = Layout::vertical([Constraint::Length(12), Constraint::Min(1)]).split(rect);
+    let chunks = Layout::vertical([Constraint::Length(12), Constraint::Fill(0)]).split(rect);
     let top_tracks_rect = chunks[0];
 
     // albums and related artitsts windows

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -752,7 +752,7 @@ pub fn render_track_table_window(
         .style(ui.theme.table_header()),
     )
     .column_spacing(2)
-    .highlight_style(ui.theme.selection_style(is_active));
+    .highlight_style(ui.theme.selection(is_active));
 
     match ui.current_page_mut() {
         PageState::Context {

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -239,7 +239,7 @@ pub fn render_context_page(
                 .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
                 .split(rect);
             frame.render_widget(
-                Paragraph::new(Text::styled(context.description(), ui.theme.page_desc())),
+                Paragraph::new(context.description()).style(ui.theme.page_desc()),
                 chunks[0],
             );
 
@@ -538,10 +538,7 @@ pub fn render_lyric_page(
 
     // 4. Render the app's widgets
     // render lyric page description text
-    frame.render_widget(
-        Paragraph::new(Text::styled(desc, ui.theme.page_desc())),
-        chunks[0],
-    );
+    frame.render_widget(Paragraph::new(desc).style(ui.theme.page_desc()), chunks[0]);
 
     // render lyric text
     frame.render_widget(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -31,23 +31,16 @@ pub fn render_search_page(
     let rect = construct_and_render_block("Search", &ui.theme, state, Borders::ALL, frame, rect);
 
     // search input's layout
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
-        .split(rect);
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
     let search_input_rect = chunks[0];
     let rect = chunks[1];
 
     // track/album/artist/playlist search results layout (2x2 table)
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+    let chunks = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(rect)
         .iter()
         .flat_map(|rect| {
-            Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                 .split(*rect)
                 .to_vec()
         })
@@ -234,10 +227,7 @@ pub fn render_context_page(
     match data.caches.context.get(&id.uri()) {
         Some(context) => {
             // render context description
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
-                .split(rect);
+            let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
             frame.render_widget(
                 Paragraph::new(context.description()).style(ui.theme.page_desc()),
                 chunks[0],
@@ -324,17 +314,12 @@ pub fn render_library_page(
     // - a playlists window
     // - a saved albums window
     // - a followed artists window
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage(40),
-                Constraint::Percentage(40),
-                Constraint::Percentage(20),
-            ]
-            .as_ref(),
-        )
-        .split(rect);
+    let chunks = Layout::horizontal([
+        Constraint::Percentage(40),
+        Constraint::Percentage(40),
+        Constraint::Percentage(20),
+    ])
+    .split(rect);
     let playlist_rect = construct_and_render_block(
         "Playlists",
         &ui.theme,
@@ -498,10 +483,7 @@ pub fn render_lyric_page(
 
     // 2. Construct the app's layout
     let rect = construct_and_render_block("Lyric", &ui.theme, state, Borders::ALL, frame, rect);
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(0)].as_ref())
-        .split(rect);
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(rect);
 
     // 3. Construct the app's widgets
     let (track, artists, scroll_offset) = match ui.current_page_mut() {
@@ -579,16 +561,11 @@ fn render_artist_context_page_windows(
 
     // 2. Construct the app's layout
     // top tracks window
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(12), Constraint::Min(1)].as_ref())
-        .split(rect);
+    let chunks = Layout::vertical([Constraint::Length(12), Constraint::Min(1)]).split(rect);
     let top_tracks_rect = chunks[0];
 
     // albums and related artitsts windows
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+    let chunks = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(chunks[1]);
     let albums_rect = construct_and_render_block(
         "Albums",
@@ -729,12 +706,12 @@ pub fn render_track_table_window(
     let track_table = Table::new(
         rows,
         [
-            Constraint::Length(2),
-            Constraint::Length(5),
-            Constraint::Percentage(25),
-            Constraint::Percentage(25),
+            Constraint::Length(1),
+            Constraint::Length(4),
             Constraint::Percentage(30),
-            Constraint::Percentage(20),
+            Constraint::Percentage(25),
+            Constraint::Percentage(35),
+            Constraint::Percentage(10),
         ],
     )
     .header(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -36,11 +36,11 @@ pub fn render_search_page(
     let rect = chunks[1];
 
     // track/album/artist/playlist search results layout (2x2 table)
-    let chunks = Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
+    let chunks = Layout::vertical([Constraint::Ratio(1, 2); 2])
         .split(rect)
         .iter()
         .flat_map(|rect| {
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            Layout::horizontal([Constraint::Ratio(1, 2); 2])
                 .split(*rect)
                 .to_vec()
         })
@@ -565,8 +565,7 @@ fn render_artist_context_page_windows(
     let top_tracks_rect = chunks[0];
 
     // albums and related artitsts windows
-    let chunks = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(chunks[1]);
+    let chunks = Layout::horizontal([Constraint::Ratio(1, 2); 2]).split(chunks[1]);
     let albums_rect = construct_and_render_block(
         "Albums",
         &ui.theme,
@@ -708,10 +707,10 @@ fn render_track_table(
         [
             Constraint::Length(1),
             Constraint::Length(4),
-            Constraint::Percentage(30),
-            Constraint::Percentage(25),
-            Constraint::Percentage(35),
-            Constraint::Percentage(10),
+            Constraint::Fill(4),
+            Constraint::Fill(3),
+            Constraint::Fill(5),
+            Constraint::Fill(1),
         ],
     )
     .header(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -251,7 +251,7 @@ pub fn render_context_page(
                     )?;
                 }
                 Context::Playlist { tracks, .. } => {
-                    render_track_table_window(
+                    render_track_table(
                         frame,
                         chunks[1],
                         is_active,
@@ -262,7 +262,7 @@ pub fn render_context_page(
                     )?;
                 }
                 Context::Album { tracks, .. } => {
-                    render_track_table_window(
+                    render_track_table(
                         frame,
                         chunks[1],
                         is_active,
@@ -273,7 +273,7 @@ pub fn render_context_page(
                     )?;
                 }
                 Context::Tracks { tracks, .. } => {
-                    render_track_table_window(
+                    render_track_table(
                         frame,
                         chunks[1],
                         is_active,
@@ -614,7 +614,7 @@ fn render_artist_context_page_windows(
     };
 
     // 4. Render the widgets
-    render_track_table_window(
+    render_track_table(
         frame,
         top_tracks_rect,
         is_active && focus_state == ArtistFocusState::TopTracks,
@@ -649,7 +649,7 @@ fn render_artist_context_page_windows(
     Ok(())
 }
 
-pub fn render_track_table_window(
+fn render_track_table(
     frame: &mut Frame,
     rect: Rect,
     is_active: bool,

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -19,10 +19,8 @@ pub fn render_playback_window(
             let (metadata_rect, progress_bar_rect) = {
                 // allocate the progress bar rect
                 let (rect, progress_bar_rect) = {
-                    let chunks = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints([Constraint::Min(0), Constraint::Length(1)].as_ref())
-                        .split(rect);
+                    let chunks =
+                        Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(rect);
 
                     (chunks[0], chunks[1])
                 };
@@ -33,33 +31,21 @@ pub fn render_playback_window(
                     {
                         // Split the allocated rectangle into `metadata_rect` and `cover_img_rect`
                         let (metadata_rect, cover_img_rect) = {
-                            let hor_chunks = Layout::default()
-                                .direction(Direction::Horizontal)
-                                .constraints(
-                                    [
-                                        Constraint::Length(
-                                            state.configs.app_config.cover_img_length as u16,
-                                        ),
-                                        Constraint::Length(1), // a margin of 1 between the cover image widget and track's metadata widget
-                                        Constraint::Min(0),    // metadata_rect
-                                    ]
-                                    .as_ref(),
-                                )
-                                .split(rect);
-                            let ver_chunks = Layout::default()
-                                .direction(Direction::Vertical)
-                                .constraints(
-                                    [
-                                        Constraint::Length(
-                                            state.configs.app_config.cover_img_width as u16,
-                                        ), // cover_img_rect
-                                        Constraint::Min(0), // a margin of 1 between the cover image widget and track's metadata widget
-                                    ]
-                                    .as_ref(),
-                                )
-                                .split(hor_chunks[0]);
+                            let hor_chunks = Layout::horizontal([
+                                Constraint::Length(
+                                    state.configs.app_config.cover_img_length as u16,
+                                ),
+                                Constraint::Min(0), // metadata_rect
+                            ])
+                            .spacing(1)
+                            .split(rect);
+                            let ver_chunks = Layout::vertical([
+                                Constraint::Length(state.configs.app_config.cover_img_width as u16), // cover_img_rect
+                                Constraint::Min(0),
+                            ])
+                            .split(hor_chunks[0]);
 
-                            (hor_chunks[2], ver_chunks[0])
+                            (hor_chunks[1], ver_chunks[0])
                         };
 
                         // set the `skip` state of cells in the cover image area
@@ -345,17 +331,13 @@ pub fn split_rect_for_playback_window(rect: Rect, state: &SharedState) -> (Rect,
 
     match state.configs.app_config.playback_window_position {
         config::Position::Top => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(playback_width), Constraint::Min(0)].as_ref())
+            let chunks = Layout::vertical([Constraint::Length(playback_width), Constraint::Min(0)])
                 .split(rect);
 
             (chunks[0], chunks[1])
         }
         config::Position::Bottom => {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(0), Constraint::Length(playback_width)].as_ref())
+            let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(playback_width)])
                 .split(rect);
 
             (chunks[1], chunks[0])

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -20,7 +20,7 @@ pub fn render_playback_window(
                 // allocate the progress bar rect
                 let (rect, progress_bar_rect) = {
                     let chunks =
-                        Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(rect);
+                        Layout::vertical([Constraint::Fill(0), Constraint::Length(1)]).split(rect);
 
                     (chunks[0], chunks[1])
                 };
@@ -35,13 +35,13 @@ pub fn render_playback_window(
                                 Constraint::Length(
                                     state.configs.app_config.cover_img_length as u16,
                                 ),
-                                Constraint::Min(0), // metadata_rect
+                                Constraint::Fill(0), // metadata_rect
                             ])
                             .spacing(1)
                             .split(rect);
                             let ver_chunks = Layout::vertical([
                                 Constraint::Length(state.configs.app_config.cover_img_width as u16), // cover_img_rect
-                                Constraint::Min(0),
+                                Constraint::Fill(0), // empty space
                             ])
                             .split(hor_chunks[0]);
 
@@ -331,14 +331,16 @@ pub fn split_rect_for_playback_window(rect: Rect, state: &SharedState) -> (Rect,
 
     match state.configs.app_config.playback_window_position {
         config::Position::Top => {
-            let chunks = Layout::vertical([Constraint::Length(playback_width), Constraint::Min(0)])
-                .split(rect);
+            let chunks =
+                Layout::vertical([Constraint::Length(playback_width), Constraint::Fill(0)])
+                    .split(rect);
 
             (chunks[0], chunks[1])
         }
         config::Position::Bottom => {
-            let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(playback_width)])
-                .split(rect);
+            let chunks =
+                Layout::vertical([Constraint::Fill(0), Constraint::Length(playback_width)])
+                    .split(rect);
 
             (chunks[1], chunks[0])
         }

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -30,7 +30,7 @@ pub fn render_popup(
         Some(ref popup) => match popup {
             PopupState::Search { query } => {
                 let chunks =
-                    Layout::vertical([Constraint::Min(0), Constraint::Length(3)]).split(rect);
+                    Layout::vertical([Constraint::Fill(0), Constraint::Length(3)]).split(rect);
 
                 let rect = construct_and_render_block(
                     "Search",
@@ -47,7 +47,7 @@ pub fn render_popup(
             PopupState::CommandHelp { .. } => {
                 // the command help popup will cover the entire main layout
                 let chunks =
-                    Layout::vertical([Constraint::Min(0), Constraint::Length(0)]).split(rect);
+                    Layout::vertical([Constraint::Fill(0), Constraint::Length(0)]).split(rect);
 
                 render_commands_help_popup(frame, state, ui, chunks[0]);
                 (chunks[1], false)
@@ -55,7 +55,7 @@ pub fn render_popup(
             PopupState::Queue { .. } => {
                 // the queue popup will cover the entire main layout
                 let chunks =
-                    Layout::vertical([Constraint::Min(0), Constraint::Length(0)]).split(rect);
+                    Layout::vertical([Constraint::Fill(0), Constraint::Length(0)]).split(rect);
 
                 render_queue_popup(frame, state, ui, chunks[0]);
                 (chunks[1], false)
@@ -159,7 +159,7 @@ fn render_list_popup(
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Rect {
-    let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(length)]).split(rect);
+    let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(length)]).split(rect);
 
     let rect = construct_and_render_block(title, &ui.theme, state, Borders::ALL, frame, chunks[1]);
     let (list, len) = utils::construct_list_widget(&ui.theme, items, true);
@@ -208,7 +208,7 @@ pub fn render_shortcut_help_popup(
     if matches.is_empty() {
         rect
     } else {
-        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(7)]).split(rect);
+        let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(7)]).split(rect);
 
         let rect = construct_and_render_block(
             "Shortcuts",

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -3,11 +3,8 @@ use crate::utils::format_duration;
 use std::collections::{btree_map::Entry, BTreeMap};
 
 const SHORTCUT_TABLE_N_COLUMNS: usize = 3;
-const SHORTCUT_TABLE_CONSTRAINS: [Constraint; SHORTCUT_TABLE_N_COLUMNS] = [
-    Constraint::Percentage(33),
-    Constraint::Percentage(33),
-    Constraint::Percentage(33),
-];
+const SHORTCUT_TABLE_CONSTRAINS: [Constraint; SHORTCUT_TABLE_N_COLUMNS] =
+    [Constraint::Ratio(1, 3); 3];
 const COMMAND_TABLE_CONSTRAINTS: [Constraint; 3] = [
     Constraint::Percentage(25),
     Constraint::Percentage(25),

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -29,10 +29,8 @@ pub fn render_popup(
         None => (rect, true),
         Some(ref popup) => match popup {
             PopupState::Search { query } => {
-                let chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Min(0), Constraint::Length(3)].as_ref())
-                    .split(rect);
+                let chunks =
+                    Layout::vertical([Constraint::Min(0), Constraint::Length(3)]).split(rect);
 
                 let rect = construct_and_render_block(
                     "Search",
@@ -48,20 +46,16 @@ pub fn render_popup(
             }
             PopupState::CommandHelp { .. } => {
                 // the command help popup will cover the entire main layout
-                let chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Min(0), Constraint::Length(0)].as_ref())
-                    .split(rect);
+                let chunks =
+                    Layout::vertical([Constraint::Min(0), Constraint::Length(0)]).split(rect);
 
                 render_commands_help_popup(frame, state, ui, chunks[0]);
                 (chunks[1], false)
             }
             PopupState::Queue { .. } => {
                 // the queue popup will cover the entire main layout
-                let chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Min(0), Constraint::Length(0)].as_ref())
-                    .split(rect);
+                let chunks =
+                    Layout::vertical([Constraint::Min(0), Constraint::Length(0)]).split(rect);
 
                 render_queue_popup(frame, state, ui, chunks[0]);
                 (chunks[1], false)
@@ -165,10 +159,7 @@ fn render_list_popup(
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Rect {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0), Constraint::Length(length)].as_ref())
-        .split(rect);
+    let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(length)]).split(rect);
 
     let rect = construct_and_render_block(title, &ui.theme, state, Borders::ALL, frame, chunks[1]);
     let (list, len) = utils::construct_list_widget(&ui.theme, items, true);
@@ -217,10 +208,7 @@ pub fn render_shortcut_help_popup(
     if matches.is_empty() {
         rect
     } else {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(0), Constraint::Length(7)].as_ref())
-            .split(rect);
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(7)]).split(rect);
 
         let rect = construct_and_render_block(
             "Shortcuts",

--- a/spotify_player/src/ui/utils.rs
+++ b/spotify_player/src/ui/utils.rs
@@ -40,7 +40,7 @@ pub fn construct_and_render_block(
     }
 
     // Set `title` for the block
-    block = block.title(theme.block_title_with_style(title));
+    block = block.title(Span::styled(title, theme.block_title()));
 
     frame.render_widget(block, rect);
     inner_rect
@@ -67,7 +67,7 @@ pub fn construct_list_widget<'a>(
                 })
                 .collect::<Vec<_>>(),
         )
-        .highlight_style(theme.selection_style(is_active)),
+        .highlight_style(theme.selection(is_active)),
         n_items,
     )
 }


### PR DESCRIPTION
- clean up getter methods to retrieve a theme's component styles
- fix a bug that page description's style is not rendered with the new `ratatui` version
- update API usages for `tui::Layout` and `tui::Constraint`
- rename `render_track_table_window` to `render_track_table` and make it private
- update rendering order