### PR TITLE
Decouple configs from application's state

### DIFF
--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -8,7 +8,7 @@ use librespot_core::{
     session::{Session, SessionError},
 };
 
-use crate::state;
+use crate::config;
 
 #[derive(Clone)]
 pub struct AuthConfig {
@@ -26,7 +26,7 @@ impl Default for AuthConfig {
 }
 
 impl AuthConfig {
-    pub fn new(configs: &state::Configs) -> Result<AuthConfig> {
+    pub fn new(configs: &config::Configs) -> Result<AuthConfig> {
         let audio_cache_folder = if configs.app_config.device.audio_cache {
             Some(configs.cache_folder.join("audio"))
         } else {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -1,7 +1,6 @@
 use crate::{
     auth::{new_session, new_session_with_new_creds, AuthConfig},
     client,
-    config::get_config,
 };
 
 use super::*;
@@ -178,7 +177,7 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Resul
 
 pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
-    let configs = get_config();
+    let configs = config::get_config();
 
     // handle commands that don't require a client separately
     match cmd {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::{new_session, new_session_with_new_creds, AuthConfig},
-    client, state,
+    client,
 };
 
 use super::*;
@@ -142,7 +142,7 @@ fn handle_playback_subcommand(args: &ArgMatches) -> Result<Request> {
 /// to the client via a UDP socket.
 /// If no running client found, create a new client running in a separate thread to
 /// handle the socket request.
-fn try_connect_to_client(socket: &UdpSocket, configs: &state::Configs) -> Result<()> {
+fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Result<()> {
     let port = configs.app_config.client_port;
     socket.connect(("127.0.0.1", port))?;
 
@@ -175,7 +175,11 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &state::Configs) -> Result
     Ok(())
 }
 
-pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches, configs: &state::Configs) -> Result<()> {
+pub fn handle_cli_subcommand(
+    cmd: &str,
+    args: &ArgMatches,
+    configs: &config::Configs,
+) -> Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
 
     // handle commands that don't require a client separately

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -1,6 +1,7 @@
 use crate::{
     auth::{new_session, new_session_with_new_creds, AuthConfig},
     client,
+    config::get_config,
 };
 
 use super::*;
@@ -175,12 +176,9 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Resul
     Ok(())
 }
 
-pub fn handle_cli_subcommand(
-    cmd: &str,
-    args: &ArgMatches,
-    configs: &config::Configs,
-) -> Result<()> {
+pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
+    let configs = get_config();
 
     // handle commands that don't require a client separately
     match cmd {

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use rspotify::model::PlayableItem;
 use tracing::Instrument;
 
-use crate::state::*;
+use crate::{config, state::*};
 
 #[cfg(feature = "lyric-finder")]
 use crate::utils::map_join;
@@ -186,13 +186,15 @@ pub async fn start_player_event_watchers(
     state: SharedState,
     client_pub: flume::Sender<ClientRequest>,
 ) {
+    let configs = config::get_config();
+
     // Start a watcher task that updates the playback every `playback_refresh_duration_in_ms` ms.
     // A positive value of `playback_refresh_duration_in_ms` is required to start the watcher.
-    if state.configs.app_config.playback_refresh_duration_in_ms > 0 {
+    if configs.app_config.playback_refresh_duration_in_ms > 0 {
         tokio::task::spawn({
             let client_pub = client_pub.clone();
             let playback_refresh_duration = std::time::Duration::from_millis(
-                state.configs.app_config.playback_refresh_duration_in_ms,
+                configs.app_config.playback_refresh_duration_in_ms,
             );
             async move {
                 loop {

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -14,8 +14,29 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-pub use keymap::*;
-pub use theme::*;
+use keymap::*;
+use theme::*;
+
+pub use theme::Theme;
+
+#[derive(Debug)]
+pub struct Configs {
+    pub app_config: AppConfig,
+    pub keymap_config: KeymapConfig,
+    pub theme_config: ThemeConfig,
+    pub cache_folder: std::path::PathBuf,
+}
+
+impl Configs {
+    pub fn new(config_folder: &std::path::Path, cache_folder: &std::path::Path) -> Result<Self> {
+        Ok(Self {
+            app_config: AppConfig::new(config_folder)?,
+            keymap_config: KeymapConfig::new(config_folder)?,
+            theme_config: ThemeConfig::new(config_folder)?,
+            cache_folder: cache_folder.to_path_buf(),
+        })
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize, ConfigParse)]
 /// Application configurations

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -12,12 +12,17 @@ use config_parser2::*;
 use librespot_core::config::SessionConfig;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 use keymap::*;
 use theme::*;
 
 pub use theme::Theme;
+
+static CONFIGS: OnceLock<Configs> = OnceLock::new();
 
 #[derive(Debug)]
 pub struct Configs {
@@ -357,4 +362,14 @@ pub fn get_cache_folder_path() -> Result<PathBuf> {
         Some(home) => Ok(home.join(DEFAULT_CACHE_FOLDER)),
         None => Err(anyhow!("cannot find the $HOME folder")),
     }
+}
+
+#[inline(always)]
+pub fn get_config() -> &'static Configs {
+    CONFIGS.get().expect("configs is already initialized")
+}
+pub fn set_config(configs: Configs) {
+    CONFIGS
+        .set(configs)
+        .expect("configs should be initialized only once")
 }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     client::{ClientRequest, PlayerRequest},
     command::{self, Command},
+    config,
     key::{Key, KeySequence},
     state::*,
     ui::single_line_input::LineInput,
@@ -87,9 +88,8 @@ fn handle_key_event(
 
     // check if the current key sequence matches any keymap's prefix
     // if not, reset the key sequence
-    if state
-        .configs
-        .keymap_config
+    let keymap_config = &config::get_config().keymap_config;
+    if keymap_config
         .find_matched_prefix_keymaps(&key_sequence)
         .is_empty()
     {
@@ -107,11 +107,7 @@ fn handle_key_event(
 
     // if the key sequence is not handled, let the global command handler handle it
     let handled = if !handled {
-        match state
-            .configs
-            .keymap_config
-            .find_command_from_key_sequence(&key_sequence)
-        {
+        match keymap_config.find_command_from_key_sequence(&key_sequence) {
             Some(command) => handle_global_command(command, client_pub, state, &mut ui)?,
             None => false,
         }
@@ -363,7 +359,7 @@ fn handle_global_command(
         }
         Command::SwitchTheme => {
             // get the available themes with the current theme moved to the first position
-            let mut themes = state.configs.theme_config.themes.clone();
+            let mut themes = config::get_config().theme_config.themes.clone();
             let id = themes.iter().position(|t| t.name == ui.theme.name);
             if let Some(id) = id {
                 let theme = themes.remove(id);

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -15,8 +15,7 @@ pub fn handle_key_sequence_for_page(
         return handle_key_sequence_for_search_page(key_sequence, client_pub, state, ui);
     }
 
-    let command = match state
-        .configs
+    let command = match config::get_config()
         .keymap_config
         .find_command_from_key_sequence(key_sequence)
     {
@@ -115,8 +114,7 @@ fn handle_key_sequence_for_search_page(
         }
     }
 
-    let command = match state
-        .configs
+    let command = match config::get_config()
         .keymap_config
         .find_command_from_key_sequence(key_sequence)
     {
@@ -320,6 +318,7 @@ pub fn handle_navigation_command(
         return false;
     }
 
+    let configs = config::get_config();
     match command {
         Command::SelectNextOrScrollDown => {
             if id + 1 < len {
@@ -335,13 +334,13 @@ pub fn handle_navigation_command(
         }
         Command::PageSelectNextOrScrollDown => {
             page.select(std::cmp::min(
-                id + state.configs.app_config.page_size_in_rows,
+                id + configs.app_config.page_size_in_rows,
                 len - 1,
             ));
             true
         }
         Command::PageSelectPreviousOrScrollUp => {
-            page.select(id.saturating_sub(state.configs.app_config.page_size_in_rows));
+            page.select(id.saturating_sub(configs.app_config.page_size_in_rows));
             true
         }
         Command::SelectLastOrScrollToBottom => {

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -29,9 +29,9 @@ pub fn handle_key_sequence_for_page(
         PageType::Context => handle_command_for_context_page(command, client_pub, ui, state),
         PageType::Browse => handle_command_for_browse_page(command, client_pub, ui, state),
         #[cfg(feature = "lyric-finder")]
-        PageType::Lyric => handle_command_for_lyric_page(command, ui, state),
-        PageType::Queue => handle_command_for_queue_page(command, ui, state),
-        PageType::CommandHelp => handle_command_for_command_help_page(command, ui, state),
+        PageType::Lyric => handle_command_for_lyric_page(command, ui),
+        PageType::Queue => handle_command_for_queue_page(command, ui),
+        PageType::CommandHelp => handle_command_for_command_help_page(command, ui),
     }
 }
 
@@ -57,14 +57,12 @@ fn handle_command_for_library_page(
                     ui.search_filtered_items(&data.user_data.playlists),
                     &data,
                     ui,
-                    state,
                 ),
                 LibraryFocusState::SavedAlbums => window::handle_command_for_album_list_window(
                     command,
                     ui.search_filtered_items(&data.user_data.saved_albums),
                     &data,
                     ui,
-                    state,
                 ),
                 LibraryFocusState::FollowedArtists => {
                     window::handle_command_for_artist_list_window(
@@ -72,7 +70,6 @@ fn handle_command_for_library_page(
                         ui.search_filtered_items(&data.user_data.followed_artists),
                         &data,
                         ui,
-                        state,
                     )
                 }
             }
@@ -131,27 +128,25 @@ fn handle_key_sequence_for_search_page(
             let tracks = search_results
                 .map(|s| s.tracks.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_track_list_window(
-                command, client_pub, tracks, &data, ui, state,
-            )
+            window::handle_command_for_track_list_window(command, client_pub, tracks, &data, ui)
         }
         SearchFocusState::Artists => {
             let artists = search_results
                 .map(|s| s.artists.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_artist_list_window(command, artists, &data, ui, state)
+            window::handle_command_for_artist_list_window(command, artists, &data, ui)
         }
         SearchFocusState::Albums => {
             let albums = search_results
                 .map(|s| s.albums.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_album_list_window(command, albums, &data, ui, state)
+            window::handle_command_for_album_list_window(command, albums, &data, ui)
         }
         SearchFocusState::Playlists => {
             let playlists = search_results
                 .map(|s| s.playlists.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_playlist_list_window(command, playlists, &data, ui, state)
+            window::handle_command_for_playlist_list_window(command, playlists, &data, ui)
         }
     }
 }
@@ -200,7 +195,7 @@ fn handle_command_for_browse_page(
         return Ok(false);
     }
 
-    if handle_navigation_command(command, page_state, state, selected, len) {
+    if handle_navigation_command(command, page_state, selected, len) {
         return Ok(true);
     }
     match command {
@@ -249,11 +244,7 @@ fn handle_command_for_browse_page(
 }
 
 #[cfg(feature = "lyric-finder")]
-fn handle_command_for_lyric_page(
-    command: Command,
-    ui: &mut UIStateGuard,
-    state: &SharedState,
-) -> Result<bool> {
+fn handle_command_for_lyric_page(command: Command, ui: &mut UIStateGuard) -> Result<bool> {
     let scroll_offset = match ui.current_page() {
         PageState::Lyric { scroll_offset, .. } => *scroll_offset,
         _ => return Ok(false),
@@ -261,7 +252,6 @@ fn handle_command_for_lyric_page(
     Ok(handle_navigation_command(
         command,
         ui.current_page_mut(),
-        state,
         scroll_offset,
         10000,
     ))
@@ -270,7 +260,6 @@ fn handle_command_for_lyric_page(
 fn handle_command_for_queue_page(
     command: Command,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool, anyhow::Error> {
     let scroll_offset = match ui.current_page() {
         PageState::Queue { scroll_offset } => *scroll_offset,
@@ -279,17 +268,12 @@ fn handle_command_for_queue_page(
     Ok(handle_navigation_command(
         command,
         ui.current_page_mut(),
-        state,
         scroll_offset,
         10000,
     ))
 }
 
-fn handle_command_for_command_help_page(
-    command: Command,
-    ui: &mut UIStateGuard,
-    state: &SharedState,
-) -> Result<bool> {
+fn handle_command_for_command_help_page(command: Command, ui: &mut UIStateGuard) -> Result<bool> {
     let scroll_offset = match ui.current_page() {
         PageState::CommandHelp { scroll_offset } => *scroll_offset,
         _ => return Ok(false),
@@ -301,7 +285,6 @@ fn handle_command_for_command_help_page(
     Ok(handle_navigation_command(
         command,
         ui.current_page_mut(),
-        state,
         scroll_offset,
         10000,
     ))
@@ -310,7 +293,6 @@ fn handle_command_for_command_help_page(
 pub fn handle_navigation_command(
     command: Command,
     page: &mut PageState,
-    state: &SharedState,
     id: usize,
     len: usize,
 ) -> bool {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -33,8 +33,7 @@ pub fn handle_key_sequence_for_popup(
         _ => {}
     }
 
-    let command = match state
-        .configs
+    let command = match config::get_config()
         .keymap_config
         .find_command_from_key_sequence(key_sequence)
     {
@@ -417,8 +416,7 @@ fn handle_key_sequence_for_action_list_popup(
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
-    let command = match state
-        .configs
+    let command = match config::get_config()
         .keymap_config
         .find_command_from_key_sequence(key_sequence)
     {

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -234,7 +234,7 @@ fn handle_command_for_track_table_window(
             client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
                 base_playback.uri_offset(
                     tracks[id].id.uri(),
-                    state.configs.app_config.tracks_playback_limit,
+                    config::get_config().app_config.tracks_playback_limit,
                 ),
                 None,
             )))?;

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -79,17 +79,15 @@ pub fn handle_command_for_focused_context_window(
                         ui.search_filtered_items(albums),
                         &data,
                         ui,
-                        state,
                     ),
                     ArtistFocusState::RelatedArtists => handle_command_for_artist_list_window(
                         command,
                         ui.search_filtered_items(related_artists),
                         &data,
                         ui,
-                        state,
                     ),
                     ArtistFocusState::TopTracks => handle_command_for_track_table_window(
-                        command, client_pub, None, top_tracks, &data, ui, state,
+                        command, client_pub, None, top_tracks, &data, ui,
                     ),
                 }
             }
@@ -100,7 +98,6 @@ pub fn handle_command_for_focused_context_window(
                 tracks,
                 &data,
                 ui,
-                state,
             ),
             Context::Playlist { tracks, .. } => handle_command_for_track_table_window(
                 command,
@@ -109,11 +106,10 @@ pub fn handle_command_for_focused_context_window(
                 tracks,
                 &data,
                 ui,
-                state,
             ),
-            Context::Tracks { tracks, .. } => handle_command_for_track_table_window(
-                command, client_pub, None, tracks, &data, ui, state,
-            ),
+            Context::Tracks { tracks, .. } => {
+                handle_command_for_track_table_window(command, client_pub, None, tracks, &data, ui)
+            }
         },
         None => Ok(false),
     }
@@ -178,7 +174,6 @@ fn handle_command_for_track_table_window(
     tracks: &[Track],
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     let filtered_tracks = ui.search_filtered_items(tracks);
@@ -207,13 +202,7 @@ fn handle_command_for_track_table_window(
         }
     }
 
-    if handle_navigation_command(
-        command,
-        ui.current_page_mut(),
-        state,
-        id,
-        filtered_tracks.len(),
-    ) {
+    if handle_navigation_command(command, ui.current_page_mut(), id, filtered_tracks.len()) {
         return Ok(true);
     }
 
@@ -262,14 +251,13 @@ pub fn handle_command_for_track_list_window(
     tracks: Vec<&Track>,
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= tracks.len() {
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), state, id, tracks.len()) {
+    if handle_navigation_command(command, ui.current_page_mut(), id, tracks.len()) {
         return Ok(true);
     }
     match command {
@@ -304,14 +292,13 @@ pub fn handle_command_for_artist_list_window(
     artists: Vec<&Artist>,
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= artists.len() {
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), state, id, artists.len()) {
+    if handle_navigation_command(command, ui.current_page_mut(), id, artists.len()) {
         return Ok(true);
     }
     match command {
@@ -340,14 +327,13 @@ pub fn handle_command_for_album_list_window(
     albums: Vec<&Album>,
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= albums.len() {
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), state, id, albums.len()) {
+    if handle_navigation_command(command, ui.current_page_mut(), id, albums.len()) {
         return Ok(true);
     }
     match command {
@@ -376,14 +362,13 @@ pub fn handle_command_for_playlist_list_window(
     playlists: Vec<&Playlist>,
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
-    state: &SharedState,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= playlists.len() {
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), state, id, playlists.len()) {
+    if handle_navigation_command(command, ui.current_page_mut(), id, playlists.len()) {
         return Ok(true);
     }
     match command {

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
     }
 
     // initialize the application configs
-    let mut configs = state::Configs::new(&config_folder, &cache_folder)?;
+    let mut configs = config::Configs::new(&config_folder, &cache_folder)?;
     if let Some(theme) = args.get_one::<String>("theme") {
         // override the theme config if user specifies a `theme` cli argument
         configs.app_config.theme = theme.to_owned();

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -82,6 +82,8 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
 
 #[tokio::main]
 async fn start_app(state: &state::SharedState) -> Result<()> {
+    let configs = config::get_config();
+
     if !state.is_daemon {
         #[cfg(feature = "image")]
         {
@@ -110,7 +112,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
                 "PULSE_PROP_stream.description",
                 format!(
                     "Spotify Connect endpoint ({})",
-                    state.configs.app_config.device.name
+                    configs.app_config.device.name
                 ),
             );
         }
@@ -123,15 +125,11 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     }
 
     // create a librespot session
-    let auth_config = auth::AuthConfig::new(&state.configs)?;
+    let auth_config = auth::AuthConfig::new(configs)?;
     let session = auth::new_session(&auth_config, !state.is_daemon).await?;
 
     // create a Spotify API client
-    let client = client::Client::new(
-        session,
-        auth_config,
-        state.configs.app_config.client_id.clone(),
-    );
+    let client = client::Client::new(session, auth_config, configs.app_config.client_id.clone());
     client.refresh_token().await?;
 
     // initialize Spotify-related stuff
@@ -147,7 +145,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
         let client = client.clone();
         let state = state.clone();
         async move {
-            let port = state.configs.app_config.client_port;
+            let port = configs.app_config.client_port;
             tracing::info!("Starting a client socket at 127.0.0.1:{port}");
             match tokio::net::UdpSocket::bind(("127.0.0.1", port)).await {
                 Ok(socket) => cli::start_socket(client, socket, Some(state)).await,
@@ -197,7 +195,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     }
 
     #[cfg(feature = "media-control")]
-    if state.configs.app_config.enable_media_control {
+    if configs.app_config.enable_media_control {
         // media control task
         tokio::task::spawn_blocking({
             let state = state.clone();
@@ -257,10 +255,13 @@ fn main() -> Result<()> {
     }
 
     // initialize the application configs
-    let mut configs = config::Configs::new(&config_folder, &cache_folder)?;
-    if let Some(theme) = args.get_one::<String>("theme") {
-        // override the theme config if user specifies a `theme` cli argument
-        configs.app_config.theme = theme.to_owned();
+    {
+        let mut configs = config::Configs::new(&config_folder, &cache_folder)?;
+        if let Some(theme) = args.get_one::<String>("theme") {
+            // override the theme config if user specifies a `theme` cli argument
+            configs.app_config.theme = theme.to_owned();
+        }
+        config::set_config(configs);
     }
 
     match args.subcommand() {
@@ -269,7 +270,7 @@ fn main() -> Result<()> {
             init_logging(&cache_folder).context("failed to initialize application's logging")?;
 
             // log the application's configurations
-            tracing::info!("Configurations: {:?}", configs);
+            tracing::info!("Configurations: {:?}", config::get_config());
 
             let is_daemon;
 
@@ -295,9 +296,9 @@ fn main() -> Result<()> {
                 is_daemon = false;
             }
 
-            let state = std::sync::Arc::new(state::State::new(configs, is_daemon));
+            let state = std::sync::Arc::new(state::State::new(is_daemon));
             start_app(&state)
         }
-        Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args, &configs),
+        Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args),
     }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -11,37 +11,15 @@ pub use player::*;
 pub use ui::*;
 
 use crate::config;
-use anyhow::Result;
 
 pub use parking_lot::{Mutex, RwLock};
 
 /// Application's shared state (wrapped inside an std::sync::Arc)
 pub type SharedState = std::sync::Arc<State>;
 
-#[derive(Debug)]
-pub struct Configs {
-    pub app_config: config::AppConfig,
-    pub keymap_config: config::KeymapConfig,
-    pub theme_config: config::ThemeConfig,
-    pub cache_folder: std::path::PathBuf,
-    pub config_folder: std::path::PathBuf,
-}
-
-impl Configs {
-    pub fn new(config_folder: &std::path::Path, cache_folder: &std::path::Path) -> Result<Self> {
-        Ok(Self {
-            app_config: config::AppConfig::new(config_folder)?,
-            keymap_config: config::KeymapConfig::new(config_folder)?,
-            theme_config: config::ThemeConfig::new(config_folder)?,
-            cache_folder: cache_folder.to_path_buf(),
-            config_folder: config_folder.to_path_buf(),
-        })
-    }
-}
-
 /// Application's state
 pub struct State {
-    pub configs: Configs,
+    pub configs: config::Configs,
     pub ui: Mutex<UIState>,
     pub player: RwLock<PlayerState>,
     pub data: RwLock<AppData>,
@@ -49,7 +27,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(configs: Configs, is_daemon: bool) -> Self {
+    pub fn new(configs: config::Configs, is_daemon: bool) -> Self {
         let mut ui = UIState::default();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -10,7 +10,7 @@ pub use model::*;
 pub use player::*;
 pub use ui::*;
 
-use crate::config;
+use crate::config::{self, get_config};
 
 pub use parking_lot::{Mutex, RwLock};
 
@@ -19,7 +19,6 @@ pub type SharedState = std::sync::Arc<State>;
 
 /// Application's state
 pub struct State {
-    pub configs: config::Configs,
     pub ui: Mutex<UIState>,
     pub player: RwLock<PlayerState>,
     pub data: RwLock<AppData>,
@@ -27,8 +26,9 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(configs: config::Configs, is_daemon: bool) -> Self {
+    pub fn new(is_daemon: bool) -> Self {
         let mut ui = UIState::default();
+        let configs = get_config();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {
             // update the UI's theme based on the `theme` config option
@@ -38,7 +38,6 @@ impl State {
         let app_data = AppData::new(&configs.cache_folder);
 
         Self {
-            configs,
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(app_data),
@@ -48,8 +47,9 @@ impl State {
 
     #[cfg(feature = "streaming")]
     pub fn is_streaming_enabled(&self) -> bool {
-        self.configs.app_config.enable_streaming == config::StreamingType::Always
-            || (self.configs.app_config.enable_streaming == config::StreamingType::DaemonOnly
+        let configs = config::get_config();
+        configs.app_config.enable_streaming == config::StreamingType::Always
+            || (configs.app_config.enable_streaming == config::StreamingType::DaemonOnly
                 && self.is_daemon)
     }
 }

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -10,7 +10,7 @@ pub use model::*;
 pub use player::*;
 pub use ui::*;
 
-use crate::config::{self, get_config};
+use crate::config;
 
 pub use parking_lot::{Mutex, RwLock};
 
@@ -22,13 +22,14 @@ pub struct State {
     pub ui: Mutex<UIState>,
     pub player: RwLock<PlayerState>,
     pub data: RwLock<AppData>,
+
     pub is_daemon: bool,
 }
 
 impl State {
     pub fn new(is_daemon: bool) -> Self {
         let mut ui = UIState::default();
-        let configs = get_config();
+        let configs = config::get_config();
 
         if let Some(theme) = configs.theme_config.find_theme(&configs.app_config.theme) {
             // update the UI's theme based on the `theme` config option

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -162,7 +162,8 @@ fn execute_player_event_hook_command(
 /// Create a new streaming connection
 pub async fn new_connection(client: Client, state: SharedState) -> Spirc {
     let session = client.session().await;
-    let device = &state.configs.app_config.device;
+    let configs = config::get_config();
+    let device = &configs.app_config.device;
 
     // `librespot` volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
@@ -236,7 +237,7 @@ pub async fn new_connection(client: Client, state: SharedState) -> Spirc {
                         client.update_playback(&state);
 
                         // execute a player event hook command
-                        if let Some(ref cmd) = state.configs.app_config.player_event_hook_command {
+                        if let Some(ref cmd) = configs.app_config.player_event_hook_command {
                             if let Err(err) = execute_player_event_hook_command(cmd, event) {
                                 tracing::warn!(
                                     "Failed to execute player event hook command: {err:#}"

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -84,7 +84,7 @@ fn clean_up(mut terminal: Terminal) -> Result<()> {
 fn render_application(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGuard, rect: Rect) {
     // rendering order: shortcut help popup -> playback window -> other popups -> main layout
 
-    let rect = popup::render_shortcut_help_popup(frame, state, ui, rect);
+    let rect = popup::render_shortcut_help_popup(frame, ui, rect);
 
     // render playback window before other popups to ensure no popup is rendered on top
     // of the playback window
@@ -112,6 +112,6 @@ fn render_main_layout(
         #[cfg(feature = "lyric-finder")]
         PageType::Lyric => page::render_lyric_page(is_active, frame, state, ui, rect),
         PageType::Queue => page::render_queue_page(frame, state, ui, rect),
-        PageType::CommandHelp => page::render_commands_help_page(frame, state, ui, rect),
+        PageType::CommandHelp => page::render_commands_help_page(frame, ui, rect),
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -14,8 +14,9 @@ mod utils;
 pub fn run(state: SharedState) -> Result<()> {
     let mut terminal = init_ui().context("failed to initialize the application's UI")?;
 
-    let ui_refresh_duration =
-        std::time::Duration::from_millis(state.configs.app_config.app_refresh_duration_in_ms);
+    let ui_refresh_duration = std::time::Duration::from_millis(
+        config::get_config().app_config.app_refresh_duration_in_ms,
+    );
     let mut last_terminal_size = None;
 
     loop {

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -39,7 +39,7 @@ pub fn render_search_page(
     let search_results = data.caches.search.get(current_query);
 
     // 2. Construct the page's layout
-    let rect = construct_and_render_block("Search", &ui.theme, state, Borders::ALL, frame, rect);
+    let rect = construct_and_render_block("Search", &ui.theme, Borders::ALL, frame, rect);
 
     // search input's layout
     let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
@@ -60,29 +60,21 @@ pub fn render_search_page(
     let track_rect = construct_and_render_block(
         "Tracks",
         &ui.theme,
-        state,
         Borders::TOP | Borders::RIGHT,
         frame,
         chunks[0],
     );
     let album_rect =
-        construct_and_render_block("Albums", &ui.theme, state, Borders::TOP, frame, chunks[1]);
+        construct_and_render_block("Albums", &ui.theme, Borders::TOP, frame, chunks[1]);
     let artist_rect = construct_and_render_block(
         "Artists",
         &ui.theme,
-        state,
         Borders::TOP | Borders::RIGHT,
         frame,
         chunks[2],
     );
-    let playlist_rect = construct_and_render_block(
-        "Playlists",
-        &ui.theme,
-        state,
-        Borders::TOP,
-        frame,
-        chunks[3],
-    );
+    let playlist_rect =
+        construct_and_render_block("Playlists", &ui.theme, Borders::TOP, frame, chunks[3]);
 
     // 3. Construct the page's widgets
     let (track_list, n_tracks) = {
@@ -214,7 +206,6 @@ pub fn render_context_page(
     let rect = construct_and_render_block(
         &context_page_type.title(),
         &ui.theme,
-        state,
         Borders::ALL,
         frame,
         rect,
@@ -344,7 +335,6 @@ pub fn render_library_page(
     let playlist_rect = construct_and_render_block(
         "Playlists",
         &ui.theme,
-        state,
         Borders::TOP | Borders::LEFT | Borders::BOTTOM,
         frame,
         chunks[0],
@@ -352,13 +342,12 @@ pub fn render_library_page(
     let album_rect = construct_and_render_block(
         "Albums",
         &ui.theme,
-        state,
         Borders::TOP | Borders::LEFT | Borders::BOTTOM,
         frame,
         chunks[1],
     );
     let artist_rect =
-        construct_and_render_block("Artists", &ui.theme, state, Borders::ALL, frame, chunks[2]);
+        construct_and_render_block("Artists", &ui.theme, Borders::ALL, frame, chunks[2]);
 
     // 3. Construct the page's widgets
     // Construct the playlist window
@@ -434,14 +423,8 @@ pub fn render_browse_page(
     let (list, len) = match ui.current_page() {
         PageState::Browse { state: ui_state } => match ui_state {
             BrowsePageUIState::CategoryList { .. } => {
-                rect = construct_and_render_block(
-                    "Categories",
-                    &ui.theme,
-                    state,
-                    Borders::ALL,
-                    frame,
-                    rect,
-                );
+                rect =
+                    construct_and_render_block("Categories", &ui.theme, Borders::ALL, frame, rect);
 
                 utils::construct_list_widget(
                     &ui.theme,
@@ -454,8 +437,7 @@ pub fn render_browse_page(
             }
             BrowsePageUIState::CategoryPlaylistList { category, .. } => {
                 let title = format!("{} Playlists", category.name);
-                rect =
-                    construct_and_render_block(&title, &ui.theme, state, Borders::ALL, frame, rect);
+                rect = construct_and_render_block(&title, &ui.theme, Borders::ALL, frame, rect);
 
                 let playlists = match data.browse.category_playlists.get(&category.id) {
                     Some(playlists) => playlists,
@@ -498,7 +480,7 @@ pub fn render_lyric_page(
     let data = state.data.read();
 
     // 2. Construct the page's layout
-    let rect = construct_and_render_block("Lyric", &ui.theme, state, Borders::ALL, frame, rect);
+    let rect = construct_and_render_block("Lyric", &ui.theme, Borders::ALL, frame, rect);
     let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
 
     // 3. Construct the page's widgets
@@ -545,12 +527,7 @@ pub fn render_lyric_page(
     );
 }
 
-pub fn render_commands_help_page(
-    frame: &mut Frame,
-    state: &SharedState,
-    ui: &mut UIStateGuard,
-    rect: Rect,
-) {
+pub fn render_commands_help_page(frame: &mut Frame, ui: &mut UIStateGuard, rect: Rect) {
     // 1. Get data
     let configs = config::get_config();
     let mut map = BTreeMap::new();
@@ -584,7 +561,7 @@ pub fn render_commands_help_page(
     };
 
     // 2. Construct the page's layout
-    let rect = construct_and_render_block("Commands", &ui.theme, state, Borders::ALL, frame, rect);
+    let rect = construct_and_render_block("Commands", &ui.theme, Borders::ALL, frame, rect);
 
     // 3. Construct the page's widget
     let help_table = Table::new(
@@ -663,7 +640,7 @@ pub fn render_queue_page(
     };
 
     // 2. Construct the page's layout
-    let rect = construct_and_render_block("Queue", &ui.theme, state, Borders::ALL, frame, rect);
+    let rect = construct_and_render_block("Queue", &ui.theme, Borders::ALL, frame, rect);
 
     // 3. Construct the page's widget
     let queue_table = Table::new(
@@ -739,19 +716,12 @@ fn render_artist_context_page_windows(
     let albums_rect = construct_and_render_block(
         "Albums",
         &ui.theme,
-        state,
         Borders::TOP | Borders::RIGHT,
         frame,
         chunks[0],
     );
-    let related_artists_rect = construct_and_render_block(
-        "Related Artists",
-        &ui.theme,
-        state,
-        Borders::TOP,
-        frame,
-        chunks[1],
-    );
+    let related_artists_rect =
+        construct_and_render_block("Related Artists", &ui.theme, Borders::TOP, frame, chunks[1]);
 
     // 3. Construct the page's widgets
     // album list widget

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -552,8 +552,9 @@ pub fn render_commands_help_page(
     rect: Rect,
 ) {
     // 1. Get data
+    let configs = config::get_config();
     let mut map = BTreeMap::new();
-    let keymaps = ui.search_filtered_items(&state.configs.keymap_config.keymaps);
+    let keymaps = ui.search_filtered_items(&configs.keymap_config.keymaps);
     keymaps
         .into_iter()
         .filter(|km| km.include_in_help_screen())
@@ -824,6 +825,7 @@ fn render_track_table(
     ui: &mut UIStateGuard,
     data: &DataReadGuard,
 ) {
+    let configs = config::get_config();
     // get the current playing track's URI to decorate such track (if exists) in the track table
     let mut playing_track_uri = "".to_string();
     let mut playing_id = "";
@@ -832,9 +834,9 @@ fn render_track_table(
             playing_track_uri = track.id.as_ref().map(|id| id.uri()).unwrap_or_default();
 
             playing_id = if playback.is_playing {
-                &state.configs.app_config.play_icon
+                &configs.app_config.play_icon
             } else {
-                &state.configs.app_config.pause_icon
+                &configs.app_config.pause_icon
             };
         }
     }
@@ -851,7 +853,7 @@ fn render_track_table(
             };
             Row::new(vec![
                 Cell::from(if data.user_data.is_liked_track(t) {
-                    &state.configs.app_config.liked_icon
+                    &configs.app_config.liked_icon
                 } else {
                     ""
                 }),
@@ -872,7 +874,7 @@ fn render_track_table(
     let track_table = Table::new(
         rows,
         [
-            Constraint::Length(state.configs.app_config.liked_icon.chars().count() as u16),
+            Constraint::Length(configs.app_config.liked_icon.chars().count() as u16),
             Constraint::Length(4),
             Constraint::Fill(4),
             Constraint::Fill(3),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -12,7 +12,7 @@ pub fn render_playback_window(
     rect: Rect,
 ) -> Rect {
     let (rect, other_rect) = split_rect_for_playback_window(rect);
-    let rect = construct_and_render_block("Playback", &ui.theme, state, Borders::ALL, frame, rect);
+    let rect = construct_and_render_block("Playback", &ui.theme, Borders::ALL, frame, rect);
 
     let player = state.player.read();
     if let Some(ref playback) = player.playback {
@@ -101,7 +101,7 @@ pub fn render_playback_window(
             };
 
             if let Some(ref playback) = player.buffered_playback {
-                let playback_text = construct_playback_text(state, ui, track, playback);
+                let playback_text = construct_playback_text(ui, track, playback);
                 let playback_desc = Paragraph::new(playback_text).wrap(Wrap { trim: false });
                 frame.render_widget(playback_desc, metadata_rect);
             }
@@ -110,7 +110,7 @@ pub fn render_playback_window(
                 player.playback_progress().expect("non-empty playback"),
                 track.duration,
             );
-            render_playback_progress_bar(frame, state, ui, progress, track, progress_bar_rect);
+            render_playback_progress_bar(frame, ui, progress, track, progress_bar_rect);
         }
     } else {
         // Previously rendered image can result in a weird rendering text,
@@ -145,7 +145,6 @@ pub fn render_playback_window(
 }
 
 fn construct_playback_text(
-    state: &SharedState,
     ui: &UIStateGuard,
     track: &rspotify_model::FullTrack,
     playback: &PlaybackMetadata,
@@ -233,7 +232,6 @@ fn construct_playback_text(
 
 fn render_playback_progress_bar(
     frame: &mut Frame,
-    state: &SharedState,
     ui: &mut UIStateGuard,
     progress: chrono::Duration,
     track: &rspotify_model::FullTrack,

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -11,7 +11,7 @@ pub fn render_playback_window(
     ui: &mut UIStateGuard,
     rect: Rect,
 ) -> Rect {
-    let (rect, other_rect) = split_rect_for_playback_window(rect, state);
+    let (rect, other_rect) = split_rect_for_playback_window(rect);
     let rect = construct_and_render_block("Playback", &ui.theme, state, Borders::ALL, frame, rect);
 
     let player = state.player.read();
@@ -30,18 +30,17 @@ pub fn render_playback_window(
                     // Render the track's cover image if `image` feature is enabled
                     #[cfg(feature = "image")]
                     {
+                        let configs = config::get_config();
                         // Split the allocated rectangle into `metadata_rect` and `cover_img_rect`
                         let (metadata_rect, cover_img_rect) = {
                             let hor_chunks = Layout::horizontal([
-                                Constraint::Length(
-                                    state.configs.app_config.cover_img_length as u16,
-                                ),
+                                Constraint::Length(configs.app_config.cover_img_length as u16),
                                 Constraint::Fill(0), // metadata_rect
                             ])
                             .spacing(1)
                             .split(rect);
                             let ver_chunks = Layout::vertical([
-                                Constraint::Length(state.configs.app_config.cover_img_width as u16), // cover_img_rect
+                                Constraint::Length(configs.app_config.cover_img_width as u16), // cover_img_rect
                                 Constraint::Fill(0), // empty space
                             ])
                             .split(hor_chunks[0]);
@@ -153,7 +152,8 @@ fn construct_playback_text(
 ) -> Text<'static> {
     // Construct a "styled" text (`playback_text`) from playback's data
     // based on a user-configurable format string (app_config.playback_format)
-    let format_str = &state.configs.app_config.playback_format;
+    let configs = config::get_config();
+    let format_str = &configs.app_config.playback_format;
 
     let mut playback_text = Text::default();
     let mut spans = vec![];
@@ -182,9 +182,9 @@ fn construct_playback_text(
                 format!(
                     "{} {}",
                     if !playback.is_playing {
-                        &state.configs.app_config.pause_icon
+                        &configs.app_config.pause_icon
                     } else {
-                        &state.configs.app_config.play_icon
+                        &configs.app_config.play_icon
                     },
                     if track.explicit {
                         format!("{} (E)", track.name)
@@ -244,7 +244,7 @@ fn render_playback_progress_bar(
     let ratio =
         (progress.num_seconds() as f64 / track.duration.num_seconds() as f64).clamp(0.0, 1.0);
 
-    match state.configs.app_config.progress_bar_type {
+    match config::get_config().app_config.progress_bar_type {
         config::ProgressBarType::Line => frame.render_widget(
             LineGauge::default()
                 .gauge_style(ui.theme.playback_progress_bar())
@@ -307,7 +307,7 @@ fn render_playback_cover_image(state: &SharedState, ui: &mut UIStateGuard) -> Re
         // This scaling factor is user configurable as the scale works differently
         // with different fonts and terminals.
         // For more context, see https://github.com/aome510/spotify-player/issues/122.
-        let scale = state.configs.app_config.cover_img_scale;
+        let scale = config::get_config().app_config.cover_img_scale;
         let width = (rect.width as f32 * scale).round() as u32;
         let height = (rect.height as f32 * scale).round() as u32;
 
@@ -332,17 +332,17 @@ fn render_playback_cover_image(state: &SharedState, ui: &mut UIStateGuard) -> Re
 
 /// Split the given area into two, the first one for the playback window
 /// and the second one for the main application's layout (popup, page, etc).
-fn split_rect_for_playback_window(rect: Rect, state: &SharedState) -> (Rect, Rect) {
-    let playback_width = state.configs.app_config.playback_window_width;
+fn split_rect_for_playback_window(rect: Rect) -> (Rect, Rect) {
+    let configs = config::get_config();
+    let playback_width = configs.app_config.playback_window_width;
     // the playback window's width should not be smaller than the cover image's width + 1
     #[cfg(feature = "image")]
-    let playback_width =
-        std::cmp::max(state.configs.app_config.cover_img_width + 1, playback_width);
+    let playback_width = std::cmp::max(configs.app_config.cover_img_width + 1, playback_width);
 
     // +2 for top/bottom borders
     let playback_width = (playback_width + 2) as u16;
 
-    match state.configs.app_config.playback_window_position {
+    match configs.app_config.playback_window_position {
         config::Position::Top => {
             let chunks =
                 Layout::vertical([Constraint::Length(playback_width), Constraint::Fill(0)])

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -33,7 +33,6 @@ pub fn render_popup(
                 let name_input = construct_and_render_block(
                     "Enter Name for New Playlist:",
                     &ui.theme,
-                    state,
                     Borders::ALL,
                     frame,
                     popup_chunks[0],
@@ -42,7 +41,6 @@ pub fn render_popup(
                 let desc_input = construct_and_render_block(
                     "Enter Description for New Playlist:",
                     &ui.theme,
-                    state,
                     Borders::ALL,
                     frame,
                     popup_chunks[1],
@@ -62,14 +60,8 @@ pub fn render_popup(
                 let chunks =
                     Layout::vertical([Constraint::Fill(0), Constraint::Length(3)]).split(rect);
 
-                let rect = construct_and_render_block(
-                    "Search",
-                    &ui.theme,
-                    state,
-                    Borders::ALL,
-                    frame,
-                    chunks[1],
-                );
+                let rect =
+                    construct_and_render_block("Search", &ui.theme, Borders::ALL, frame, chunks[1]);
 
                 frame.render_widget(Paragraph::new(format!("/{query}")), rect);
                 (chunks[0], true)
@@ -85,7 +77,6 @@ pub fn render_popup(
                         .map(|(id, d)| (format!("[{id}] {d}"), false))
                         .collect(),
                     item.n_actions() as u16 + 2, // 2 for top/bot paddings
-                    state,
                     ui,
                 );
                 (rect, false)
@@ -103,13 +94,13 @@ pub fn render_popup(
                     .map(|d| (format!("{} | {}", d.name, d.id), current_device_id == d.id))
                     .collect();
 
-                let rect = render_list_popup(frame, rect, "Devices", items, 5, state, ui);
+                let rect = render_list_popup(frame, rect, "Devices", items, 5, ui);
                 (rect, false)
             }
             PopupState::ThemeList(themes, ..) => {
                 let items = themes.iter().map(|t| (t.name.clone(), false)).collect();
 
-                let rect = render_list_popup(frame, rect, "Themes", items, 7, state, ui);
+                let rect = render_list_popup(frame, rect, "Themes", items, 7, ui);
                 (rect, false)
             }
             PopupState::UserPlaylistList(action, _) => {
@@ -123,7 +114,7 @@ pub fn render_popup(
                     .map(|p| (p.to_string(), false))
                     .collect();
 
-                let rect = render_list_popup(frame, rect, "User Playlists", items, 10, state, ui);
+                let rect = render_list_popup(frame, rect, "User Playlists", items, 10, ui);
                 (rect, false)
             }
             PopupState::UserFollowedArtistList { .. } => {
@@ -136,8 +127,7 @@ pub fn render_popup(
                     .map(|a| (a.to_string(), false))
                     .collect();
 
-                let rect =
-                    render_list_popup(frame, rect, "User Followed Artists", items, 7, state, ui);
+                let rect = render_list_popup(frame, rect, "User Followed Artists", items, 7, ui);
                 (rect, false)
             }
             PopupState::UserSavedAlbumList { .. } => {
@@ -150,13 +140,13 @@ pub fn render_popup(
                     .map(|a| (a.to_string(), false))
                     .collect();
 
-                let rect = render_list_popup(frame, rect, "User Saved Albums", items, 7, state, ui);
+                let rect = render_list_popup(frame, rect, "User Saved Albums", items, 7, ui);
                 (rect, false)
             }
             PopupState::ArtistList(_, artists, ..) => {
                 let items = artists.iter().map(|a| (a.to_string(), false)).collect();
 
-                let rect = render_list_popup(frame, rect, "Artists", items, 5, state, ui);
+                let rect = render_list_popup(frame, rect, "Artists", items, 5, ui);
                 (rect, false)
             }
         },
@@ -170,12 +160,11 @@ fn render_list_popup(
     title: &str,
     items: Vec<(String, bool)>,
     length: u16,
-    state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Rect {
     let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(length)]).split(rect);
 
-    let rect = construct_and_render_block(title, &ui.theme, state, Borders::ALL, frame, chunks[1]);
+    let rect = construct_and_render_block(title, &ui.theme, Borders::ALL, frame, chunks[1]);
     let (list, len) = utils::construct_list_widget(&ui.theme, items, true);
 
     utils::render_list_window(
@@ -190,12 +179,7 @@ fn render_list_popup(
 }
 
 /// Render a shortcut help popup to show the available shortcuts based on user's inputs
-pub fn render_shortcut_help_popup(
-    frame: &mut Frame,
-    state: &SharedState,
-    ui: &mut UIStateGuard,
-    rect: Rect,
-) -> Rect {
+pub fn render_shortcut_help_popup(frame: &mut Frame, ui: &mut UIStateGuard, rect: Rect) -> Rect {
     let input = &ui.input_key_sequence;
 
     // get the matches (keymaps) from the current key sequence input,
@@ -223,14 +207,8 @@ pub fn render_shortcut_help_popup(
     } else {
         let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(7)]).split(rect);
 
-        let rect = construct_and_render_block(
-            "Shortcuts",
-            &ui.theme,
-            state,
-            Borders::ALL,
-            frame,
-            chunks[1],
-        );
+        let rect =
+            construct_and_render_block("Shortcuts", &ui.theme, Borders::ALL, frame, chunks[1]);
 
         let help_table = Table::new(
             matches

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -204,8 +204,7 @@ pub fn render_shortcut_help_popup(
         if input.keys.is_empty() {
             vec![]
         } else {
-            state
-                .configs
+            config::get_config()
                 .keymap_config
                 .find_matched_prefix_keymaps(input)
                 .into_iter()

--- a/spotify_player/src/ui/utils.rs
+++ b/spotify_player/src/ui/utils.rs
@@ -7,7 +7,6 @@ use super::*;
 pub fn construct_and_render_block(
     title: &str,
     theme: &config::Theme,
-    state: &SharedState,
     borders: Borders,
     frame: &mut Frame,
     rect: Rect,

--- a/spotify_player/src/ui/utils.rs
+++ b/spotify_player/src/ui/utils.rs
@@ -14,7 +14,9 @@ pub fn construct_and_render_block(
 ) -> Rect {
     let mut title = title.to_string();
 
-    let (borders, border_type) = match state.configs.app_config.border_type {
+    let configs = config::get_config();
+
+    let (borders, border_type) = match configs.app_config.border_type {
         config::BorderType::Hidden => (borders, BorderType::Plain),
         config::BorderType::Plain => (borders, BorderType::Plain),
         config::BorderType::Rounded => (borders, BorderType::Rounded),
@@ -33,7 +35,7 @@ pub fn construct_and_render_block(
     // `Hidden` border can be done by setting the borders to be `NONE`.
     // NOTE: we want to handle the border after the inner rectangle computation,
     // so that paddings between windows are properly determined.
-    if state.configs.app_config.border_type == config::BorderType::Hidden {
+    if configs.app_config.border_type == config::BorderType::Hidden {
         block = block.borders(Borders::NONE);
         // add padding to the title to ensure the inner text is aligned with the title
         title = format!(" {title}");


### PR DESCRIPTION
## Changes
- remove `configs: Configs` from application's `State` struct
- add `config::CONFIGS` as a global static variable representing the application's configs
- implement `config::get_config` to get a static reference of `config::CONFIGS` and `config::set_config` to set the global variable