### PR TITLE
Better clipboard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "clipboard-win"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1136,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "exr"
@@ -4305,6 +4320,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clipboard-win",
  "config_parser2",
  "crossterm",
  "daemonize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,6 +4335,7 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "viuer",
+ "which",
  "windows 0.54.0",
  "winit",
 ]
@@ -5243,6 +5253,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5612,6 +5634,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "x11-dl"

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,39 +21,37 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify_player` uses `app.toml` to configure general application configurations:
 
-| Option                            | Description                                                                              | Default                                                                                                          |
-| --------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                                                                               |
-| `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                                                                           |
-| `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                                                                             |
-| `playback_format`                 | the format of the text in the playback's window                                          | `{track} • {artists}\n{album}\n{metadata}`                                                                       |
-| `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }`                                                          |
-| `notify_timeout_in_secs`          | the timeout (in seconds) of a notification (`notify` feature only)                       | `0` (no timeout)                                                                                                 |
-| `copy_command`                    | the command used to execute a copy-to-clipboard action                                   | depends on the OS, see [example config](https://github.com/aome510/spotify-player/blob/master/examples/app.toml) |
-| `paste_command`                   | the command used to get clipboard's content                                              | depends on the OS, see [example config](https://github.com/aome510/spotify-player/blob/master/examples/app.toml) |
-| `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                                                                           |
-| `ap_port`                         | the application's Spotify session connection port                                        | `None`                                                                                                           |
-| `proxy`                           | the application's Spotify session connection proxy                                       | `None`                                                                                                           |
-| `theme`                           | the application's theme                                                                  | `default`                                                                                                        |
-| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes                       | `32`                                                                                                             |
-| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                                                                              |
-| `page_size_in_rows`               | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                                                                             |
-| `enable_media_control`            | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)                                                                      |
-| `enable_streaming`                | enable streaming (`streaming` feature only)                                              | `Always`                                                                                                         |
-| `enable_notify`                   | enable notification (`notify` feature only)                                              | `true`                                                                                                           |
-| `enable_cover_image_cache`        | store album's cover images in the cache folder                                           | `true`                                                                                                           |
-| `notify_streaming_only`           | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                                                                          |
-| `default_device`                  | the default device to connect to on startup if no playing device found                   | `spotify-player`                                                                                                 |
-| `play_icon`                       | the icon to indicate playing state of a Spotify item                                     | `▶`                                                                                                             |
-| `pause_icon`                      | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                                                                             |
-| `liked_icon`                      | the icon to indicate the liked state of a song                                           | `♥`                                                                                                             |
-| `border_type`                     | the type of the application's borders                                                    | `Plain`                                                                                                          |
-| `progress_bar_type`               | the type of the playback progress bar                                                    | `Rectangle`                                                                                                      |
-| `playback_window_position`        | the position of the playback window                                                      | `Top`                                                                                                            |
-| `playback_window_width`           | the width of the playback window                                                         | `6`                                                                                                              |
-| `cover_img_width`                 | the width of the cover image (`image` feature only)                                      | `5`                                                                                                              |
-| `cover_img_length`                | the length of the cover image (`image` feature only)                                     | `9`                                                                                                              |
-| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                      | `1.0`                                                                                                            |
+| Option                            | Description                                                                              | Default                                                 |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                      |
+| `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                  |
+| `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                    |
+| `playback_format`                 | the format of the text in the playback's window                                          | `{track} • {artists}\n{album}\n{metadata}`              |
+| `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }` |
+| `notify_timeout_in_secs`          | the timeout (in seconds) of a notification (`notify` feature only)                       | `0` (no timeout)                                        |
+| `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                  |
+| `ap_port`                         | the application's Spotify session connection port                                        | `None`                                                  |
+| `proxy`                           | the application's Spotify session connection proxy                                       | `None`                                                  |
+| `theme`                           | the application's theme                                                                  | `default`                                               |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes                       | `32`                                                    |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                     |
+| `page_size_in_rows`               | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                    |
+| `enable_media_control`            | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)             |
+| `enable_streaming`                | enable streaming (`streaming` feature only)                                              | `Always`                                                |
+| `enable_notify`                   | enable notification (`notify` feature only)                                              | `true`                                                  |
+| `enable_cover_image_cache`        | store album's cover images in the cache folder                                           | `true`                                                  |
+| `notify_streaming_only`           | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                 |
+| `default_device`                  | the default device to connect to on startup if no playing device found                   | `spotify-player`                                        |
+| `play_icon`                       | the icon to indicate playing state of a Spotify item                                     | `▶`                                                    |
+| `pause_icon`                      | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                    |
+| `liked_icon`                      | the icon to indicate the liked state of a song                                           | `♥`                                                    |
+| `border_type`                     | the type of the application's borders                                                    | `Plain`                                                 |
+| `progress_bar_type`               | the type of the playback progress bar                                                    | `Rectangle`                                             |
+| `playback_window_position`        | the position of the playback window                                                      | `Top`                                                   |
+| `playback_window_width`           | the width of the playback window                                                         | `6`                                                     |
+| `cover_img_width`                 | the width of the cover image (`image` feature only)                                      | `5`                                                     |
+| `cover_img_length`                | the length of the cover image (`image` feature only)                                     | `9`                                                     |
+| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                      | `1.0`                                                   |
 
 ### Notes
 
@@ -76,12 +74,6 @@ All configuration files should be placed inside the application's configuration 
   **Note**: the above list might not be up-to-date.
 
 - An example of event that triggers a playback update is the one happening when the current track ends.
-- `copy_command` or `paste_command` is represented by an object with two fields `command` and `args`. For example,
-  ```toml
-  copy_command = { command = "xclip", args = ["-sel", "c"] }
-  paste_command = { command = "xclip", args = ["-o", "-sel", "c"] }
-  ```
-  The copy command should read input from **stdin** while the paste command should print output to **stdout**.
 - `enable_streaming` can be either `Always`, `Never` or `DaemonOnly`. For backwards compatibility, `true` and `false` are still accepted as aliases for `Always` and `Never`.
 - `playback_window_position` can only be either `Top` or `Bottom`.
 - `border_type` can be either `Hidden`, `Plain`, `Rounded`, `Double` or `Thick`.
@@ -96,7 +88,7 @@ MacOS and Windows require **an open window** to listen to OS media event. As a r
 
 ### Player event hook command
 
-Similar to `copy_command`, if specified, `player_event_hook_command` should be an object with two fields `command` and `args`. Each time `spotify_player` receives a new player event, `player_event_hook_command` is executed with the event's data as the script's arguments.
+If specified, `player_event_hook_command` should be an object with two fields `command` and `args`. Each time `spotify_player` receives a new player event, `player_event_hook_command` is executed with the event's data as the script's arguments.
 
 A player event is represented as a list of arguments with either of the following values:
 

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -5,13 +5,6 @@ tracks_playback_limit = 50
 playback_format = "{track} • {artists}\n{album}\n{metadata}"
 notify_format = { summary = "{track} • {artists}", body = "{album}" }
 notify_timeout_in_secs = 0
-# the default `copy_command` is based on the OS
-# copy_command = { command = "pbcopy" } # macos
-# copy_command = { command = "xclip", args = ["-sel", "c"] } # linux
-# copy_command = { command = "clip", args = [] } # windows
-# paste_command = { command = "pbpaste" } # macos
-# paste_command = { command = "xclip", args = ["-o", "-sel", "c"] } # linux
-# paste_command = { command = "powershell", args = ["-command", "Get-Clipboard"] } # windows
 app_refresh_duration_in_ms = 32
 playback_refresh_duration_in_ms = 0
 page_size_in_rows = 20

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -46,6 +46,7 @@ regex = "1.10.4"
 daemonize = { version = "0.5.0", optional = true }
 ttl_cache = "0.5.1"
 clap_complete = "4.5.1"
+which = "6.0.1"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
 version = "0.29.15"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -52,6 +52,9 @@ which = "6.0.1"
 version = "0.29.15"
 optional = true
 
+[target.'cfg(target_os = "windows")'.dependencies.clipboard-win]
+version = "5.3.1"
+
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.54.0"
 features = [

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -177,7 +177,7 @@ impl Command {
     {
         Self {
             command: command.to_string(),
-            args: args.into_iter().map(|a| a.to_string()).collect(),
+            args: args.iter().map(|a| a.to_string()).collect(),
         }
     }
 }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -169,6 +169,19 @@ impl From<StreamingTypeOrBool> for StreamingType {
     }
 }
 
+impl Command {
+    pub fn new<C, A>(command: C, args: &[A]) -> Self
+    where
+        C: std::fmt::Display,
+        A: std::fmt::Display,
+    {
+        Self {
+            command: command.to_string(),
+            args: args.into_iter().map(|a| a.to_string()).collect(),
+        }
+    }
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -25,9 +25,6 @@ pub struct AppConfig {
 
     pub client_port: u16,
 
-    pub copy_command: Command,
-    pub paste_command: Command,
-
     pub player_event_hook_command: Option<Command>,
 
     pub playback_format: String,
@@ -191,39 +188,6 @@ impl Default for AppConfig {
             },
             #[cfg(feature = "notify")]
             notify_timeout_in_secs: 0,
-
-            #[cfg(target_os = "macos")]
-            copy_command: Command {
-                command: "pbcopy".to_string(),
-                args: vec![],
-            },
-            #[cfg(all(unix, not(target_os = "macos")))]
-            copy_command: Command {
-                command: "xclip".to_string(),
-                args: vec!["-sel".to_string(), "c".to_string()],
-            },
-            #[cfg(target_os = "windows")]
-            copy_command: Command {
-                command: "clip".to_string(),
-                args: vec![],
-            },
-
-            #[cfg(target_os = "macos")]
-            paste_command: Command {
-                command: "pbpaste".to_string(),
-                args: vec![],
-            },
-            #[cfg(all(unix, not(target_os = "macos")))]
-            paste_command: Command {
-                command: "xclip".to_string(),
-                args: vec!["-o".to_string(), "-sel".to_string(), "c".to_string()],
-            },
-            // based on https://stackoverflow.com/a/54910545
-            #[cfg(target_os = "windows")]
-            paste_command: Command {
-                command: "powershell".to_string(),
-                args: vec!["-command".to_string(), "Get-Clipboard".to_string()],
-            },
 
             player_event_hook_command: None,
 

--- a/spotify_player/src/event/clipboard.rs
+++ b/spotify_player/src/event/clipboard.rs
@@ -62,11 +62,13 @@ impl ClipboardProvider for NopProvider {
 #[cfg(target_os = "windows")]
 impl ClipboardProvider for WindowsProvider {
     fn get_contents(&self) -> Result<String> {
-        let contents = clipboard_win::get_clipboard(clipboard_win::formats::Unicode)?;
+        let contents = clipboard_win::get_clipboard(clipboard_win::formats::Unicode)
+            .map_err(|_| anyhow::anyhow!("failed to get windows clipboard"))?;
         Ok(contents)
     }
-    fn set_contents(&self, _contents: String) -> Result<()> {
-        clipboard_win::set_clipboard(clipboard_win::formats::Unicode, contents)?;
+    fn set_contents(&self, contents: String) -> Result<()> {
+        clipboard_win::set_clipboard(clipboard_win::formats::Unicode, contents)
+            .map_err(|_| anyhow::anyhow!("failed to set windows clipboard"))?;
         Ok(())
     }
 }

--- a/spotify_player/src/event/clipboard.rs
+++ b/spotify_player/src/event/clipboard.rs
@@ -1,0 +1,97 @@
+use std::io::Write;
+
+use anyhow::Result;
+
+use crate::config::Command;
+
+pub trait ClipboardProvider {
+    fn get_contents(&self) -> Result<String>;
+    fn set_contents(&mut self, contents: String) -> Result<()>;
+}
+
+struct CommandProvider {
+    copy_command: Command,
+    paste_command: Command,
+}
+
+struct NopProvider {}
+
+impl ClipboardProvider for CommandProvider {
+    fn get_contents(&self) -> Result<String> {
+        let output = std::process::Command::new(&self.paste_command.command)
+            .args(self.paste_command.args)
+            .output()?;
+        Ok(String::from_utf8(output.stdout)?)
+    }
+
+    fn set_contents(&mut self, contents: String) -> Result<()> {
+        let mut child = std::process::Command::new(&self.copy_command.command)
+            .args(&self.copy_command.args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(contents.as_bytes())?;
+        }
+
+        let output = child.wait_with_output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("copy command failed: {}", String::from_utf8(output.stderr)?);
+        }
+    }
+}
+
+impl ClipboardProvider for NopProvider {
+    fn get_contents(&self) -> Result<String> {
+        anyhow::bail!("no clipboard provider found!")
+    }
+    fn set_contents(&mut self, contents: String) -> Result<()> {
+        anyhow::bail!("no clipboard provider found!")
+    }
+}
+
+/// Get a clipboard provider based on user's environment
+// The function's implementation is inspired by helix
+// (https://github.com/blaggacao/helix/blob/master/helix-view/src/clipboard.rs)
+pub fn get_clipboard_provider() -> Box<dyn ClipboardProvider> {
+    if binary_exists("pbcopy") && binary_exists("pbpaste") {
+        Box::new(CommandProvider {
+            paste_command: Command::new::<_, &str>("pbpaste", &[]),
+            copy_command: Command::new::<_, &str>("pbcopy", &[]),
+        })
+    } else if env_var_is_set("WAYLAND_DISPLAY")
+        && binary_exists("wl-copy")
+        && binary_exists("wl-paste")
+    {
+        Box::new(CommandProvider {
+            paste_command: Command::new("wl-paste", &["--no-newline"]),
+            copy_command: Command::new("wl-copy", &["--type", "text/plain"]),
+        })
+    } else if env_var_is_set("DISPLAY") && binary_exists("xclip") {
+        Box::new(CommandProvider {
+            paste_command: Command::new("xclip", &["-o", "-selection", "clipboard"]),
+            copy_command: Command::new("xclip", &["-i", "-selection", "clipboard"]),
+        })
+    } else if env_var_is_set("DISPLAY") && binary_exists("xsel") {
+        Box::new(CommandProvider {
+            paste_command: Command::new("xsel", &["-o", "-b"]),
+            copy_command: Command::new("xsel", &["--nodetach", "-i", "-b"]),
+        })
+    } else {
+        tracing::warn!("No clipboard provider found! Fallback to a NOP clipboard provider.");
+        #[cfg(not(target_os = "windows"))]
+        Box::new(NopProvider {})
+    }
+}
+
+fn binary_exists(command: &'static str) -> bool {
+    which::which(command).is_ok()
+}
+
+fn env_var_is_set(env_var_name: &str) -> bool {
+    std::env::var_os(env_var_name).is_some()
+}

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use crate::utils::map_join;
 use anyhow::{Context as _, Result};
 
+mod clipboard;
 mod page;
 mod popup;
 mod window;

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     client::{ClientRequest, PlayerRequest},
     command::{self, Command},
-    config,
     key::{Key, KeySequence},
     state::*,
     ui::single_line_input::LineInput,
@@ -11,6 +10,8 @@ use crate::{
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
 use anyhow::{Context as _, Result};
+
+use self::clipboard::{get_clipboard_provider, CLIPBOARD_PROVIDER};
 
 mod clipboard;
 mod page;
@@ -293,8 +294,7 @@ fn handle_global_command(
             }
         }
         Command::OpenSpotifyLinkFromClipboard => {
-            let content = get_clipboard_content(&state.configs.app_config.paste_command)
-                .context("get clipboard's content")?;
+            let content = get_clipboard_content().context("get clipboard's content")?;
             let re = regex::Regex::new(
                 r"https://open.spotify.com/(?P<type>.*?)/(?P<id>[[:alnum:]]*).*",
             )?;
@@ -405,9 +405,8 @@ fn handle_global_command(
     Ok(true)
 }
 
-fn get_clipboard_content(cmd: &config::Command) -> Result<String> {
-    let output = std::process::Command::new(&cmd.command)
-        .args(&cmd.args)
-        .output()?;
-    Ok(String::from_utf8(output.stdout)?)
+fn get_clipboard_content() -> Result<String> {
+    CLIPBOARD_PROVIDER
+        .get_or_init(|| get_clipboard_provider())
+        .get_contents()
 }


### PR DESCRIPTION
Context for the PR: https://github.com/aome510/spotify-player/issues/393#issuecomment-2066613724

## Breaking changes
- remove `copy_command` and `paste_command` config options

## Changes
- add a logic to automatically determine clipboard provider based on user's environment
- add `which` crate and `clipboard-win` crate (for windows)