### PR TITLE
fix: decode html entities in playlist description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,6 +4394,7 @@ dependencies = [
  "dirs-next",
  "flume",
  "fuzzy-matcher",
+ "html-escape",
  "image",
  "librespot-connect",
  "librespot-core",
@@ -5052,6 +5062,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -48,6 +48,7 @@ ttl_cache = "0.5.1"
 clap_complete = "4.5.1"
 which = "6.0.1"
 fuzzy-matcher = { version = "0.3.7", optional = true }
+html-escape = "0.2.13"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
 version = "0.30.0"

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -3,6 +3,7 @@ use rspotify::model::CurrentPlaybackContext;
 pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
 
 use crate::utils::map_join;
+use html_escape::decode_html_entities;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -403,10 +404,9 @@ impl From<rspotify_model::SimplifiedPlaylist> for Playlist {
 impl From<rspotify_model::FullPlaylist> for Playlist {
     fn from(playlist: rspotify_model::FullPlaylist) -> Self {
         // remove HTML tags from the description
-        // TODO: may also need to do HTML escaping here
         let re = regex::Regex::new("(<.*?>|</.*?>)").expect("valid regex");
         let desc = playlist.description.unwrap_or_default();
-        let desc = re.replace_all(&desc, "").to_string();
+        let desc = decode_html_entities(&re.replace_all(&desc, "")).to_string();
 
         Self {
             id: playlist.id,


### PR DESCRIPTION
Noticed in one of my playlists the apostrophe in the description was displayed as `&#x27;`. initially i tried to fix this without using a library, but it doesn't seem feasible to roll my own decoder for this. I've added the library `html-escape` which seems like the best out of a few choices. 

I'm not quite sure if we still need the regex to remove html tags as i haven't seen any examples of these being sent down.