### PR TITLE
Explicit cargo-binstall support

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -81,3 +81,7 @@ clipboard = ["copypasta"]
 daemon = ["daemonize"]
 
 default = ["rodio-backend", "media-control", "clipboard"]
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }_{ target }{ archive-suffix }"
+


### PR DESCRIPTION
`cargo-binstall` is a cargo subcommand that allows users to install rust binary crates directly from github release binaries, without having to compile it themselves from source.

This PR significantly reduces the number of required GH API requests for cargo-binstall users, shaving 2 seconds off cargo-binstall installation.

Note: the most "native" way of doing this is naming the releases according to their own usual pattern, but tbh seems unnecessary to complicate things