### PR TITLE
got rid of that stupid shorts player in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## Examples
 
-A demo of `spotify_player` `v0.5.0-pre-release` on [youtube](https://www.youtube.com/shorts/Jbfe9GLNWbA) or on [asciicast](https://asciinema.org/a/446913):
+A demo of `spotify_player` `v0.5.0-pre-release` on [youtube](https://www.youtube.com/watch/Jbfe9GLNWbA) or on [asciicast](https://asciinema.org/a/446913):
 
 Checkout [examples/README.md](./examples/README.md) for more examples.
 


### PR DESCRIPTION
Just simply changed the link of the youtube demo from youtube.com/shorts/video-id to youtube.com/watch/video-id to get rid of the ugly youtube shorts player