### PR TITLE
Refactor client request handling module

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -94,7 +94,6 @@ async fn current_playback(
     match state {
         Some(ref state) => Ok(state.player.read().current_playback()),
         None => client
-            .spotify
             .current_playback(None, None::<Vec<_>>)
             .await
             .context("get current playback"),
@@ -106,7 +105,7 @@ async fn handle_socket_request(
     state: &Option<SharedState>,
     request: super::Request,
 ) -> Result<Vec<u8>> {
-    if client.spotify.session().await.is_invalid() {
+    if client.session().await.is_invalid() {
         if let Some(state) = state {
             tracing::info!("Spotify client's session is invalid, re-creating a new session...");
             client.new_session(state).await?;
@@ -126,7 +125,7 @@ async fn handle_socket_request(
             let id = match data {
                 IdOrName::Id(id) => id,
                 IdOrName::Name(name) => {
-                    let devices = client.spotify.device().await?;
+                    let devices = client.device().await?;
                     match devices
                         .into_iter()
                         .find(|d| d.name == name)
@@ -140,7 +139,7 @@ async fn handle_socket_request(
                 }
             };
 
-            client.spotify.transfer_playback(&id, None).await?;
+            client.transfer_playback(&id, None).await?;
             Ok(Vec::new())
         }
         Request::Like { unlike } => {
@@ -157,12 +156,9 @@ async fn handle_socket_request(
 
             if let Some(id) = track.and_then(|t| t.id.to_owned()) {
                 if unlike {
-                    client
-                        .spotify
-                        .current_user_saved_tracks_delete([id])
-                        .await?;
+                    client.current_user_saved_tracks_delete([id]).await?;
                 } else {
-                    client.spotify.current_user_saved_tracks_add([id]).await?;
+                    client.current_user_saved_tracks_add([id]).await?;
                 }
             }
 
@@ -186,7 +182,7 @@ async fn handle_get_key_request(
             serde_json::to_vec(&playback)?
         }
         Key::Devices => {
-            let devices = client.spotify.device().await?;
+            let devices = client.device().await?;
             serde_json::to_vec(&devices)?
         }
         Key::UserPlaylists => {
@@ -210,7 +206,7 @@ async fn handle_get_key_request(
             serde_json::to_vec(&artists)?
         }
         Key::Queue => {
-            let queue = client.spotify.current_user_queue().await?;
+            let queue = client.current_user_queue().await?;
             serde_json::to_vec(&queue)?
         }
     })
@@ -325,10 +321,7 @@ async fn handle_playback_request(
     let playback = match state {
         Some(state) => state.player.read().buffered_playback.clone(),
         None => {
-            let playback = client
-                .spotify
-                .current_playback(None, None::<Vec<_>>)
-                .await?;
+            let playback = client.current_playback(None, None::<Vec<_>>).await?;
             playback.as_ref().map(SimplifiedPlayback::from_playback)
         }
     };
@@ -412,7 +405,6 @@ async fn handle_playback_request(
             // the function scope is from the application's state (cached) or the `current_playback` API.
             // Therefore, we need to make an additional API request to get the playback's progress.
             let progress = client
-                .spotify
                 .current_playback(None, None::<Vec<_>>)
                 .await?
                 .context("no active playback found!")?
@@ -456,7 +448,7 @@ async fn handle_playback_request(
 }
 
 async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> Result<String> {
-    let uid = client.spotify.current_user().await?.id;
+    let uid = client.current_user().await?.id;
 
     match command {
         PlaylistCommand::New {
@@ -466,7 +458,6 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
             description,
         } => {
             let resp = client
-                .spotify
                 .user_playlist_create(
                     uid,
                     name.as_str(),
@@ -482,7 +473,6 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
         }
         PlaylistCommand::Delete { id } => {
             let following = client
-                .spotify
                 .playlist_check_follow(id.to_owned(), &[uid])
                 .await
                 .context(format!("Could not find playlist '{}'", id.id()))?
@@ -491,7 +481,7 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
 
             // Won't delete if not following
             if following {
-                client.spotify.playlist_unfollow(id.to_owned()).await?;
+                client.playlist_unfollow(id.to_owned()).await?;
                 Ok(format!("Playlist '{id}' was deleted/unfollowed"))
             } else {
                 Ok(format!(
@@ -517,14 +507,12 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
         } => playlist_import(client, import_from, import_to, delete).await,
         PlaylistCommand::Fork { id } => {
             let from = client
-                .spotify
                 .playlist(id.to_owned(), None, None)
                 .await
                 .context(format!("Cannot import from {}.", id.id()))?;
             let from_desc = from.description.unwrap_or_default();
 
             let to = client
-                .spotify
                 .user_playlist_create(
                     uid,
                     &from.name,
@@ -567,7 +555,6 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
                 }
 
                 let pl_follow = client
-                    .spotify
                     .playlist_check_follow(to_id.as_ref(), &[uid.as_ref()])
                     .await?
                     .pop()
@@ -681,7 +668,6 @@ async fn playlist_import(
 
                 if track_buff.len() == TRACK_BUFFER_CAP {
                     client
-                        .spotify
                         .playlist_remove_all_occurrences_of_items(
                             import_to.as_ref(),
                             track_buff,
@@ -694,7 +680,6 @@ async fn playlist_import(
 
             if !track_buff.is_empty() {
                 client
-                    .spotify
                     .playlist_remove_all_occurrences_of_items(import_to.as_ref(), track_buff, None)
                     .await?;
             }
@@ -716,7 +701,6 @@ async fn playlist_import(
 
         if track_buff.len() == TRACK_BUFFER_CAP {
             client
-                .spotify
                 .playlist_add_items(import_to.as_ref(), track_buff, None)
                 .await?;
             track_buff = Vec::new();
@@ -727,7 +711,6 @@ async fn playlist_import(
 
     if !track_buff.is_empty() {
         client
-            .spotify
             .playlist_add_items(import_to.as_ref(), track_buff, None)
             .await?;
     }

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -12,9 +12,8 @@ use tracing::Instrument;
 
 use crate::{
     cli::Request,
-    client::Client,
+    client::{Client, PlayerRequest},
     config::get_cache_folder_path,
-    event::PlayerRequest,
     state::{Context, ContextId, Playback, SharedState, SimplifiedPlayback},
 };
 use rspotify::{

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -7,6 +7,7 @@ use super::*;
 use anyhow::{Context, Result};
 use clap::{ArgMatches, Id};
 use clap_complete::{generate, Shell};
+use rspotify::clients::BaseClient;
 use std::net::UdpSocket;
 
 fn receive_response(socket: &UdpSocket) -> Result<Response> {
@@ -159,7 +160,7 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &state::Configs) -> Result
             // create a Spotify API client
             let client =
                 client::Client::new(session, auth_config, configs.app_config.client_id.clone());
-            rt.block_on(client.init_token())?;
+            rt.block_on(client.refresh_token())?;
 
             // create a client socket for handling CLI commands
             let client_socket = rt.block_on(tokio::net::UdpSocket::bind(("127.0.0.1", port)))?;

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -2,10 +2,12 @@ use anyhow::Context;
 use rspotify::model::PlayableItem;
 use tracing::Instrument;
 
-use crate::{event::ClientRequest, state::*};
+use crate::state::*;
 
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
+
+use super::ClientRequest;
 
 struct PlayerEventHandlerState {
     add_track_to_queue_req_timer: std::time::Instant,

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -20,12 +20,9 @@ pub async fn start_client_handler(
     client_sub: flume::Receiver<ClientRequest>,
 ) {
     while let Ok(request) = client_sub.recv_async().await {
-        if client.spotify.session().await.is_invalid() {
-            tracing::info!("Spotify client's session is invalid, re-creating a new session...");
-            if let Err(err) = client.new_session(&state).await {
-                tracing::error!("Failed to create a new session: {err:#}");
-                continue;
-            }
+        if let Err(err) = client.check_valid_session(&state).await {
+            tracing::error!("{err:#}");
+            continue;
         }
 
         let state = state.clone();

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -2,11 +2,7 @@ use std::{borrow::Cow, collections::HashMap, io::Write, sync::Arc};
 
 #[cfg(feature = "streaming")]
 use crate::streaming;
-use crate::{
-    auth::AuthConfig,
-    event::{ClientRequest, PlayerRequest},
-    state::*,
-};
+use crate::{auth::AuthConfig, state::*};
 
 use anyhow::Context as _;
 use anyhow::Result;
@@ -20,9 +16,11 @@ use rspotify::{
 };
 
 mod handlers;
+mod request;
 mod spotify;
 
 pub use handlers::*;
+pub use request::*;
 use serde::Deserialize;
 
 /// The application's client

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -654,7 +654,6 @@ impl Client {
             )
             .await?;
         // let first_page = self
-        //
         //     .current_user_playlists_manual(Some(50), None)
         //     .await?;
 
@@ -770,7 +769,7 @@ impl Client {
         Ok(())
     }
 
-    /// Get recommended (radio) tracks based on a seed
+    /// Get recommendation (radio) tracks based on a seed
     pub async fn radio_tracks(&self, seed_uri: String) -> Result<Vec<Track>> {
         let session = self.session().await;
 
@@ -874,7 +873,7 @@ impl Client {
         })
     }
 
-    /// Search for items of a specific type
+    /// Search for items of a specific type matching a given query
     pub async fn search_specific_type(
         &self,
         query: &str,
@@ -1107,7 +1106,6 @@ impl Client {
         // TODO: this should use `rspotify::playlist` API instead of `internal_call`
         // See: https://github.com/ramsayleung/rspotify/issues/459
         // let playlist = self
-        //
         //     .playlist(playlist_id, None, Some(Market::FromToken))
         //     .await?;
         let playlist = self
@@ -1200,7 +1198,7 @@ impl Client {
         })
     }
 
-    /// Call a GET HTTP request to the Spotify server
+    /// Make a GET HTTP request to the Spotify server
     async fn http_get<T>(&self, url: &str, payload: &Query<'_>) -> Result<T>
     where
         T: serde::de::DeserializeOwned,

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -1,0 +1,68 @@
+use crate::state::*;
+
+#[derive(Clone, Debug)]
+/// A request that modifies the player's playback
+pub enum PlayerRequest {
+    NextTrack,
+    PreviousTrack,
+    Resume,
+    Pause,
+    ResumePause,
+    SeekTrack(chrono::Duration),
+    Repeat,
+    Shuffle,
+    Volume(u8),
+    ToggleMute,
+    TransferPlayback(String, bool),
+    StartPlayback(Playback, Option<bool>),
+}
+
+#[derive(Clone, Debug)]
+/// A request to the client
+pub enum ClientRequest {
+    GetCurrentUser,
+    GetDevices,
+    GetBrowseCategories,
+    GetBrowseCategoryPlaylists(Category),
+    GetUserPlaylists,
+    GetUserSavedAlbums,
+    GetUserFollowedArtists,
+    GetUserSavedTracks,
+    GetUserTopTracks,
+    GetUserRecentlyPlayedTracks,
+    GetContext(ContextId),
+    GetCurrentPlayback,
+    GetRadioTracks {
+        seed_uri: String,
+        seed_name: String,
+    },
+    Search(String),
+    AddTrackToQueue(TrackId<'static>),
+    AddTrackToPlaylist(PlaylistId<'static>, TrackId<'static>),
+    DeleteTrackFromPlaylist(PlaylistId<'static>, TrackId<'static>),
+    ReorderPlaylistItems {
+        playlist_id: PlaylistId<'static>,
+        insert_index: usize,
+        range_start: usize,
+        range_length: Option<usize>,
+        snapshot_id: Option<String>,
+    },
+    AddToLibrary(Item),
+    DeleteFromLibrary(ItemId),
+    ConnectDevice(Option<String>),
+    Player(PlayerRequest),
+    GetCurrentUserQueue,
+    #[cfg(feature = "lyric-finder")]
+    GetLyric {
+        track: String,
+        artists: String,
+    },
+    #[cfg(feature = "streaming")]
+    RestartIntegratedClient,
+    CreatePlaylist {
+        playlist_name: String,
+        public: bool,
+        collab: bool,
+        desc: String,
+    },
+}

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -65,4 +65,6 @@ pub enum ClientRequest {
         collab: bool,
         desc: String,
     },
+    #[cfg(feature = "streaming")]
+    HandleStreamingEvent(crate::streaming::PlayerEvent),
 }

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -65,6 +65,4 @@ pub enum ClientRequest {
         collab: bool,
         desc: String,
     },
-    #[cfg(feature = "streaming")]
-    HandleStreamingEvent(crate::streaming::PlayerEvent),
 }

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -49,7 +49,7 @@ pub enum ClientRequest {
     },
     AddToLibrary(Item),
     DeleteFromLibrary(ItemId),
-    ConnectDevice(Option<String>),
+    ConnectDevice,
     Player(PlayerRequest),
     GetCurrentUserQueue,
     #[cfg(feature = "lyric-finder")]

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -20,9 +20,8 @@ pub struct Spotify {
     token: Arc<Mutex<Option<Token>>>,
     client_id: String,
     http: HttpClient,
-    // session should be always non-empty, but `Option` is required
-    // for the struct to implement `Default`, which is required to
-    // implement `rspotify::BaseClient`
+    // session should always be non-empty, but `Option` is used to implement `Default`,
+    // which is required to implement `rspotify::BaseClient` trait
     pub(crate) session: Arc<tokio::sync::Mutex<Option<Session>>>,
 }
 

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client::{ClientRequest, PlayerRequest},
     command::{self, Command},
     config,
     key::{Key, KeySequence},
@@ -14,73 +15,6 @@ use anyhow::{Context as _, Result};
 mod page;
 mod popup;
 mod window;
-
-#[derive(Debug)]
-/// A request that modifies the player's playback
-pub enum PlayerRequest {
-    NextTrack,
-    PreviousTrack,
-    Resume,
-    Pause,
-    ResumePause,
-    SeekTrack(chrono::Duration),
-    Repeat,
-    Shuffle,
-    Volume(u8),
-    ToggleMute,
-    TransferPlayback(String, bool),
-    StartPlayback(Playback, Option<bool>),
-}
-
-#[derive(Debug)]
-/// A request to the client
-pub enum ClientRequest {
-    GetCurrentUser,
-    GetDevices,
-    GetBrowseCategories,
-    GetBrowseCategoryPlaylists(Category),
-    GetUserPlaylists,
-    GetUserSavedAlbums,
-    GetUserFollowedArtists,
-    GetUserSavedTracks,
-    GetUserTopTracks,
-    GetUserRecentlyPlayedTracks,
-    GetContext(ContextId),
-    GetCurrentPlayback,
-    GetRadioTracks {
-        seed_uri: String,
-        seed_name: String,
-    },
-    Search(String),
-    AddTrackToQueue(TrackId<'static>),
-    AddTrackToPlaylist(PlaylistId<'static>, TrackId<'static>),
-    DeleteTrackFromPlaylist(PlaylistId<'static>, TrackId<'static>),
-    ReorderPlaylistItems {
-        playlist_id: PlaylistId<'static>,
-        insert_index: usize,
-        range_start: usize,
-        range_length: Option<usize>,
-        snapshot_id: Option<String>,
-    },
-    AddToLibrary(Item),
-    DeleteFromLibrary(ItemId),
-    ConnectDevice(Option<String>),
-    Player(PlayerRequest),
-    GetCurrentUserQueue,
-    #[cfg(feature = "lyric-finder")]
-    GetLyric {
-        track: String,
-        artists: String,
-    },
-    #[cfg(feature = "streaming")]
-    RestartIntegratedClient,
-    CreatePlaylist {
-        playlist_name: String,
-        public: bool,
-        collab: bool,
-        desc: String,
-    },
-}
 
 /// starts a terminal event handler (key pressed, mouse clicked, etc)
 pub fn start_event_handler(state: SharedState, client_pub: flume::Sender<ClientRequest>) {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result};
 use std::io::Write;
 
 async fn init_spotify(
-    client_pub: &flume::Sender<event::ClientRequest>,
+    client_pub: &flume::Sender<client::ClientRequest>,
     client: &client::Client,
     state: &state::SharedState,
 ) -> Result<()> {
@@ -33,15 +33,15 @@ async fn init_spotify(
 
     if state.player.read().playback.is_none() {
         tracing::info!("No playback found on startup, trying to connect to an available device...");
-        client_pub.send(event::ClientRequest::ConnectDevice(None))?;
+        client_pub.send(client::ClientRequest::ConnectDevice(None))?;
     }
 
     // request user data
-    client_pub.send(event::ClientRequest::GetCurrentUser)?;
-    client_pub.send(event::ClientRequest::GetUserPlaylists)?;
-    client_pub.send(event::ClientRequest::GetUserFollowedArtists)?;
-    client_pub.send(event::ClientRequest::GetUserSavedAlbums)?;
-    client_pub.send(event::ClientRequest::GetUserSavedTracks)?;
+    client_pub.send(client::ClientRequest::GetCurrentUser)?;
+    client_pub.send(client::ClientRequest::GetUserPlaylists)?;
+    client_pub.send(client::ClientRequest::GetUserFollowedArtists)?;
+    client_pub.send(client::ClientRequest::GetUserSavedAlbums)?;
+    client_pub.send(client::ClientRequest::GetUserSavedTracks)?;
 
     Ok(())
 }
@@ -93,7 +93,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     }
 
     // client channels
-    let (client_pub, client_sub) = flume::unbounded::<event::ClientRequest>();
+    let (client_pub, client_sub) = flume::unbounded::<client::ClientRequest>();
 
     #[cfg(feature = "pulseaudio-backend")]
     {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -34,7 +34,7 @@ async fn init_spotify(
 
     if state.player.read().playback.is_none() {
         tracing::info!("No playback found on startup, trying to connect to an available device...");
-        client_pub.send(client::ClientRequest::ConnectDevice(None))?;
+        client_pub.send(client::ClientRequest::ConnectDevice)?;
     }
 
     // request user data

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -15,6 +15,7 @@ mod ui;
 mod utils;
 
 use anyhow::{Context, Result};
+use rspotify::clients::BaseClient;
 use std::io::Write;
 
 async fn init_spotify(
@@ -29,7 +30,7 @@ async fn init_spotify(
     }
 
     // initialize the playback state
-    client.update_current_playback_state(state, false).await?;
+    client.retrieve_current_playback(state, false).await?;
 
     if state.player.read().playback.is_none() {
         tracing::info!("No playback found on startup, trying to connect to an available device...");
@@ -131,7 +132,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
         auth_config,
         state.configs.app_config.client_id.clone(),
     );
-    client.init_token().await?;
+    client.refresh_token().await?;
 
     // initialize Spotify-related stuff
     init_spotify(&client_pub, &client, state)

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -4,7 +4,7 @@ use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, P
 
 use crate::utils;
 use crate::{
-    event::{ClientRequest, PlayerRequest},
+    client::{ClientRequest, PlayerRequest},
     state::SharedState,
     utils::map_join,
 };

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -93,9 +93,8 @@ pub enum ItemId {
     Playlist(PlaylistId<'static>),
 }
 
-/// A simplified version of `rspotify::CurrentPlaybackContext`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SimplifiedPlayback {
+pub struct PlaybackMetadata {
     pub device_name: String,
     pub device_id: Option<String>,
     pub volume: Option<u32>,
@@ -477,7 +476,7 @@ impl Playback {
     }
 }
 
-impl SimplifiedPlayback {
+impl PlaybackMetadata {
     pub fn from_playback(p: &CurrentPlaybackContext) -> Self {
         Self {
             device_name: p.device.name.clone(),

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -7,18 +7,18 @@ pub struct PlayerState {
 
     pub playback: Option<rspotify_model::CurrentPlaybackContext>,
     pub playback_last_updated_time: Option<std::time::Instant>,
-    /// a buffered state to speedup the feedback of playback metadata update to user
+    /// A buffered state to speedup the feedback of playback metadata update to user
     // Related issue: https://github.com/aome510/spotify-player/issues/109
-    pub buffered_playback: Option<SimplifiedPlayback>,
+    pub buffered_playback: Option<PlaybackMetadata>,
 
     pub queue: Option<rspotify_model::CurrentUserQueue>,
 }
 
 impl PlayerState {
-    /// gets the current playback
+    /// Get the current playback
     ///
     /// # Note
-    /// Because playback data stored inside the player state is buffered and cached,
+    /// Because playback metadata stored inside the player state is buffered,
     /// the returned playback is estimated based on the available data.
     pub fn current_playback(&self) -> Option<rspotify_model::CurrentPlaybackContext> {
         let mut playback = self.playback.clone()?;
@@ -46,7 +46,6 @@ impl PlayerState {
         Some(playback)
     }
 
-    /// gets the current playing track
     pub fn current_playing_track(&self) -> Option<&rspotify_model::FullTrack> {
         match self.playback {
             None => None,
@@ -57,7 +56,6 @@ impl PlayerState {
         }
     }
 
-    /// gets the current playback progress
     pub fn playback_progress(&self) -> Option<chrono::Duration> {
         match self.playback {
             None => None,
@@ -76,7 +74,6 @@ impl PlayerState {
         }
     }
 
-    /// gets the current playing context's ID
     pub fn playing_context_id(&self) -> Option<ContextId> {
         match self.playback {
             Some(ref playback) => match playback.context {

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -37,8 +37,8 @@ compile_error!("Streaming feature is enabled but no audio backend has been selec
 For more information, visit https://github.com/aome510/spotify-player?tab=readme-ov-file#streaming
 ");
 
-#[derive(Debug, Serialize)]
-enum PlayerEvent {
+#[derive(Clone, Debug, Serialize)]
+pub enum PlayerEvent {
     Changed {
         old_track_id: TrackId<'static>,
         new_track_id: TrackId<'static>,
@@ -219,8 +219,6 @@ pub fn new_connection(
                         tracing::warn!("Failed to convert a `librespot` player event into `spotify_player` player event: {err:#}");
                     }
                     Ok(Some(event)) => {
-                        tracing::info!("Got a new player event: {event:?}");
-
                         // execute a player event hook command
                         if let Some(ref cmd) = player_event_hook_command {
                             if let Err(err) = execute_player_event_hook_command(cmd, event) {

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -1,8 +1,7 @@
-use crate::config;
+use crate::{config, state::SharedState};
 use librespot_connect::spirc::Spirc;
 use librespot_core::{
     config::{ConnectConfig, DeviceType},
-    session::Session,
     spotify_id,
 };
 use librespot_playback::mixer::MixerConfig;
@@ -161,18 +160,17 @@ fn execute_player_event_hook_command(
 }
 
 /// Create a new streaming connection
-pub fn new_connection(
-    session: Session,
-    device: config::DeviceConfig,
-    player_event_hook_command: Option<config::Command>,
-) -> Spirc {
+pub async fn new_connection(client: crate::client::Client, state: SharedState) -> Spirc {
+    let session = client.session().await;
+    let device = &state.configs.app_config.device;
+
     // `librespot` volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
     // So we need to convert from one format to another
     let volume = (std::cmp::min(device.volume, 100_u8) as f64 / 100.0 * 65535.0).round() as u16;
 
     let connect_config = ConnectConfig {
-        name: device.name,
+        name: device.name.clone(),
         device_type: device.device_type.parse::<DeviceType>().unwrap_or_default(),
         initial_volume: Some(volume),
 
@@ -219,8 +217,11 @@ pub fn new_connection(
                         tracing::warn!("Failed to convert a `librespot` player event into `spotify_player` player event: {err:#}");
                     }
                     Ok(Some(event)) => {
+                        tracing::info!("Got a new player event: {event:?}");
+                        client.update_playback(&state);
+
                         // execute a player event hook command
-                        if let Some(ref cmd) = player_event_hook_command {
+                        if let Some(ref cmd) = state.configs.app_config.player_event_hook_command {
                             if let Err(err) = execute_player_event_hook_command(cmd, event) {
                                 tracing::warn!(
                                     "Failed to execute player event hook command: {err:#}"

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -1,4 +1,4 @@
-use crate::{config, state::SharedState};
+use crate::{client::Client, config, state::SharedState};
 use librespot_connect::spirc::Spirc;
 use librespot_core::{
     config::{ConnectConfig, DeviceType},
@@ -160,7 +160,7 @@ fn execute_player_event_hook_command(
 }
 
 /// Create a new streaming connection
-pub async fn new_connection(client: crate::client::Client, state: SharedState) -> Spirc {
+pub async fn new_connection(client: Client, state: SharedState) -> Spirc {
     let session = client.session().await;
     let device = &state.configs.app_config.device;
 

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -37,8 +37,8 @@ compile_error!("Streaming feature is enabled but no audio backend has been selec
 For more information, visit https://github.com/aome510/spotify-player?tab=readme-ov-file#streaming
 ");
 
-#[derive(Clone, Debug, Serialize)]
-pub enum PlayerEvent {
+#[derive(Debug, Serialize)]
+enum PlayerEvent {
     Changed {
         old_track_id: TrackId<'static>,
         new_track_id: TrackId<'static>,

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -149,7 +149,7 @@ fn render_playback_text(
     ui: &UIStateGuard,
     rect: Rect,
     track: &rspotify_model::FullTrack,
-    playback: &SimplifiedPlayback,
+    playback: &PlaybackMetadata,
 ) {
     // Construct a "styled" text (`playback_text`) from playback's data
     // based on a user-configurable format string (app_config.playback_format)

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -33,6 +33,7 @@ where
     })
 }
 
+#[allow(dead_code)]
 pub fn get_track_album_image_url(track: &rspotify::model::FullTrack) -> Option<&str> {
     if track.album.images.is_empty() {
         None


### PR DESCRIPTION
Resolves #415

## Changes
- update player's playback state upon receiving new player event from the integrated client
- move `ClientRequest` and `PlayerRequest` from `event` module to `client::request` module
- clean up client request handling codes, update comments/documentations