### PR TITLE
fix #464 by adding full date to display next to albums

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1538,21 +1538,13 @@ impl Client {
 
     /// Process a list of albums, which includes
     /// - sort albums by the release date
-    /// - remove albums with duplicated names
     fn process_artist_albums(&self, albums: Vec<Album>) -> Vec<Album> {
         let mut albums = albums.into_iter().collect::<Vec<_>>();
 
         albums.sort_by(|x, y| x.release_date.partial_cmp(&y.release_date).unwrap());
 
-        // use a HashSet to keep track albums with the same name
-        let mut seen_names = std::collections::HashSet::new();
+        albums.reverse();
 
-        albums.into_iter().rfold(vec![], |mut acc, a| {
-            if !seen_names.contains(&a.name) {
-                seen_names.insert(a.name.clone());
-                acc.push(a);
-            }
-            acc
-        })
+        albums
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -728,7 +728,7 @@ fn render_artist_context_page_windows(
     let (album_list, n_albums) = {
         let album_items = albums
             .into_iter()
-            .map(|a| (format!("{1} • {0}", a.name, a.year()), false))
+            .map(|a| (format!("{1} • {0}", a.name, a.release_date), false))
             .collect::<Vec<_>>();
 
         utils::construct_list_widget(


### PR DESCRIPTION
fixes #464

This PR removes the code previously responsible for filtering out duplicate album names, which had caused #464.

I have decided to not any additional text to signal the difference between the albums with the same name as: 
1) That might cause confusion as the the actual name of the album
2) There is in my opinion no problem with having 2 entries with the same name
3) The official Spotify client also handles this situation in this manner

This PR however doesn't entirely fix the bug described in the issue, as it seems that this is an upstream issue. The Spotify API doesn't return both copies of the album "Revelations" by "Audioslave" and accordingly the Spotify Client has the exact same behavior as spotfiy_player. But now the two versions of Original Fire show up as they should. 

[Spotify response sample](https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums): 

`jq '.items[].name' response.json`

```
"Revelations"
"Out of Exile"
"Audioslave"
"Original Fire"
"Original Fire"
"Doesn't Remind Me"
"Sessions @AOL Music - EP (Live)"
"Your Time Has Come"
"Like A Stone (Live from New York City)"
"Be Yourself"
"Audioslave Live on Hollywood Blvd."
"Show Me How To Live"
"Cochise"
"Chris Cornell (Deluxe Edition)"
"Live 8 (Live, July 2005)"
"Rock Clássico"
"90s Grunge"
"Canciones De Hace Un Tiempo - Rock"
"20 Top Rock Hits"
"Summer Rocks Best Buy Version"
"Miami Ibiza St. Tropez, Selected Housetunes Vol. 1"
```