### PR TITLE
Extended CI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   RUST_FEATURES: "rodio-backend,lyric-finder,media-control,image,notify,clipboard"
+  LINUX_PACKAGES: "libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev"
 
 jobs:
    msrv:
@@ -26,7 +27,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - run: sudo apt-get update && sudo apt-get install ${{ env.LINUX_PACKAGES }}
         if: ${{ runner.os == 'Linux'}}
       - uses: actions/checkout@v4
       
@@ -58,7 +59,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update && sudo apt-get install ${{ env.LINUX_PACKAGES }}
         if: ${{ runner.os == 'Linux' }}
 
       - name: Checkout source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,33 @@ env:
   RUST_FEATURES: "rodio-backend,lyric-finder,media-control,image,notify,clipboard"
 
 jobs:
-  rust-ci:
+   msrv:
+    if: github.event.pull_request.draft != true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            OS_SPECIFIC_FEATURES: ",daemon, sixel"
+          - os: macOS-latest
+            OS_SPECIFIC_FEATURES: ",sixel"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: sudo apt-get update && sudo apt-get install libssl-dev libasound2-dev libdbus-1-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        if: ${{ runner.os == 'Linux'}}
+      - uses: actions/checkout@v4
+      
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo hack check --rust-version --package spotify_player --all-targets --profile ci --features "${{ env.RUST_FEATURES }} ${{ matrix.OS_SPECIFIC_FEATURES }}"
+
+   rust-ci:
     if: github.event.pull_request.draft != true
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
         include:
           - os: ubuntu-latest
             toolchain: beta
-            OS_SPECIFIC_FEATURES: ",daemon, sixel"
+            OS_SPECIFIC_FEATURES: "daemon sixel"
           - os: ubuntu-latest
-            OS_SPECIFIC_FEATURES: ",daemon, sixel"
+            OS_SPECIFIC_FEATURES: "daemon sixel"
           - os: macOS-latest
-            OS_SPECIFIC_FEATURES: ",sixel"
+            OS_SPECIFIC_FEATURES: "sixel"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
         include:
           - os: ubuntu-latest
             toolchain: beta
+            OS_SPECIFIC_FEATURES: ",daemon, sixel"
+          - os: ubuntu-latest
+            OS_SPECIFIC_FEATURES: ",daemon, sixel"
+          - os: macOS-latest
+            OS_SPECIFIC_FEATURES: ",sixel"
 
     runs-on: ${{ matrix.os }}
 
@@ -75,8 +80,8 @@ jobs:
         run: cargo clippy --no-default-features --profile ci -- -D warnings
 
       - name: Cargo clippy with all features
-        run: cargo clippy --no-default-features --profile ci --features ${{ env.RUST_FEATURES }} -- -D warnings
+        run: cargo clippy --no-default-features --profile ci --features "${{ env.RUST_FEATURES }} ${{ matrix.OS_SPECIFIC_FEATURES }}" -- -D warnings
 
       - name: Cargo test
-        run: cargo test --no-default-features --profile ci --features ${{ env.RUST_FEATURES }}
+        run: cargo test --no-default-features --profile ci --features "${{ env.RUST_FEATURES }} ${{ matrix.OS_SPECIFIC_FEATURES }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,25 +40,17 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
 
-      - name: Cache cargo deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-rustc-${{ steps.install_toolchain.outputs.cachekey }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-rustc-${{ steps.install_toolchain.outputs.cachekey }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo format
         run: cargo fmt --all -- --check
 
-      - name: Cargo test
-        run: cargo test --no-default-features --features ${{ env.RUST_FEATURES }}
+      - name: Cargo clippy without features
+        run: cargo clippy --no-default-features --profile ci -- -D warnings
 
       - name: Cargo clippy with all features
-        run: cargo clippy --no-default-features --features ${{ env.RUST_FEATURES }} -- -D warnings
+        run: cargo clippy --no-default-features --profile ci --features ${{ env.RUST_FEATURES }} -- -D warnings
 
-      - name: Cargo clippy without features
-        run: cargo clippy --no-default-features -- -D warnings
+      - name: Cargo test
+        run: cargo test --no-default-features --profile ci --features ${{ env.RUST_FEATURES }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,14 @@
 members = ["spotify_player", "lyric_finder"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.74"
+
+[profile.ci]
+inherits = "dev"
+debug = 0
+strip = true
+incremental = false
+
 [profile.release]
 debug = 1

--- a/lyric_finder/Cargo.toml
+++ b/lyric_finder/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lyric_finder"
 version = "0.1.5"
 edition = "2021"
+rust-version.workspace = true
 license = "MIT"
 description = "A lyric finder library"
 authors = ["Thang Pham <phamducthang1234@gmail.com>"]

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -3,6 +3,7 @@ name = "spotify_player"
 version = "0.16.3"
 authors = ["Thang Pham <phamducthang1234@gmail.com>"]
 edition = "2021"
+rust-version.workspace = true
 license = "MIT"
 description = "A Spotify player in the terminal with full feature parity"
 repository = "https://github.com/aome510/spotify-player"
@@ -71,14 +72,17 @@ jackaudio-backend = ["streaming", "librespot-playback/jackaudio-backend"]
 rodiojack-backend = ["streaming", "librespot-playback/rodiojack-backend"]
 sdl-backend = ["streaming", "librespot-playback/sdl-backend"]
 gstreamer-backend = ["streaming", "librespot-playback/gstreamer-backend"]
+
 streaming = ["librespot-playback", "librespot-connect"]
-lyric-finder = ["lyric_finder"]
 media-control = ["souvlaki", "winit", "windows"]
+
 image = ["viuer", "dep:image"]
 sixel = ["image", "viuer/sixel"]
+daemon = ["daemonize", "streaming"]
+
+lyric-finder = ["lyric_finder"]
 notify = ["notify-rust"]
 clipboard = ["copypasta"]
-daemon = ["daemonize", "streaming"]
 
 default = ["rodio-backend", "media-control", "clipboard"]
 


### PR DESCRIPTION
Took me a while to get around to it, but finally there's something to show for it.

- Set a MSRV in the Cargo.toml and a new MSRV job
- Check OS specific features, both in MSRV and general CI job
- Cache `./target/` and creates a CI profile to reduce its cache usage, though Swatinem does a good job already 
- Reorders calls to `cargo clippy` and `test` to have the quickest at the beginning

I also took the liberty of reordering the features in the Cargo.toml file, in decreasing number of dependencies, mostly. We can drop that.
New (action) dependencies: [taiki-e/install-action@v2](https://github.com/taiki-e/install-action) and [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)

