### PR TITLE
Remove winit from compilation on Linux

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -36,7 +36,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 lyric_finder = { version = "0.1.5", path = "../lyric_finder" , optional = true }
 backtrace = "0.3.69"
 souvlaki = { version = "0.7.3", optional = true }
-winit = { version = "0.29.10", optional = true }
 viuer = { version = "0.7.1", optional = true }
 image = { version = "0.24.8", optional = true }
 notify-rust = { version = "4.10.0", optional = true, default-features = false, features = ["d"] }
@@ -48,6 +47,10 @@ daemonize = { version = "0.5.0", optional = true }
 ttl_cache = "0.5.1"
 copypasta = { version = "0.10.0", optional = true }
 clap_complete = "4.4.10"
+
+[target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
+version = "0.29.10"
+optional = true
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.52.0"


### PR DESCRIPTION
Winit is only used in one line in MacOS and Windows, and unused in Linux.

This change improves from-scratch compile times from ~3m 47s to ~3m 25 on my Linux machine, as `winit` was in the critical chain of compilation. 

I attached the output of `cargo b --release --timings` in case you want to read them. GitHub does not allow uploading HTML files so they're zipped here
[timings.zip](https://github.com/aome510/spotify-player/files/14290010/timings.zip)

(BTW enjoy the vacation!)