### PR TITLE
show album types in the artist context

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -202,7 +202,10 @@ pub fn handle_action_in_context(
                 if let Some(album) = track.album {
                     let context = ActionContext::Album(album.clone());
                     ui.popup = Some(PopupState::ActionList(
-                        ActionListItem::Album(album, context.get_available_actions(data)),
+                        Box::new(ActionListItem::Album(
+                            album,
+                            context.get_available_actions(data),
+                        )),
                         new_list_state(),
                     ));
                 }
@@ -405,7 +408,7 @@ fn handle_global_command(
                     let data = state.data.read();
                     let actions = command::construct_track_actions(&track, &data);
                     ui.popup = Some(PopupState::ActionList(
-                        ActionListItem::Track(track, actions),
+                        Box::new(ActionListItem::Track(track, actions)),
                         new_list_state(),
                     ));
                 }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -75,7 +75,7 @@ pub fn handle_key_sequence_for_popup(
                                 construct_artist_actions(&artists[id], &data)
                             };
                             ui.popup = Some(PopupState::ActionList(
-                                ActionListItem::Artist(artists[id].clone(), actions),
+                                Box::new(ActionListItem::Artist(artists[id].clone(), actions)),
                                 new_list_state(),
                             ));
                         }
@@ -452,7 +452,7 @@ pub fn handle_item_action(
     ui: &mut UIStateGuard,
 ) -> Result<()> {
     let item = match ui.popup {
-        Some(PopupState::ActionList(ref item, ..)) => item.clone(),
+        Some(PopupState::ActionList(ref item, ..)) => *item.clone(),
         _ => return Ok(()),
     };
 

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -249,7 +249,7 @@ fn handle_playlist_modify_command(
             let mut actions = command::construct_track_actions(tracks[id], data);
             actions.push(Action::DeleteFromPlaylist);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Track(tracks[id].clone(), actions),
+                Box::new(ActionListItem::Track(tracks[id].clone(), actions)),
                 new_list_state(),
             ));
             return Ok(true);
@@ -324,7 +324,7 @@ fn handle_command_for_track_table_window(
         Command::ShowActionsOnSelectedItem => {
             let actions = command::construct_track_actions(filtered_tracks[id], data);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Track(tracks[id].clone(), actions),
+                Box::new(ActionListItem::Track(tracks[id].clone(), actions)),
                 new_list_state(),
             ));
         }
@@ -368,7 +368,7 @@ pub fn handle_command_for_track_list_window(
         Command::ShowActionsOnSelectedItem => {
             let actions = command::construct_track_actions(tracks[id], data);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Track(tracks[id].clone(), actions),
+                Box::new(ActionListItem::Track(tracks[id].clone(), actions)),
                 new_list_state(),
             ));
         }
@@ -406,7 +406,7 @@ pub fn handle_command_for_artist_list_window(
         Command::ShowActionsOnSelectedItem => {
             let actions = construct_artist_actions(artists[id], data);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Artist(artists[id].clone(), actions),
+                Box::new(ActionListItem::Artist(artists[id].clone(), actions)),
                 new_list_state(),
             ));
         }
@@ -442,7 +442,7 @@ pub fn handle_command_for_album_list_window(
         Command::ShowActionsOnSelectedItem => {
             let actions = construct_album_actions(albums[id], data);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Album(albums[id].clone(), actions),
+                Box::new(ActionListItem::Album(albums[id].clone(), actions)),
                 new_list_state(),
             ));
         }
@@ -480,7 +480,7 @@ pub fn handle_command_for_playlist_list_window(
         Command::ShowActionsOnSelectedItem => {
             let actions = construct_playlist_actions(playlists[id], data);
             ui.popup = Some(PopupState::ActionList(
-                ActionListItem::Playlist(playlists[id].clone(), actions),
+                Box::new(ActionListItem::Playlist(playlists[id].clone(), actions)),
                 new_list_state(),
             ));
         }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -1,6 +1,6 @@
 pub use rspotify::model as rspotify_model;
 use rspotify::model::CurrentPlaybackContext;
-pub use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId, UserId};
+pub use rspotify::model::{AlbumId, AlbumType, ArtistId, Id, PlaylistId, TrackId, UserId};
 
 use crate::utils::map_join;
 use html_escape::decode_html_entities;
@@ -137,6 +137,7 @@ pub struct Album {
     pub release_date: String,
     pub name: String,
     pub artists: Vec<Artist>,
+    pub album_type: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -314,6 +315,7 @@ impl Album {
             name: album.name,
             release_date: album.release_date.unwrap_or_default(),
             artists: from_simplified_artists_to_artists(album.artists),
+            album_type: album.album_type.unwrap_or_default(),
         })
     }
 
@@ -334,6 +336,12 @@ impl From<rspotify_model::FullAlbum> for Album {
             id: album.id,
             release_date: album.release_date,
             artists: from_simplified_artists_to_artists(album.artists),
+            album_type: match album.album_type {
+                AlbumType::Album => "album".to_string(),
+                AlbumType::Single => "single".to_string(),
+                AlbumType::Compilation => "compilation".to_string(),
+                AlbumType::AppearsOn => "appears on".to_string(),
+            },
         }
     }
 }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -78,7 +78,7 @@ pub enum ContextPageUIState {
     },
     Artist {
         top_track_table: TableState,
-        album_list: ListState,
+        album_table: TableState,
         related_artist_list: ListState,
         focus: ArtistFocusState,
     },
@@ -200,12 +200,12 @@ impl PageState {
                 ContextPageUIState::Album { track_table } => MutableWindowState::Table(track_table),
                 ContextPageUIState::Artist {
                     top_track_table,
-                    album_list,
+                    album_table,
                     related_artist_list,
                     focus,
                 } => match focus {
                     ArtistFocusState::TopTracks => MutableWindowState::Table(top_track_table),
-                    ArtistFocusState::Albums => MutableWindowState::List(album_list),
+                    ArtistFocusState::Albums => MutableWindowState::Table(album_table),
                     ArtistFocusState::RelatedArtists => {
                         MutableWindowState::List(related_artist_list)
                     }
@@ -279,7 +279,7 @@ impl ContextPageUIState {
     pub fn new_artist() -> Self {
         Self::Artist {
             top_track_table: utils::new_table_state(),
-            album_list: utils::new_list_state(),
+            album_table: utils::new_table_state(),
             related_artist_list: utils::new_list_state(),
             focus: ArtistFocusState::TopTracks,
         }

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -18,7 +18,7 @@ pub enum PopupState {
     DeviceList(ListState),
     ArtistList(ArtistPopupAction, Vec<Artist>, ListState),
     ThemeList(Vec<crate::config::Theme>, ListState),
-    ActionList(ActionListItem, ListState),
+    ActionList(Box<ActionListItem>, ListState),
     PlaylistCreate {
         name: LineInput,
         desc: LineInput,

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -739,7 +739,7 @@ fn render_artist_context_page_windows(
         .map(|a| {
             Row::new(vec![
                 Cell::from(a.release_date.clone()),
-                Cell::from(a.album_type.clone()),
+                Cell::from(a.album_type()),
                 Cell::from(a.name.clone()),
             ])
             .style(Style::default())


### PR DESCRIPTION
If an artist has many singles it's hard to find an album in the list:
![image](https://github.com/user-attachments/assets/e12ec086-4dd7-47fc-b327-aee6ec569862)

I added an album type information and converted the list widget to a table:
![image](https://github.com/user-attachments/assets/9e152952-2e98-46d5-98fd-e57f6d986e5f)
