### PR TITLE
Make Daemon feature imply streaming feature

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -78,7 +78,7 @@ image = ["viuer", "dep:image"]
 sixel = ["image", "viuer/sixel"]
 notify = ["notify-rust"]
 clipboard = ["copypasta"]
-daemon = ["daemonize"]
+daemon = ["daemonize", "streaming"]
 
 default = ["rodio-backend", "media-control", "clipboard"]
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -283,10 +283,6 @@ fn main() -> Result<()> {
                         eprintln!("Running the application as a daemon on windows/macos with `media-control` feature enabled is not supported!");
                         std::process::exit(1);
                     }
-                    if cfg!(not(feature = "streaming")) {
-                        eprintln!("`streaming` feature must be enabled to run the application as a daemon!");
-                        std::process::exit(1);
-                    }
 
                     tracing::info!("Starting the application as a daemon...");
                     let daemonize = daemonize::Daemonize::new();

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -15,6 +15,28 @@ use librespot_playback::{
 use rspotify::model::TrackId;
 use serde::Serialize;
 
+#[cfg(not(any(
+    feature = "rodio-backend",
+    feature = "alsa-backend",
+    feature = "pulseaudio-backend",
+    feature = "portaudio-backend",
+    feature = "jackaudio-backend",
+    feature = "rodiojack-backend",
+    feature = "sdl-backend",
+    feature = "gstreamer-backend"
+)))]
+compile_error!("Streaming feature is enabled but no audio backend has been selected. Consider adding one of the following features:
+    rodio-backend,
+    alsa-backend,
+    pulseaudio-backend,
+    portaudio-backend,
+    jackaudio-backend,
+    rodiojack-backend,
+    sdl-backend,
+    gstreamer-backend
+For more information, visit https://github.com/aome510/spotify-player?tab=readme-ov-file#streaming
+");
+
 #[derive(Debug, Serialize)]
 enum PlayerEvent {
     Changed {


### PR DESCRIPTION
Right now launching spotify_player with the `daemon` CLI flag results in a runtime error if the binary was compiled without the streaming feature. As far as I understand it, I do not see why not just do this. The README says it still indicates that it needs _some_ audio backend but AFAIK there's no way to encode that in the feature system.

Note: stumbled into this for the CI suite. There's tooling (aka `cargo hack`) that uses feature dependencies to build many options. This would stop compilation of binaries with the daemon feature without the streaming feature, reducing number of possible checks. Also just general less possible binaries.
