### PR TITLE
ensure no popup is rendered on top the playback window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         toolchain: [stable]
-        include:
-          - os: ubuntu-latest
-            toolchain: beta
 
     runs-on: ${{ matrix.os }}
 
@@ -61,4 +58,3 @@ jobs:
 
       - name: Cargo clippy without features
         run: cargo clippy --no-default-features -- -D warnings
-

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -88,14 +88,16 @@ fn render_application(
     ui: &mut UIStateGuard,
     rect: Rect,
 ) -> Result<()> {
-    // rendering order: help popup -> other popups -> playback window -> main layout
+    // rendering order: shortcut help popup -> playback window -> other popups -> main layout
 
     let rect = popup::render_shortcut_help_popup(frame, state, ui, rect);
 
-    let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
-
+    // render playback window before other popups to ensure no popup is rendered on top
+    // of the playback window
     let (playback_rect, rect) = playback::split_rect_for_playback_window(rect, state);
     playback::render_playback_window(frame, state, ui, playback_rect)?;
+
+    let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
 
     render_main_layout(is_active, frame, state, ui, rect)?;
     Ok(())

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -82,20 +82,12 @@ pub fn render_popup(
                 (chunks[0], true)
             }
             PopupState::CommandHelp { .. } => {
-                // the command help popup will cover the entire main layout
-                let chunks =
-                    Layout::vertical([Constraint::Fill(0), Constraint::Length(0)]).split(rect);
-
-                render_commands_help_popup(frame, state, ui, chunks[0]);
-                (chunks[1], false)
+                render_commands_help_popup(frame, state, ui, rect);
+                (Rect::default(), false)
             }
             PopupState::Queue { .. } => {
-                // the queue popup will cover the entire main layout
-                let chunks =
-                    Layout::vertical([Constraint::Fill(0), Constraint::Length(0)]).split(rect);
-
-                render_queue_popup(frame, state, ui, chunks[0]);
-                (chunks[1], false)
+                render_queue_popup(frame, state, ui, rect);
+                (Rect::default(), false)
             }
             PopupState::ActionList(item, _) => {
                 let rect = render_list_popup(


### PR DESCRIPTION
Resolves #399.

Fix rendering issue with `image` feature when a popup is rendered on top of the cover image. This PR updates the UI logic to ensure that the whole playback window is always visible from the UI.