### PR TITLE
add jump to track command

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ List of supported commands:
 | `MovePlaylistItemUp`           | move playlist item up one position                                      | `C-k`              |
 | `MovePlaylistItemDown`         | move playlist item down one position                                    | `C-j`              |
 | `CreatePlaylist`               | create a new playlist                                                   | `N`                |
+| `JumpToCurrentTrackInContext`  | jump to the current track in the context                                | `g c`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -30,6 +30,7 @@ pub enum Command {
     SelectFirstOrScrollToTop,
     SelectLastOrScrollToBottom,
 
+    JumpToCurrentTrackInContext,
     ChooseSelected,
 
     RefreshPlayback,
@@ -251,6 +252,7 @@ impl Command {
                 "select the last item in a list/table or scroll to the bottom"
             }
             Self::ChooseSelected => "choose the selected item and act on it",
+            Self::JumpToCurrentTrackInContext => "jump to the current track in the context",
             Self::RefreshPlayback => "manually refresh the current playback",
             Self::ShowActionsOnSelectedItem => "open a popup showing actions on a selected item",
             Self::ShowActionsOnCurrentTrack => "open a popup showing actions on the current track",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -312,6 +312,10 @@ impl Default for KeymapConfig {
                     key_sequence: "N".into(),
                     command: Command::CreatePlaylist,
                 },
+                Keymap {
+                    key_sequence: "g c".into(),
+                    command: Command::JumpToCurrentTrackInContext,
+                },
             ],
         }
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -593,6 +593,25 @@ fn handle_global_command(
                 current_field: PlaylistCreateCurrentField::Name,
             });
         }
+        Command::JumpToCurrentTrackInContext => {
+            state.player.read()
+                .current_playing_track()
+                .and_then(|track| track.id.clone())
+                .and_then(|track_id| match ui.current_page() {
+                    PageState::Context { id: Some(context_id), .. } => {
+                        state.data.read().caches.context.get(&context_id.uri())
+                            .and_then(|context| match context {
+                                Context::Tracks { tracks, .. } => {
+                                    tracks.iter().position(|t| t.id == track_id)
+                                }
+                                _ => None,
+                            })
+                    }
+                    _ => None,
+                })
+                .map(|i| ui.current_page_mut().select(i));
+            ui.popup = None;
+        }
         Command::ClosePopup => {
             ui.popup = None;
         }

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -132,7 +132,7 @@ pub fn handle_command_for_focused_context_window(
         // sort ordering commands
         if let Some(order) = order {
             let mut data = state.data.write();
-            if let Some(tracks) = data.context_tracks(context_id) {
+            if let Some(tracks) = data.context_tracks_mut(context_id) {
                 tracks.sort_by(|x, y| order.compare(x, y));
             }
             return Ok(true);
@@ -140,7 +140,7 @@ pub fn handle_command_for_focused_context_window(
         // reverse ordering command
         if command == Command::ReverseTrackOrder {
             let mut data = state.data.write();
-            if let Some(tracks) = data.context_tracks(context_id) {
+            if let Some(tracks) = data.context_tracks_mut(context_id) {
                 tracks.reverse();
             }
             return Ok(true);

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -76,8 +76,19 @@ impl AppData {
     }
 
     /// Get a list of tracks inside a given context
-    pub fn context_tracks(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
+    pub fn context_tracks_mut(&mut self, id: &ContextId) -> Option<&mut Vec<Track>> {
         self.caches.context.get_mut(&id.uri()).map(|c| match c {
+            Context::Album { tracks, .. } => tracks,
+            Context::Playlist { tracks, .. } => tracks,
+            Context::Artist {
+                top_tracks: tracks, ..
+            } => tracks,
+            Context::Tracks { tracks, .. } => tracks,
+        })
+    }
+
+    pub fn context_tracks(&self, id: &ContextId) -> Option<&Vec<Track>> {
+        self.caches.context.get(&id.uri()).map(|c| match c {
             Context::Album { tracks, .. } => tracks,
             Context::Playlist { tracks, .. } => tracks,
             Context::Artist {


### PR DESCRIPTION
Resolves #484

I decided to refresh my ancient Rust knowledge and resolve my own feature request by myself 😄

It turns out that the simple jump to track action is better suited for this feature than the alternative of pressing `#` and entering a track number. The latter requires a track position to be persistent in the model, while currently track numbers are calculated during rendering. 