### PR TITLE
Use XDG specification environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ To move the focus from the search input to the other windows such as track resul
 
 ## Configurations
 
-By default, `spotify_player` will look into `$HOME/.config/spotify-player` for application's configuration files. This can be changed by either specifying `-c <FOLDER_PATH>` or `--config-folder <FOLDER_PATH>` option.
+By default, `spotify_player` will look into the `$HOME/.config/spotify-player` and the `$XDG_CONFIG_HOME/spotify-player` directories for application's configuration files, with that preference. This can be changed by either specifying `-c <FOLDER_PATH>` or `--config-folder <FOLDER_PATH>` option.
 
 If an application configuration file is not found, one will be created with default values.
 
@@ -389,7 +389,7 @@ Please refer to [the configuration documentation](docs/config.md) for more detai
 
 ## Caches
 
-By default, `spotify_player` will look into `$HOME/.cache/spotify-player` for application's cache files, which include log files, Spotify's authorization credentials, audio cache files, etc. This can be changed by either specifying `-C <FOLDER_PATH>` or `--cache-folder <FOLDER_PATH>` option.
+By default, `spotify_player` will look into `$XDG_CACHE_HOME/spotify-player` for application's cache files, which include log files, Spotify's authorization credentials, audio cache files, etc, falling back on `$HOME/.cache/spotify-player`. This can be changed by either specifying `-C <FOLDER_PATH>` or `--cache-folder <FOLDER_PATH>` option.
 
 ### Logging
 


### PR DESCRIPTION
I noticed a while back that the default XDG base specification locations are hard coded. This PR changes the project to use the corresponding environment variables.
<details>
<summary> This is a now obsolete message, but let's keep it for context </summary>
This was when considering to use the dirs-next crate:
~~As I comment in the commit message~~, it is a BREAKING CHANGE for users with the XDG_CONFIG_HOME variable set to one different from the default. Note that while the spec seems relatively Linux-centric, the dirs-next crate also uses recommended guidelines in both mac OS and Windows and so would ~~be breaking for possibly absolutely~~ affect all users. See the table:

```
Linux	 $XDG_CONFIG_HOME or $HOME/.config	/home/alice/.config
macOS	 $HOME/Library/Application Support	/Users/Alice/Library/Application Support
Windows	 {FOLDERID_RoamingAppData}	        C:\Users\Alice\AppData\Roaming
```
Obviously breaking all users' config is breaking for any release, so I thought about renaming the current files to whatever they would become after the new location, but that might just break other users, for all I know. (I'm looking at you, NixOS)

</details>

Then this is some contextual information from what other projects do:
<details>
Instead of doing that, a more reasonable solution is simply using the old config location in case it exists, or otherwise default to the new location. I think this is what git did ( https://git-scm.com/docs/git-config#Documentation/git-config.txt-XDGCONFIGHOMEgitconfig ), only they go on to read the non-compliant file anyway. 
<br>
<br>
It seem that while the convention is clearly defined in Linux, the situation is not so clear in MacOS, and somewhat in Windows. In Mac, ome people strongly prefer the platform recommended locations, and other strongly prefer the XDG ~/.config location. There's precendent: https://github.com/rust-lang/rfcs/pull/1615#issuecomment-221361170, https://github.com/dirs-dev/directories-rs/issues/47. 
Neovim seems to clump all Unix together, so they also use ~/.config for MacOS. On the opposite end is the `dirs-next` crate, which doesn't honor the XDG environment variables in MacOS: [docs](https://docs.rs/dirs-next/2.0.0/dirs_next/fn.cache_dir.html)
</details>

## Current status

This PR just detects if the XDG_CONFIG_HOME and XDG_CACHE_HOME environment variable are set. For compatibililty, if XDG_CONFIG_HOME is set but the old location exists, keep current behaviour. Cache is migrated to XDG_CACHE_HOME always.

Given that the cache folder is not routinely accessed, this should not affect any users negatively.