### PR TITLE
Add optional fuzzy search algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4384,7 @@ dependencies = [
  "daemonize",
  "dirs-next",
  "flume",
+ "fuzzy-matcher",
  "image",
  "librespot-connect",
  "librespot-core",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Notify](#notify)
   - [Mouse support](#mouse-support)
   - [Daemon](#daemon)
+  - [Fuzzy search](#fuzzy-search)
   - [CLI commands](#cli-commands)
 - [Commands](#commands)
 - [Configurations](#configurations)
@@ -274,6 +275,10 @@ You can run the application as a daemon by specifying the `-d` or `--daemon` opt
   ```shell
   cargo install spotify_player --no-default-features --features daemon,rodio-backend
   ```
+
+### Fuzzy search
+
+To enable [fuzzy search](https://en.wikipedia.org/wiki/Approximate_string_matching) support, `spotify_player` needs to be built/installed with `fzf` feature (**disabled** by default).
 
 ### CLI Commands
 

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -47,6 +47,7 @@ daemonize = { version = "0.5.0", optional = true }
 ttl_cache = "0.5.1"
 clap_complete = "4.5.1"
 which = "6.0.1"
+fuzzy-matcher = { version = "0.3.7", optional = true }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
 version = "0.30.0"
@@ -81,6 +82,7 @@ image = ["viuer", "dep:image"]
 sixel = ["image", "viuer/sixel"]
 notify = ["notify-rust"]
 daemon = ["daemonize", "streaming"]
+fzf = ["fuzzy-matcher"]
 
 default = ["rodio-backend", "media-control"]
 

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -121,9 +121,7 @@ fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> 
         .collect::<Vec<_>>();
 
     result.sort_by(|(_, a), (_, b)| b.cmp(a));
-    let result = result.into_iter().map(|(t, _)| t).collect::<Vec<_>>();
-
-    result
+    result.into_iter().map(|(t, _)| t).collect::<Vec<_>>()
 }
 
 impl Default for UIState {

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -83,6 +83,11 @@ impl UIState {
         match self.popup {
             Some(PopupState::Search { ref query }) => {
                 let query = query.to_lowercase();
+
+                #[cfg(feature = "fzf")]
+                return fuzzy_search_items(items, &query);
+
+                #[cfg(not(feature = "fzf"))]
                 items
                     .iter()
                     .filter(|t| {
@@ -98,6 +103,27 @@ impl UIState {
             _ => items.iter().collect::<Vec<_>>(),
         }
     }
+}
+
+#[cfg(feature = "fzf")]
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+#[cfg(feature = "fzf")]
+fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> Vec<&'a T> {
+    let matcher = SkimMatcherV2::default();
+    let mut result = items
+        .iter()
+        .filter_map(|t| {
+            matcher
+                .fuzzy(&t.to_string(), &query, false)
+                .map(|(score, _)| (t, score))
+        })
+        .collect::<Vec<_>>();
+
+    result.sort_by(|(_, a), (_, b)| b.cmp(a));
+    let result = result.into_iter().map(|(t, _)| t).collect::<Vec<_>>();
+
+    return result;
 }
 
 impl Default for UIState {

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -123,7 +123,7 @@ fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> 
     result.sort_by(|(_, a), (_, b)| b.cmp(a));
     let result = result.into_iter().map(|(t, _)| t).collect::<Vec<_>>();
 
-    return result;
+    result
 }
 
 impl Default for UIState {

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -11,6 +11,7 @@ pub use page::*;
 pub use popup::*;
 
 #[derive(Default, Debug)]
+#[cfg(feature = "image")]
 pub struct ImageRenderInfo {
     pub url: String,
     pub render_area: tui::layout::Rect,


### PR DESCRIPTION
I discovered that the current search algorithm struggles with queries that start with a single letter followed by a space. To address this issue, I've added a new feature flag that enables fuzzy searching. This makes searching a lot more flexible and also sorts the results by their relevance.

This is my first time using feature flags, so I am open to feedback on the control flow implementation.