### PR TITLE
re-render image if the last rectangle is different from the current one

### DIFF
--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -10,6 +10,14 @@ use super::*;
 pub use page::*;
 pub use popup::*;
 
+#[derive(Default, Debug)]
+pub struct ImageRenderInfo {
+    pub url: String,
+    pub render_area: tui::layout::Rect,
+    /// indicates if the image is rendered
+    pub rendered: bool,
+}
+
 /// Application's UI state
 #[derive(Debug)]
 pub struct UIState {
@@ -25,7 +33,7 @@ pub struct UIState {
     pub playback_progress_bar_rect: tui::layout::Rect,
 
     #[cfg(feature = "image")]
-    pub last_cover_image_render_info: Option<(String, tui::layout::Rect)>,
+    pub last_cover_image_render_info: ImageRenderInfo,
 }
 
 impl UIState {
@@ -86,7 +94,7 @@ impl Default for UIState {
     fn default() -> Self {
         Self {
             is_running: true,
-            theme: config::Theme::default(),
+            theme: Default::default(),
             input_key_sequence: key::KeySequence { keys: vec![] },
 
             history: vec![PageState::Library {
@@ -94,10 +102,10 @@ impl Default for UIState {
             }],
             popup: None,
 
-            playback_progress_bar_rect: tui::layout::Rect::default(),
+            playback_progress_bar_rect: Default::default(),
 
             #[cfg(feature = "image")]
-            last_cover_image_render_info: None,
+            last_cover_image_render_info: Default::default(),
         }
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -88,14 +88,18 @@ fn render_application(
     ui: &mut UIStateGuard,
     rect: Rect,
 ) -> Result<()> {
-    // rendering order: help popup -> other popups -> playback window -> main layout
+    // rendering order: playback window -> help popup -> other popups -> main layout
+    //
+    // Playback window is rendered first to make sure the window's position is fixed
+    // which avoids any rendering issues with the cover image area.
+    // See: https://github.com/aome510/spotify-player/issues/389
+
+    let (playback_rect, rect) = playback::split_rect_for_playback_window(rect, state);
+    playback::render_playback_window(frame, state, ui, playback_rect)?;
 
     let rect = popup::render_shortcut_help_popup(frame, state, ui, rect);
 
     let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
-
-    let (playback_rect, rect) = playback::split_rect_for_playback_window(rect, state);
-    playback::render_playback_window(frame, state, ui, playback_rect)?;
 
     render_main_layout(is_active, frame, state, ui, rect)?;
     Ok(())

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -32,7 +32,7 @@ pub fn run(state: SharedState) -> Result<()> {
                 #[cfg(feature = "image")]
                 {
                     // redraw the cover image when the terminal's size changes
-                    ui.last_cover_image_render_info = None;
+                    ui.last_cover_image_render_info = Default::default();
                 }
             }
 

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -59,7 +59,9 @@ pub fn render_playback_window(
                         let url = crate::utils::get_track_album_image_url(track).map(String::from);
                         if let Some(url) = url {
                             let needs_render = match &ui.last_cover_image_render_info {
-                                Some((last_url, _)) => *last_url != url,
+                                Some((last_url, last_rect)) => {
+                                    *last_url != url || *last_rect != cover_img_rect
+                                }
                                 None => true,
                             };
                             if needs_render {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -59,14 +59,14 @@ pub fn render_playback_window(
                             if needs_render {
                                 render_playback_cover_image(frame, state, ui, cover_img_rect, url)
                                     .context("render playback's cover image")?;
-                            }
-                        }
-
-                        // set the `skip` state of cells in the cover image area
-                        // to prevent buffer from overwriting image cells
-                        for x in cover_img_rect.left()..cover_img_rect.right() {
-                            for y in cover_img_rect.top()..cover_img_rect.bottom() {
-                                frame.buffer_mut().get_mut(x, y).set_skip(true);
+                            } else {
+                                // set the `skip` state of cells in the cover image area
+                                // to prevent buffer from overwriting the image's rendered area
+                                for x in cover_img_rect.left()..cover_img_rect.right() {
+                                    for y in cover_img_rect.top()..cover_img_rect.bottom() {
+                                        frame.buffer_mut().get_mut(x, y).set_skip(true);
+                                    }
+                                }
                             }
                         }
 
@@ -301,7 +301,9 @@ fn render_playback_cover_image(
         let width = (rect.width as f32 * scale).round() as u32;
         let height = (rect.height as f32 * scale).round() as u32;
 
-        frame.render_widget(Clear, rect);
+        // clear the image's area to ensure no remaining artifacts when rendering the image
+        // See: https://github.com/aome510/spotify-player/issues/389
+        frame.render_widget(Block::new(), rect);
 
         viuer::print(
             image,


### PR DESCRIPTION
Resolves #389 

This PR also reverts the rendering order back to the before `v0.17.0` in which playback window is rendered before any popups.