### PR TITLE
Add Alternating Colors for Help Table

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -203,6 +203,7 @@ To define application's component styles, the user can specify any of the below 
 - `page_desc`
 - `table_header`
 - `selection`
+- `secondary_row`
 
 A field in `component_style` is a struct with three **optional** fields: `fg` (foreground), `bg` (background) and `modifiers` (terminal effects):
 

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -43,6 +43,31 @@ bright_cyan = "#8be9fd"
 bright_white = "#ffffff"
 
 [[themes]]
+name = "my_dracula"
+[themes.palette]
+background = "#1e1f29"
+foreground = "#f8f8f2"
+black = "#000000"
+red = "#ff5555"
+green = "#50fa7b"
+yellow = "#f1fa8c"
+blue = "#bd93f9"
+magenta = "#ff79c6"
+cyan = "#8be9fd"
+white = "#bbbbbb"
+bright_black = "#555555"
+bright_red = "#ff5555"
+bright_green = "#50fa7b"
+bright_yellow = "#f1fa8c"
+bright_blue = "#bd93f9"
+bright_magenta = "#ff79c6"
+bright_cyan = "#8be9fd"
+bright_white = "#ffffff"
+[themes.component_style]
+selection = {bg = "Black", fg = "White", modifiers = ["Bold"]}
+secondary_row = { bg = "#677075" }
+
+[[themes]]
 name = "gruvbox_dark"
 [themes.palette]
 background = "#282828"

--- a/examples/theme.toml
+++ b/examples/theme.toml
@@ -42,8 +42,9 @@ bright_magenta = "#ff79c6"
 bright_cyan = "#8be9fd"
 bright_white = "#ffffff"
 
+# same colors as dracula, but includes non-default component styles
 [[themes]]
-name = "my_dracula"
+name = "dracula2"
 [themes.palette]
 background = "#1e1f29"
 foreground = "#f8f8f2"
@@ -64,7 +65,7 @@ bright_magenta = "#ff79c6"
 bright_cyan = "#8be9fd"
 bright_white = "#ffffff"
 [themes.component_style]
-selection = {bg = "Black", fg = "White", modifiers = ["Bold"]}
+selection = { bg = "Black", fg = "White", modifiers = ["Bold"] }
 secondary_row = { bg = "#677075" }
 
 [[themes]]

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -287,14 +287,7 @@ impl Theme {
     }
     pub fn secondary_row(&self) -> tui::style::Style {
         match &self.component_style.secondary_row {
-            None => Style::default()
-                .bg(StyleColor::Rgb {
-                    // "Dark Steel Gray"
-                    r: 67,
-                    g: 70,
-                    b: 75,
-                })
-                .style(&self.palette),
+            None => Style::default().style(&self.palette),
             Some(s) => s.style(&self.palette),
         }
     }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -77,6 +77,7 @@ pub struct ComponentStyle {
     pub playlist_desc: Option<Style>,
     pub table_header: Option<Style>,
     pub selection: Option<Style>,
+    pub secondary_row: Option<Style>,
 }
 
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -288,7 +289,12 @@ impl Theme {
             Some(s) => s.style(&self.palette),
         }
     }
-
+    pub fn secondary_row(&self) -> tui::style::Style {
+        match &self.component_style.secondary_row {
+            None => Style::default().bg(StyleColor::DarkGray).style(&self.palette),
+            Some(s) => s.style(&self.palette),
+        }
+    }
 }
 
 impl Style {

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -58,6 +58,9 @@ pub struct Palette {
     pub bright_blue: Color,
     #[serde(default = "Color::bright_yellow")]
     pub bright_yellow: Color,
+
+    #[serde(default = "Color::dark_gray")]
+    pub dark_gray: Color,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -102,6 +105,7 @@ pub enum StyleColor {
     BrightCyan,
     BrightBlue,
     BrightYellow,
+    DarkGray,
     Rgb { r: u8, g: u8, b: u8 },
 }
 
@@ -284,6 +288,7 @@ impl Theme {
             Some(s) => s.style(&self.palette),
         }
     }
+
 }
 
 impl Style {
@@ -379,6 +384,7 @@ impl StyleColor {
             Self::BrightCyan => palette.bright_cyan.color,
             Self::BrightBlue => palette.bright_blue.color,
             Self::BrightYellow => palette.bright_yellow.color,
+            Self::DarkGray => style::Color::DarkGray,
             Self::Rgb { r, g, b } => style::Color::Rgb(r, g, b),
         }
     }
@@ -463,6 +469,9 @@ impl Color {
     pub fn bright_white() -> Self {
         style::Color::White.into()
     }
+    pub fn dark_gray() -> Self {
+        style::Color::DarkGray.into()
+    }
 }
 
 impl From<&str> for Color {
@@ -519,6 +528,7 @@ impl Default for Palette {
             bright_magenta: Color::bright_magenta(),
             bright_cyan: Color::bright_cyan(),
             bright_white: Color::bright_white(),
+            dark_gray: Color::dark_gray(),
         }
     }
 }

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -58,9 +58,6 @@ pub struct Palette {
     pub bright_blue: Color,
     #[serde(default = "Color::bright_yellow")]
     pub bright_yellow: Color,
-
-    #[serde(default = "Color::dark_gray")]
-    pub dark_gray: Color,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -106,7 +103,6 @@ pub enum StyleColor {
     BrightCyan,
     BrightBlue,
     BrightYellow,
-    DarkGray,
     Rgb { r: u8, g: u8, b: u8 },
 }
 
@@ -291,7 +287,14 @@ impl Theme {
     }
     pub fn secondary_row(&self) -> tui::style::Style {
         match &self.component_style.secondary_row {
-            None => Style::default().bg(StyleColor::DarkGray).style(&self.palette),
+            None => Style::default()
+                .bg(StyleColor::Rgb {
+                    // "Dark Steel Gray"
+                    r: 67,
+                    g: 70,
+                    b: 75,
+                })
+                .style(&self.palette),
             Some(s) => s.style(&self.palette),
         }
     }
@@ -390,7 +393,6 @@ impl StyleColor {
             Self::BrightCyan => palette.bright_cyan.color,
             Self::BrightBlue => palette.bright_blue.color,
             Self::BrightYellow => palette.bright_yellow.color,
-            Self::DarkGray => style::Color::DarkGray,
             Self::Rgb { r, g, b } => style::Color::Rgb(r, g, b),
         }
     }
@@ -475,9 +477,6 @@ impl Color {
     pub fn bright_white() -> Self {
         style::Color::White.into()
     }
-    pub fn dark_gray() -> Self {
-        style::Color::DarkGray.into()
-    }
 }
 
 impl From<&str> for Color {
@@ -534,7 +533,6 @@ impl Default for Palette {
             bright_magenta: Color::bright_magenta(),
             bright_cyan: Color::bright_cyan(),
             bright_white: Color::bright_white(),
-            dark_gray: Color::dark_gray(),
         }
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -567,12 +567,19 @@ pub fn render_commands_help_page(frame: &mut Frame, ui: &mut UIStateGuard, rect:
     let help_table = Table::new(
         map.into_iter()
             .skip(scroll_offset)
-            .map(|(command, keys)| {
+            .enumerate()
+            .map(|(i, (command, keys))| {
                 Row::new(vec![
                     Cell::from(format!("{command:?}")),
                     Cell::from(format!("[{keys}]")),
                     Cell::from(command.desc()),
                 ])
+                    // adding alternating row colors
+                    .style(if (i + scroll_offset) % 2 == 0 {
+                        ui.theme.app().bg(Color::DarkGray)
+                    } else {
+                        ui.theme.app()
+                    })
             })
             .collect::<Vec<_>>(),
         COMMAND_TABLE_CONSTRAINTS,

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -574,12 +574,12 @@ pub fn render_commands_help_page(frame: &mut Frame, ui: &mut UIStateGuard, rect:
                     Cell::from(format!("[{keys}]")),
                     Cell::from(command.desc()),
                 ])
-                    // adding alternating row colors
-                    .style(if (i + scroll_offset) % 2 == 0 {
-                        ui.theme.secondary_row()
-                    } else {
-                        ui.theme.app()
-                    })
+                // adding alternating row colors
+                .style(if (i + scroll_offset) % 2 == 0 {
+                    ui.theme.secondary_row()
+                } else {
+                    ui.theme.app()
+                })
             })
             .collect::<Vec<_>>(),
         COMMAND_TABLE_CONSTRAINTS,

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -576,7 +576,7 @@ pub fn render_commands_help_page(frame: &mut Frame, ui: &mut UIStateGuard, rect:
                 ])
                     // adding alternating row colors
                     .style(if (i + scroll_offset) % 2 == 0 {
-                        ui.theme.app().bg(Color::DarkGray)
+                        ui.theme.secondary_row()
                     } else {
                         ui.theme.app()
                     })


### PR DESCRIPTION
I started using spotify-player, and I found the help table difficult to read. I added alternating row coloring as pictured below to help with identifying keybindings. 

![image](https://github.com/aome510/spotify-player/assets/84808053/9302bb0c-202c-4927-adec-3c8494fc23cf)
