### PR TITLE
update search popup's filtering logic

### DIFF
--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -298,6 +298,9 @@ fn handle_key_sequence_for_search_popup(
                     if !query.is_empty() {
                         query.pop().unwrap();
                         ui.current_page_mut().select(0);
+                    } else {
+                        // close search popup when user presses backspace on empty search
+                        ui.popup = None;
                     }
                     return Ok(true);
                 }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -96,7 +96,10 @@ impl UIState {
                             true
                         } else {
                             let t = t.to_string().to_lowercase();
-                            query.split(' ').any(|q| !q.is_empty() && t.contains(q))
+                            query
+                                .split(' ')
+                                .filter(|q| !q.is_empty())
+                                .all(|q| t.contains(q))
                         }
                     })
                     .collect::<Vec<_>>()


### PR DESCRIPTION
Also fixes #489 

Filtering logic is updated to select items matching **any sub-queries** to **all sub-queries**. Sub-queries are non-empty strings separated by spaces in the search's query.