### PR TITLE
Don't create streaming connections for non-streaming instances

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -68,7 +68,7 @@ impl Client {
 
         // upon creating a new session, also create a new streaming connection
         #[cfg(feature = "streaming")]
-        {
+        if state.is_streaming_enabled() {
             self.new_streaming_connection(state).await;
             // handle `ConnectDevice` separately as we don't want to block here
             self.client_pub.send(ClientRequest::ConnectDevice(None))?;

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -24,10 +24,7 @@ async fn init_spotify(
 ) -> Result<()> {
     // if `streaming` feature is enabled, create a new streaming connection
     #[cfg(feature = "streaming")]
-    if state.configs.app_config.enable_streaming == config::StreamingType::Always
-        || (state.configs.app_config.enable_streaming == config::StreamingType::DaemonOnly
-            && state.is_daemon)
-    {
+    if state.is_streaming_enabled() {
         client.new_streaming_connection(state).await;
     }
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -135,7 +135,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     client.init_token().await?;
 
     // initialize Spotify-related stuff
-    init_spotify(&client_pub, &client, &state)
+    init_spotify(&client_pub, &client, state)
         .await
         .context("Failed to initialize the Spotify data")?;
 

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -67,4 +67,11 @@ impl State {
             is_daemon,
         }
     }
+
+    #[cfg(feature = "streaming")]
+    pub fn is_streaming_enabled(&self) -> bool {
+        self.configs.app_config.enable_streaming == config::StreamingType::Always
+            || (self.configs.app_config.enable_streaming == config::StreamingType::DaemonOnly
+                && self.is_daemon)
+    }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -45,10 +45,11 @@ pub struct State {
     pub ui: Mutex<UIState>,
     pub player: RwLock<PlayerState>,
     pub data: RwLock<AppData>,
+    pub is_daemon: bool,
 }
 
 impl State {
-    pub fn new(configs: Configs) -> Self {
+    pub fn new(configs: Configs, is_daemon: bool) -> Self {
         let mut ui = UIState::default();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {
@@ -63,6 +64,7 @@ impl State {
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(app_data),
+            is_daemon,
         }
     }
 }


### PR DESCRIPTION
This fixes an issue I've been having for a little while.

For context: I'm running spotify_player in daemon mode with `enable_streaming = "DaemonOnly"`, and another instance to control the daemon.
From time to time, however, things get weird, with several devices with the same name showing in the UI. This typically happens after my laptop goes to sleep and wakes up on a different wifi network.

The reason is that during the app init, `enable_streaming` is correctly checked against `is_daemon`, but isn't checked again when the session needs to be restarted. So, when the TUI recreates a session, it also creates a new streaming connection, resulting in 2 devices with the same name in the UI, and no way to tell them apart and know if the TUI or the daemon was actually used.

To fix this, I moved the `is_daemon` bool to `state`, added a helper to check `enable_streaming` against `is_daemon` correctly, and used it everywhere it's required. I've been running this for several days without having this issue again.

Did that before #370, so there was an extra place where `is_streaming_enabled()` was needed, but I don't think this will change anything.