### PR TITLE
Add album to queue action

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -416,6 +416,16 @@ impl Client {
                 self.add_track_to_playlist(state, playlist_id, track_id)
                     .await?;
             }
+            ClientRequest::AddAlbumToQueue(album_id) => {
+                let album_context = self.album_context(album_id).await?;
+
+                if let Context::Album { album: _, tracks } = album_context {
+                    for track in tracks {
+                        self.add_item_to_queue(PlayableId::Track(track.id), None)
+                            .await?;
+                    }
+                }
+            }
             ClientRequest::DeleteTrackFromPlaylist(playlist_id, track_id) => {
                 self.delete_track_from_playlist(state, playlist_id, track_id)
                     .await?;

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -38,6 +38,7 @@ pub enum ClientRequest {
     },
     Search(String),
     AddTrackToQueue(TrackId<'static>),
+    AddAlbumToQueue(AlbumId<'static>),
     AddTrackToPlaylist(PlaylistId<'static>, TrackId<'static>),
     DeleteTrackFromPlaylist(PlaylistId<'static>, TrackId<'static>),
     ReorderPlaylistItems {

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -101,6 +101,7 @@ pub enum AlbumAction {
     AddToLibrary,
     DeleteFromLibrary,
     CopyAlbumLink,
+    AddToQueue,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -149,6 +150,7 @@ pub fn construct_album_actions(album: &Album, data: &DataReadGuard) -> Vec<Album
         AlbumAction::GoToAlbumRadio,
         AlbumAction::ShowActionsOnArtist,
         AlbumAction::CopyAlbumLink,
+        AlbumAction::AddToQueue,
     ];
     if data.user_data.saved_albums.iter().any(|a| a.id == album.id) {
         actions.push(AlbumAction::DeleteFromLibrary);

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -63,6 +63,7 @@ fn handle_command_for_library_page(
                     ui.search_filtered_items(&data.user_data.saved_albums),
                     &data,
                     ui,
+                    client_pub,
                 ),
                 LibraryFocusState::FollowedArtists => {
                     window::handle_command_for_artist_list_window(
@@ -140,7 +141,7 @@ fn handle_key_sequence_for_search_page(
             let albums = search_results
                 .map(|s| s.albums.iter().collect())
                 .unwrap_or_default();
-            window::handle_command_for_album_list_window(command, albums, &data, ui)
+            window::handle_command_for_album_list_window(command, albums, &data, ui, client_pub)
         }
         SearchFocusState::Playlists => {
             let playlists = search_results

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -25,7 +25,7 @@ pub fn handle_key_sequence_for_page(
 
     match page_type {
         PageType::Search => anyhow::bail!("page search type should already be handled!"),
-        PageType::Library => handle_command_for_library_page(command, ui, state),
+        PageType::Library => handle_command_for_library_page(command, client_pub, ui, state),
         PageType::Context => handle_command_for_context_page(command, client_pub, ui, state),
         PageType::Browse => handle_command_for_browse_page(command, client_pub, ui, state),
         #[cfg(feature = "lyric-finder")]
@@ -37,6 +37,7 @@ pub fn handle_key_sequence_for_page(
 
 fn handle_command_for_library_page(
     command: Command,
+    client_pub: &flume::Sender<ClientRequest>,
     ui: &mut UIStateGuard,
     state: &SharedState,
 ) -> Result<bool> {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -587,6 +587,10 @@ fn handle_item_action(
                 client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Album(album.id)))?;
                 ui.popup = None;
             }
+            AlbumAction::AddToQueue => {
+                client_pub.send(ClientRequest::AddAlbumToQueue(album.id))?;
+                ui.popup = None;
+            }
         },
         ActionListItem::Artist(artist, actions) => match actions[n] {
             ArtistAction::Follow => {

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -79,6 +79,7 @@ pub fn handle_command_for_focused_context_window(
                         ui.search_filtered_items(albums),
                         &data,
                         ui,
+                        client_pub,
                     ),
                     ArtistFocusState::RelatedArtists => handle_command_for_artist_list_window(
                         command,
@@ -327,6 +328,7 @@ pub fn handle_command_for_album_list_window(
     albums: Vec<&Album>,
     data: &DataReadGuard,
     ui: &mut UIStateGuard,
+    client_pub: &flume::Sender<ClientRequest>,
 ) -> Result<bool> {
     let id = ui.current_page_mut().selected().unwrap_or_default();
     if id >= albums.len() {
@@ -351,6 +353,9 @@ pub fn handle_command_for_album_list_window(
                 ActionListItem::Album(albums[id].clone(), actions),
                 new_list_state(),
             ));
+        }
+        Command::AddSelectedItemToQueue => {
+            client_pub.send(ClientRequest::AddAlbumToQueue(albums[id].id.clone()))?;
         }
         _ => return Ok(false),
     }


### PR DESCRIPTION
Hi @aome510,

I'm new to Rust bu tried implementing the _Add album to queue_ action but could not get the development version working locally. I'm left with a blank screen when running the binary even from master after `cargo build`. Do you need to do something else or is the master failing? I have a release version authenticated with spotify and working.

Are there any additional places we need to add `AddAlbumToQueue`, `AddToQueue` and the `AddSelectedItemToQueue` for supporting keymapped queue.

Drafted until ready.

Closes #407 