### PR TITLE
add playlist folders support 

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -300,6 +300,12 @@ impl Client {
             }
             ClientRequest::GetUserPlaylists => {
                 let playlists = self.current_user_playlists().await?;
+                let nodes = state.data.read().user_data.playlist_folder_nodes.clone();
+                let playlists = if nodes.is_empty() {
+                    playlists
+                } else {
+                    crate::playlist_folders::structurize(&playlists, nodes)
+                };
                 store_data_into_file_cache(
                     FileCacheKey::Playlists,
                     &config::get_config().cache_folder,

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -300,11 +300,11 @@ impl Client {
             }
             ClientRequest::GetUserPlaylists => {
                 let playlists = self.current_user_playlists().await?;
-                let nodes = state.data.read().user_data.playlist_folder_nodes.clone();
-                let playlists = if nodes.is_empty() {
-                    playlists
+                let node = state.data.read().user_data.playlist_folder_node.clone();
+                let playlists = if let Some(node) = node.filter(|n| !n.children.is_empty()) {
+                    crate::playlist_folders::structurize(playlists, node.children)
                 } else {
-                    crate::playlist_folders::structurize(&playlists, nodes)
+                    playlists
                 };
                 store_data_into_file_cache(
                     FileCacheKey::Playlists,

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -305,8 +305,7 @@ impl Client {
                     crate::playlist_folders::structurize(playlists, node.children)
                 } else {
                     playlists
-                        .iter()
-                        .cloned()
+                        .into_iter()
                         .map(PlaylistFolderItem::Playlist)
                         .collect()
                 };
@@ -912,11 +911,9 @@ impl Client {
                 _ => anyhow::bail!("expect an album search result"),
             },
             match playlist_result {
-                rspotify_model::SearchResult::Playlists(p) => p
-                    .items
-                    .into_iter()
-                    .map(|i| PlaylistFolderItem::Playlist(i.into()))
-                    .collect(),
+                rspotify_model::SearchResult::Playlists(p) => {
+                    p.items.into_iter().map(|i| i.into()).collect()
+                }
                 _ => anyhow::bail!("expect a playlist search result"),
             },
         );

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -205,14 +205,18 @@ pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Ac
 
 /// constructs a list of actions on an playlist
 pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![Action::GoToRadio, Action::CopyLink];
-
-    if data.user_data.playlists.iter().any(|a| a.id == playlist.id) {
-        actions.push(Action::DeleteFromLibrary);
+    if playlist.is_folder {
+        vec![]
     } else {
-        actions.push(Action::AddToLibrary);
+        let mut actions = vec![Action::GoToRadio, Action::CopyLink];
+
+        if data.user_data.playlists.iter().any(|a| a.id == playlist.id) {
+            actions.push(Action::DeleteFromLibrary);
+        } else {
+            actions.push(Action::AddToLibrary);
+        }
+        actions
     }
-    actions
 }
 
 impl Command {

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -1,4 +1,6 @@
-use crate::state::{Album, Artist, DataReadGuard, Playlist, PlaylistFolderItem, Track};
+use crate::state::{
+    Album, Artist, DataReadGuard, Playlist, PlaylistFolder, PlaylistFolderItem, Track,
+};
 use serde::Deserialize;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -105,6 +107,9 @@ pub enum ActionContext {
     Album(Album),
     Artist(Artist),
     Playlist(Playlist),
+    #[allow(dead_code)]
+    // TODO: support actions for playlist folders
+    PlaylistFolder(PlaylistFolder),
 }
 
 pub enum CommandOrAction {
@@ -136,6 +141,15 @@ impl From<Playlist> for ActionContext {
     }
 }
 
+impl From<PlaylistFolderItem> for ActionContext {
+    fn from(value: PlaylistFolderItem) -> Self {
+        match value {
+            PlaylistFolderItem::Playlist(p) => ActionContext::Playlist(p),
+            PlaylistFolderItem::Folder(f) => ActionContext::PlaylistFolder(f),
+        }
+    }
+}
+
 impl ActionContext {
     pub fn get_available_actions(&self, data: &DataReadGuard) -> Vec<Action> {
         match self {
@@ -143,6 +157,8 @@ impl ActionContext {
             Self::Album(album) => construct_album_actions(album, data),
             Self::Artist(artist) => construct_artist_actions(artist, data),
             Self::Playlist(playlist) => construct_playlist_actions(playlist, data),
+            // TODO: support actions for playlist folders
+            Self::PlaylistFolder(_) => vec![],
         }
     }
 }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -1,4 +1,4 @@
-use crate::state::{Album, Artist, DataReadGuard, PlaylistFolderItem, Track};
+use crate::state::{Album, Artist, DataReadGuard, Playlist, PlaylistFolderItem, Track};
 use serde::Deserialize;
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -104,7 +104,7 @@ pub enum ActionContext {
     Track(Track),
     Album(Album),
     Artist(Artist),
-    Playlist(PlaylistFolderItem),
+    Playlist(Playlist),
 }
 
 pub enum CommandOrAction {
@@ -130,8 +130,8 @@ impl From<Album> for ActionContext {
     }
 }
 
-impl From<PlaylistFolderItem> for ActionContext {
-    fn from(v: PlaylistFolderItem) -> Self {
+impl From<Playlist> for ActionContext {
+    fn from(v: Playlist) -> Self {
         Self::Playlist(v)
     }
 }
@@ -204,28 +204,20 @@ pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Ac
 }
 
 /// constructs a list of actions on an playlist
-pub fn construct_playlist_actions(
-    playlist_item: &PlaylistFolderItem,
-    data: &DataReadGuard,
-) -> Vec<Action> {
-    match playlist_item {
-        PlaylistFolderItem::Folder(_) => vec![],
-        PlaylistFolderItem::Playlist(playlist) => {
-            let mut actions = vec![Action::GoToRadio, Action::CopyLink];
+pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> Vec<Action> {
+    let mut actions = vec![Action::GoToRadio, Action::CopyLink];
 
-            if data
-                .user_data
-                .playlists
-                .iter()
-                .any(|item| matches!(item, PlaylistFolderItem::Playlist(p) if p.id == playlist.id))
-            {
-                actions.push(Action::DeleteFromLibrary);
-            } else {
-                actions.push(Action::AddToLibrary);
-            }
-            actions
-        }
+    if data
+        .user_data
+        .playlists
+        .iter()
+        .any(|item| matches!(item, PlaylistFolderItem::Playlist(p) if p.id == playlist.id))
+    {
+        actions.push(Action::DeleteFromLibrary);
+    } else {
+        actions.push(Action::AddToLibrary);
     }
+    actions
 }
 
 impl Command {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -159,7 +159,7 @@ pub fn handle_action_in_context(
             Action::AddToPlaylist => {
                 client_pub.send(ClientRequest::GetUserPlaylists)?;
                 ui.popup = Some(PopupState::UserPlaylistList(
-                    PlaylistPopupAction::AddTrack(track.id),
+                    PlaylistPopupAction::AddTrack(0, track.id),
                     ListState::default(),
                 ));
             }
@@ -444,7 +444,7 @@ fn handle_global_command(
         Command::BrowseUserPlaylists => {
             client_pub.send(ClientRequest::GetUserPlaylists)?;
             ui.popup = Some(PopupState::UserPlaylistList(
-                PlaylistPopupAction::Browse,
+                PlaylistPopupAction::Browse(0),
                 ListState::default(),
             ));
         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -159,7 +159,10 @@ pub fn handle_action_in_context(
             Action::AddToPlaylist => {
                 client_pub.send(ClientRequest::GetUserPlaylists)?;
                 ui.popup = Some(PopupState::UserPlaylistList(
-                    PlaylistPopupAction::AddTrack(0, track.id),
+                    PlaylistPopupAction::AddTrack {
+                        folder_id: 0,
+                        track_id: track.id,
+                    },
                     ListState::default(),
                 ));
             }
@@ -276,38 +279,34 @@ pub fn handle_action_in_context(
             }
             _ => {}
         },
-        ActionContext::Playlist(item) => {
-            if let PlaylistFolderItem::Playlist(playlist) = item {
-                match action {
-                    Action::AddToLibrary => {
-                        client_pub.send(ClientRequest::AddToLibrary(Item::Playlist(playlist)))?;
-                        ui.popup = None;
-                    }
-                    Action::GoToRadio => {
-                        let uri = playlist.id.uri();
-                        let name = playlist.name;
-                        ui.new_radio_page(&uri);
-                        client_pub.send(ClientRequest::GetRadioTracks {
-                            seed_uri: uri,
-                            seed_name: name,
-                        })?;
-                    }
-                    Action::CopyLink => {
-                        let playlist_url =
-                            format!("https://open.spotify.com/playlist/{}", playlist.id.id());
-                        execute_copy_command(playlist_url)?;
-                        ui.popup = None;
-                    }
-                    Action::DeleteFromLibrary => {
-                        client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(
-                            playlist.id,
-                        )))?;
-                        ui.popup = None;
-                    }
-                    _ => {}
-                }
+        ActionContext::Playlist(playlist) => match action {
+            Action::AddToLibrary => {
+                client_pub.send(ClientRequest::AddToLibrary(Item::Playlist(playlist)))?;
+                ui.popup = None;
             }
-        }
+            Action::GoToRadio => {
+                let uri = playlist.id.uri();
+                let name = playlist.name;
+                ui.new_radio_page(&uri);
+                client_pub.send(ClientRequest::GetRadioTracks {
+                    seed_uri: uri,
+                    seed_name: name,
+                })?;
+            }
+            Action::CopyLink => {
+                let playlist_url =
+                    format!("https://open.spotify.com/playlist/{}", playlist.id.id());
+                execute_copy_command(playlist_url)?;
+                ui.popup = None;
+            }
+            Action::DeleteFromLibrary => {
+                client_pub.send(ClientRequest::DeleteFromLibrary(ItemId::Playlist(
+                    playlist.id,
+                )))?;
+                ui.popup = None;
+            }
+            _ => {}
+        },
     }
 
     Ok(())
@@ -448,7 +447,7 @@ fn handle_global_command(
         Command::BrowseUserPlaylists => {
             client_pub.send(ClientRequest::GetUserPlaylists)?;
             ui.popup = Some(PopupState::UserPlaylistList(
-                PlaylistPopupAction::Browse(0),
+                PlaylistPopupAction::Browse { folder_id: 0 },
                 ListState::default(),
             ));
         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -307,6 +307,8 @@ pub fn handle_action_in_context(
             }
             _ => {}
         },
+        // TODO: support actions for playlist folders
+        ActionContext::PlaylistFolder(_) => {}
     }
 
     Ok(())

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -50,12 +50,12 @@ fn handle_action_for_library_page(
     state: &SharedState,
 ) -> Result<bool> {
     let data = state.data.read();
-    let focus_state = match ui.current_page() {
-        PageState::Library { state } => state.focus,
+    let (focus_state, folder_id) = match ui.current_page() {
+        PageState::Library { state } => (state.focus, state.playlist_folder_id),
         _ => anyhow::bail!("expect a library page state"),
     };
     match focus_state {
-        LibraryFocusState::Playlists(folder_id) => window::handle_action_for_selected_item(
+        LibraryFocusState::Playlists => window::handle_action_for_selected_item(
             action,
             ui.search_filtered_items(
                 &data
@@ -102,26 +102,24 @@ fn handle_command_for_library_page(
         }
         _ => {
             let data = state.data.read();
-            let focus_state = match ui.current_page() {
-                PageState::Library { state } => state.focus,
+            let (focus_state, folder_id) = match ui.current_page() {
+                PageState::Library { state } => (state.focus, state.playlist_folder_id),
                 _ => anyhow::bail!("expect a library page state"),
             };
             match focus_state {
-                LibraryFocusState::Playlists(folder_id) => {
-                    window::handle_command_for_playlist_list_window(
-                        command,
-                        ui.search_filtered_items(
-                            &data
-                                .user_data
-                                .folder_playlists_items(folder_id)
-                                .into_iter()
-                                .cloned()
-                                .collect::<Vec<PlaylistFolderItem>>(),
-                        ),
-                        &data,
-                        ui,
-                    )
-                }
+                LibraryFocusState::Playlists => window::handle_command_for_playlist_list_window(
+                    command,
+                    ui.search_filtered_items(
+                        &data
+                            .user_data
+                            .folder_playlists_items(folder_id)
+                            .into_iter()
+                            .cloned()
+                            .collect::<Vec<PlaylistFolderItem>>(),
+                    ),
+                    &data,
+                    ui,
+                ),
                 LibraryFocusState::SavedAlbums => window::handle_command_for_album_list_window(
                     command,
                     ui.search_filtered_items(&data.user_data.saved_albums),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -60,10 +60,9 @@ fn handle_action_for_library_page(
             ui.search_filtered_items(
                 &data
                     .user_data
-                    .playlists
-                    .clone()
+                    .folder_playlists(level)
                     .into_iter()
-                    .filter(|p| p.level.0 == level)
+                    .cloned()
                     .collect::<Vec<Playlist>>(),
             ),
             &data,
@@ -111,10 +110,9 @@ fn handle_command_for_library_page(
                         ui.search_filtered_items(
                             &data
                                 .user_data
-                                .playlists
-                                .clone()
+                                .folder_playlists(level)
                                 .into_iter()
-                                .filter(|p| p.level.0 == level)
+                                .cloned()
                                 .collect::<Vec<Playlist>>(),
                         ),
                         &data,

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -55,9 +55,17 @@ fn handle_action_for_library_page(
         _ => anyhow::bail!("expect a library page state"),
     };
     match focus_state {
-        LibraryFocusState::Playlists => window::handle_action_for_selected_item(
+        LibraryFocusState::Playlists(level) => window::handle_action_for_selected_item(
             action,
-            ui.search_filtered_items(&data.user_data.playlists),
+            ui.search_filtered_items(
+                &data
+                    .user_data
+                    .playlists
+                    .clone()
+                    .into_iter()
+                    .filter(|p| p.level.0 == level)
+                    .collect::<Vec<Playlist>>(),
+            ),
             &data,
             ui,
             client_pub,
@@ -97,12 +105,22 @@ fn handle_command_for_library_page(
                 _ => anyhow::bail!("expect a library page state"),
             };
             match focus_state {
-                LibraryFocusState::Playlists => window::handle_command_for_playlist_list_window(
-                    command,
-                    ui.search_filtered_items(&data.user_data.playlists),
-                    &data,
-                    ui,
-                ),
+                LibraryFocusState::Playlists(level) => {
+                    window::handle_command_for_playlist_list_window(
+                        command,
+                        ui.search_filtered_items(
+                            &data
+                                .user_data
+                                .playlists
+                                .clone()
+                                .into_iter()
+                                .filter(|p| p.level.0 == level)
+                                .collect::<Vec<Playlist>>(),
+                        ),
+                        &data,
+                        ui,
+                    )
+                }
                 LibraryFocusState::SavedAlbums => window::handle_command_for_album_list_window(
                     command,
                     ui.search_filtered_items(&data.user_data.saved_albums),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -55,15 +55,15 @@ fn handle_action_for_library_page(
         _ => anyhow::bail!("expect a library page state"),
     };
     match focus_state {
-        LibraryFocusState::Playlists(level) => window::handle_action_for_selected_item(
+        LibraryFocusState::Playlists(folder_id) => window::handle_action_for_selected_item(
             action,
             ui.search_filtered_items(
                 &data
                     .user_data
-                    .folder_playlists(level)
+                    .folder_playlists_items(folder_id)
                     .into_iter()
                     .cloned()
-                    .collect::<Vec<Playlist>>(),
+                    .collect::<Vec<PlaylistFolderItem>>(),
             ),
             &data,
             ui,
@@ -104,16 +104,16 @@ fn handle_command_for_library_page(
                 _ => anyhow::bail!("expect a library page state"),
             };
             match focus_state {
-                LibraryFocusState::Playlists(level) => {
+                LibraryFocusState::Playlists(folder_id) => {
                     window::handle_command_for_playlist_list_window(
                         command,
                         ui.search_filtered_items(
                             &data
                                 .user_data
-                                .folder_playlists(level)
+                                .folder_playlists_items(folder_id)
                                 .into_iter()
                                 .cloned()
-                                .collect::<Vec<Playlist>>(),
+                                .collect::<Vec<PlaylistFolderItem>>(),
                         ),
                         &data,
                         ui,
@@ -285,7 +285,7 @@ fn handle_action_for_browse_page(
 
                 handle_action_in_context(
                     action,
-                    playlists[selected].clone().into(),
+                    PlaylistFolderItem::Playlist(playlists[selected].clone()).into(),
                     client_pub,
                     &data,
                     ui,

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -90,40 +90,35 @@ pub fn handle_key_sequence_for_popup(
         }
         PopupState::UserPlaylistList(action, _) => match action {
             PlaylistPopupAction::Browse { folder_id } => {
-                let playlist_uris = state
-                    .data
-                    .read()
-                    .user_data
-                    .folder_playlists_items(*folder_id)
-                    .iter()
-                    .map(|item| match item {
-                        PlaylistFolderItem::Playlist(p) => (p.id.uri(), false, 0),
-                        PlaylistFolderItem::Folder(f) => ("".to_string(), true, f.target_id),
-                    })
-                    .collect::<Vec<_>>();
+                let data = state.data.read();
+                let items = data.user_data.folder_playlists_items(*folder_id);
 
                 handle_command_for_list_popup(
                     command,
                     ui,
-                    playlist_uris.len(),
+                    items.len(),
                     |_, _| {},
                     |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                        if playlist_uris[id].1 {
-                            ui.popup = Some(PopupState::UserPlaylistList(
-                                PlaylistPopupAction::Browse {
-                                    folder_id: playlist_uris[id].2,
-                                },
-                                ListState::default(),
-                            ));
-                        } else {
-                            let uri = crate::utils::parse_uri(&playlist_uris[id].0);
-                            let context_id =
-                                ContextId::Playlist(PlaylistId::from_uri(&uri)?.into_static());
-                            ui.new_page(PageState::Context {
-                                id: None,
-                                context_page_type: ContextPageType::Browsing(context_id),
-                                state: None,
-                            });
+                        match items[id] {
+                            PlaylistFolderItem::Folder(f) => {
+                                ui.popup = Some(PopupState::UserPlaylistList(
+                                    PlaylistPopupAction::Browse {
+                                        folder_id: f.target_id,
+                                    },
+                                    ListState::default(),
+                                ));
+                            }
+                            PlaylistFolderItem::Playlist(p) => {
+                                let context_id = ContextId::Playlist(
+                                    PlaylistId::from_uri(&crate::utils::parse_uri(&p.id.uri()))?
+                                        .into_static(),
+                                );
+                                ui.new_page(PageState::Context {
+                                    id: None,
+                                    context_page_type: ContextPageType::Browsing(context_id),
+                                    state: None,
+                                });
+                            }
                         }
                         Ok(())
                     },
@@ -137,38 +132,30 @@ pub fn handle_key_sequence_for_popup(
                 track_id,
             } => {
                 let track_id = track_id.clone();
-                let playlist_ids = state
-                    .data
-                    .read()
-                    .user_data
-                    .modifiable_playlist_items(Some(*folder_id))
-                    .into_iter()
-                    .map(|item| match item {
-                        PlaylistFolderItem::Playlist(p) => (p.id.id().to_string(), false, 0),
-                        PlaylistFolderItem::Folder(f) => ("".to_string(), true, f.target_id),
-                    })
-                    .collect::<Vec<_>>();
+                let data = state.data.read();
+                let items = data.user_data.modifiable_playlist_items(Some(*folder_id));
 
                 handle_command_for_list_popup(
                     command,
                     ui,
-                    playlist_ids.len(),
+                    items.len(),
                     |_, _| {},
                     |ui: &mut UIStateGuard, id: usize| -> Result<()> {
-                        ui.popup = if playlist_ids[id].1 {
-                            Some(PopupState::UserPlaylistList(
+                        ui.popup = match items[id] {
+                            PlaylistFolderItem::Folder(f) => Some(PopupState::UserPlaylistList(
                                 PlaylistPopupAction::AddTrack {
-                                    folder_id: playlist_ids[id].2,
-                                    track_id: track_id.clone(),
+                                    folder_id: f.target_id,
+                                    track_id,
                                 },
                                 ListState::default(),
-                            ))
-                        } else {
-                            client_pub.send(ClientRequest::AddTrackToPlaylist(
-                                PlaylistId::from_id(playlist_ids[id].0.clone()).unwrap(),
-                                track_id.clone(),
-                            ))?;
-                            None
+                            )),
+                            PlaylistFolderItem::Playlist(p) => {
+                                client_pub.send(ClientRequest::AddTrackToPlaylist(
+                                    p.id.clone(),
+                                    track_id,
+                                ))?;
+                                None
+                            }
                         };
                         Ok(())
                     },
@@ -412,9 +399,9 @@ fn handle_command_for_list_popup(
     command: Command,
     ui: &mut UIStateGuard,
     n_items: usize,
-    on_select_func: impl Fn(&mut UIStateGuard, usize),
-    on_choose_func: impl Fn(&mut UIStateGuard, usize) -> Result<()>,
-    on_close_func: impl Fn(&mut UIStateGuard),
+    on_select_func: impl FnOnce(&mut UIStateGuard, usize),
+    on_choose_func: impl FnOnce(&mut UIStateGuard, usize) -> Result<()>,
+    on_close_func: impl FnOnce(&mut UIStateGuard),
 ) -> Result<bool> {
     let popup = ui.popup.as_mut().with_context(|| "expect a popup")?;
     let current_id = popup.list_selected().unwrap_or_default();

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -275,13 +275,10 @@ fn handle_command_for_track_table_window(
     }
 
     if let Some(ContextId::Playlist(ref playlist_id)) = context_id {
-        let modifiable = data.user_data.modifiable_playlists().iter().any(|item| {
-            if let PlaylistFolderItem::Playlist(p) = item {
-                p.id.eq(playlist_id)
-            } else {
-                false
-            }
-        });
+        let modifiable =
+            data.user_data.modifiable_playlist_items(None).iter().any(
+                |item| matches!(item, PlaylistFolderItem::Playlist(p) if p.id.eq(playlist_id)),
+            );
         if modifiable
             && handle_playlist_modify_command(
                 id,
@@ -493,10 +490,10 @@ pub fn handle_command_for_playlist_list_window(
             }
         }
         Command::ShowActionsOnSelectedItem => {
-            if let PlaylistFolderItem::Playlist(_) = playlists[id] {
-                let actions = construct_playlist_actions(playlists[id], data);
+            if let PlaylistFolderItem::Playlist(p) = playlists[id] {
+                let actions = construct_playlist_actions(p, data);
                 ui.popup = Some(PopupState::ActionList(
-                    Box::new(ActionListItem::Playlist(playlists[id].clone(), actions)),
+                    Box::new(ActionListItem::Playlist(p.clone(), actions)),
                     ListState::default(),
                 ));
             }

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -469,15 +469,17 @@ pub fn handle_command_for_playlist_list_window(
     }
     match command {
         Command::ChooseSelected => {
-            let state = match ui.current_page_mut() {
-                PageState::Library { state } => state,
-                _ => return Ok(false),
-            };
             let playlist = playlists[id];
             match playlist {
                 PlaylistFolderItem::Folder(f) => {
-                    state.playlist_list.select(Some(0));
-                    state.focus = LibraryFocusState::Playlists(f.target_id);
+                    // currently folders are only supported in the library page
+                    match ui.current_page_mut() {
+                        PageState::Library { state } => {
+                            state.playlist_list.select(Some(0));
+                            state.focus = LibraryFocusState::Playlists(f.target_id);
+                        }
+                        _ => return Ok(false),
+                    };
                 }
                 PlaylistFolderItem::Playlist(p) => {
                     let context_id = ContextId::Playlist(p.id.clone());

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -470,12 +470,22 @@ pub fn handle_command_for_playlist_list_window(
     }
     match command {
         Command::ChooseSelected => {
-            let context_id = ContextId::Playlist(playlists[id].id.clone());
-            ui.new_page(PageState::Context {
-                id: None,
-                context_page_type: ContextPageType::Browsing(context_id),
-                state: None,
-            });
+            let state = match ui.current_page_mut() {
+                PageState::Library { state } => state,
+                _ => return Ok(false),
+            };
+            let playlist = playlists[id];
+            if playlist.is_folder {
+                state.playlist_list.select(Some(0));
+                state.focus = LibraryFocusState::Playlists(playlist.level.1);
+            } else {
+                let context_id = ContextId::Playlist(playlists[id].id.clone());
+                ui.new_page(PageState::Context {
+                    id: None,
+                    context_page_type: ContextPageType::Browsing(context_id),
+                    state: None,
+                });
+            }
         }
         Command::ShowActionsOnSelectedItem => {
             let actions = construct_playlist_actions(playlists[id], data);

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -476,7 +476,8 @@ pub fn handle_command_for_playlist_list_window(
                     match ui.current_page_mut() {
                         PageState::Library { state } => {
                             state.playlist_list.select(Some(0));
-                            state.focus = LibraryFocusState::Playlists(f.target_id);
+                            state.focus = LibraryFocusState::Playlists;
+                            state.playlist_folder_id = f.target_id;
                         }
                         _ => return Ok(false),
                     };

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -488,11 +488,13 @@ pub fn handle_command_for_playlist_list_window(
             }
         }
         Command::ShowActionsOnSelectedItem => {
-            let actions = construct_playlist_actions(playlists[id], data);
-            ui.popup = Some(PopupState::ActionList(
-                Box::new(ActionListItem::Playlist(playlists[id].clone(), actions)),
-                ListState::default(),
-            ));
+            if !playlists[id].is_folder {
+                let actions = construct_playlist_actions(playlists[id], data);
+                ui.popup = Some(PopupState::ActionList(
+                    Box::new(ActionListItem::Playlist(playlists[id].clone(), actions)),
+                    ListState::default(),
+                ));
+            }
         }
         _ => return Ok(false),
     }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -7,6 +7,7 @@ mod event;
 mod key;
 #[cfg(feature = "media-control")]
 mod media_control;
+mod playlist_folders;
 mod state;
 #[cfg(feature = "streaming")]
 mod streaming;

--- a/spotify_player/src/playlist_folders.rs
+++ b/spotify_player/src/playlist_folders.rs
@@ -5,13 +5,13 @@ use rspotify::model::{Id, PlaylistId, UserId};
 use crate::state::{Playlist, PlaylistFolderNode};
 
 /// Structurizes a flat input playlist according to the playlist folder nodes
-pub fn structurize(playlists: &Vec<Playlist>, nodes: Vec<PlaylistFolderNode>) -> Vec<Playlist> {
+pub fn structurize(playlists: Vec<Playlist>, nodes: Vec<PlaylistFolderNode>) -> Vec<Playlist> {
     // 1. Collect playlist ids from inner nodes
     let mut playlist_ids: HashSet<String> = HashSet::new();
     get_playlist_ids_from_nodes(&nodes, &mut playlist_ids);
     // 2. Add root playlists that don't belong to folders
     let mut playlist_folders: Vec<Playlist> = Vec::new();
-    for playlist in playlists {
+    for playlist in &playlists {
         if !playlist_ids.contains(playlist.id.id()) {
             let mut p = playlist.clone();
             p.is_folder = false;
@@ -21,7 +21,6 @@ pub fn structurize(playlists: &Vec<Playlist>, nodes: Vec<PlaylistFolderNode>) ->
     }
     // 3. Add the rest
     let by_ids: HashMap<String, Playlist> = playlists
-        .clone()
         .into_iter()
         .map(|p| (p.id.id().to_string(), p))
         .collect();
@@ -42,7 +41,7 @@ fn get_playlist_ids_from_nodes(nodes: &Vec<PlaylistFolderNode>, acc: &mut HashSe
 fn add_playlist_folders(
     nodes: &Vec<PlaylistFolderNode>,
     by_ids: &HashMap<String, Playlist>,
-    folder_level: &mut i32,
+    folder_level: &mut usize,
     acc: &mut Vec<Playlist>,
 ) {
     let level = *folder_level;

--- a/spotify_player/src/playlist_folders.rs
+++ b/spotify_player/src/playlist_folders.rs
@@ -17,7 +17,7 @@ pub fn structurize(
     for playlist in &playlists {
         if !playlist_ids.contains(playlist.id.id()) {
             let mut p = playlist.clone();
-            p.current_id = 0;
+            p.current_folder_id = 0;
             playlist_folders.push(PlaylistFolderItem::Playlist(p));
         }
     }
@@ -66,7 +66,7 @@ fn add_playlist_folders(
                 add_playlist_folders(&f.children, by_ids, folder_id, acc);
             } else if let Some(playlist) = by_ids.get(id) {
                 let mut p = playlist.clone();
-                p.current_id = folder_local_id;
+                p.current_folder_id = folder_local_id;
                 acc.push(PlaylistFolderItem::Playlist(p));
             }
         }

--- a/spotify_player/src/playlist_folders.rs
+++ b/spotify_player/src/playlist_folders.rs
@@ -1,72 +1,62 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use rspotify::model::Id;
 
 use crate::state::{Playlist, PlaylistFolder, PlaylistFolderItem, PlaylistFolderNode};
 
-/// Structurizes a flat input playlist according to the playlist folder nodes
+/// Structurize a flat input playlist according to the playlist folder nodes
 pub fn structurize(
     playlists: Vec<Playlist>,
     nodes: Vec<PlaylistFolderNode>,
 ) -> Vec<PlaylistFolderItem> {
-    // 1. Collect playlist ids from inner nodes
-    let mut playlist_ids: HashSet<String> = HashSet::new();
-    get_playlist_ids_from_nodes(&nodes, &mut playlist_ids);
-    // 2. Add root playlists that don't belong to folders
-    let mut playlist_folders: Vec<PlaylistFolderItem> = Vec::new();
-    for playlist in &playlists {
-        if !playlist_ids.contains(playlist.id.id()) {
-            let mut p = playlist.clone();
-            p.current_folder_id = 0;
-            playlist_folders.push(PlaylistFolderItem::Playlist(p));
-        }
-    }
-    // 3. Add the rest
-    let by_ids: HashMap<String, Playlist> = playlists
+    let mut playlist_folders = Vec::new();
+
+    let mut playlists = playlists
         .into_iter()
         .map(|p| (p.id.id().to_string(), p))
-        .collect();
-    add_playlist_folders(&nodes, &by_ids, &mut 0, &mut playlist_folders);
-    playlist_folders
-}
+        .collect::<HashMap<_, _>>();
 
-fn get_playlist_ids_from_nodes(nodes: &Vec<PlaylistFolderNode>, acc: &mut HashSet<String>) {
-    for f in nodes {
-        if f.node_type == "folder" {
-            get_playlist_ids_from_nodes(&f.children, acc);
-        } else {
-            acc.insert(f.uri.replace("spotify:playlist:", ""));
-        }
+    // Construct playlist folders with relevant playlists
+    add_playlist_folders(&nodes, &mut playlists, &mut 0, &mut playlist_folders);
+
+    // Remaining playlists that don't belong to any folders are added as root playlists
+    for (_, mut p) in playlists {
+        p.current_folder_id = 0;
+        playlist_folders.push(PlaylistFolderItem::Playlist(p));
     }
+    playlist_folders
 }
 
 fn add_playlist_folders(
     nodes: &Vec<PlaylistFolderNode>,
-    by_ids: &HashMap<String, Playlist>,
+    playlists: &mut HashMap<String, Playlist>,
     folder_id: &mut usize,
     acc: &mut Vec<PlaylistFolderItem>,
 ) {
-    let folder_local_id = *folder_id;
+    let current_folder_id = *folder_id;
     for f in nodes {
         if let Some((_, id)) = f.uri.rsplit_once(':') {
             if f.node_type == "folder" {
                 *folder_id += 1;
+                let name = f
+                    .name
+                    .clone()
+                    .unwrap_or(format!("folder_{current_folder_id}"));
                 // Folder node
                 acc.push(PlaylistFolderItem::Folder(PlaylistFolder {
-                    name: f.name.clone().unwrap_or_default(),
-                    current_id: folder_local_id,
+                    name: name.clone(),
+                    current_id: current_folder_id,
                     target_id: *folder_id,
                 }));
                 // Up node
                 acc.push(PlaylistFolderItem::Folder(PlaylistFolder {
-                    name: format!("← {}", f.name.clone().unwrap_or_default()),
+                    name: format!("← {name}"),
                     current_id: *folder_id,
-                    target_id: folder_local_id,
+                    target_id: current_folder_id,
                 }));
-                add_playlist_folders(&f.children, by_ids, folder_id, acc);
-            } else if let Some(playlist) = by_ids.get(id) {
-                let mut p = playlist.clone();
-                p.current_folder_id = folder_local_id;
+                add_playlist_folders(&f.children, playlists, folder_id, acc);
+            } else if let Some(mut p) = playlists.remove(id) {
+                p.current_folder_id = current_folder_id;
                 acc.push(PlaylistFolderItem::Playlist(p));
             }
         }

--- a/spotify_player/src/playlist_folders.rs
+++ b/spotify_player/src/playlist_folders.rs
@@ -1,0 +1,86 @@
+use std::collections::{HashMap, HashSet};
+
+use rspotify::model::{Id, PlaylistId, UserId};
+
+use crate::state::{Playlist, PlaylistFolderNode};
+
+/// Structurizes a flat input playlist according to the playlist folder nodes
+pub fn structurize(playlists: &Vec<Playlist>, nodes: Vec<PlaylistFolderNode>) -> Vec<Playlist> {
+    // 1. Collect playlist ids from inner nodes
+    let mut playlist_ids: HashSet<String> = HashSet::new();
+    get_playlist_ids_from_nodes(&nodes, &mut playlist_ids);
+    // 2. Add root playlists that don't belong to folders
+    let mut playlist_folders: Vec<Playlist> = Vec::new();
+    for playlist in playlists {
+        if !playlist_ids.contains(playlist.id.id()) {
+            let mut p = playlist.clone();
+            p.is_folder = false;
+            p.level = (0, 0);
+            playlist_folders.push(p);
+        }
+    }
+    // 3. Add the rest
+    let by_ids: HashMap<String, Playlist> = playlists
+        .clone()
+        .into_iter()
+        .map(|p| (p.id.id().to_string(), p))
+        .collect();
+    add_playlist_folders(&nodes, &by_ids, &mut 0, &mut playlist_folders);
+    playlist_folders
+}
+
+fn get_playlist_ids_from_nodes(nodes: &Vec<PlaylistFolderNode>, acc: &mut HashSet<String>) {
+    for f in nodes {
+        if f.node_type == "folder" {
+            get_playlist_ids_from_nodes(&f.children, acc);
+        } else {
+            acc.insert(f.uri.replace("spotify:playlist:", ""));
+        }
+    }
+}
+
+fn add_playlist_folders(
+    nodes: &Vec<PlaylistFolderNode>,
+    by_ids: &HashMap<String, Playlist>,
+    folder_level: &mut i32,
+    acc: &mut Vec<Playlist>,
+) {
+    let level = *folder_level;
+    for f in nodes {
+        if let Some((_, id)) = f.uri.rsplit_once(':') {
+            if f.node_type == "folder" {
+                *folder_level += 1;
+                // Folder node
+                acc.push(Playlist {
+                    id: PlaylistId::from_id("f".to_string() + id)
+                        .unwrap()
+                        .into_static(),
+                    collaborative: false,
+                    name: f.name.clone().unwrap_or_default(),
+                    owner: ("".to_string(), UserId::from_id(id).unwrap().into_static()),
+                    desc: "".to_string(),
+                    is_folder: true,
+                    level: (level, *folder_level),
+                });
+                // Up node
+                acc.push(Playlist {
+                    id: PlaylistId::from_id("u".to_string() + id)
+                        .unwrap()
+                        .into_static(),
+                    collaborative: false,
+                    name: "← ".to_string() + f.name.clone().unwrap_or_default().as_str(),
+                    owner: ("".to_string(), UserId::from_id(id).unwrap().into_static()),
+                    desc: "".to_string(),
+                    is_folder: true,
+                    level: (*folder_level, level),
+                });
+                add_playlist_folders(&f.children, by_ids, folder_level, acc);
+            } else if let Some(playlist) = by_ids.get(id) {
+                let mut p = playlist.clone();
+                p.is_folder = false;
+                p.level = (level, level);
+                acc.push(p);
+            }
+        }
+    }
+}

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -133,9 +133,17 @@ impl UserData {
             Some(ref u) => self
                 .playlists
                 .iter()
-                .filter(|p| p.owner.1 == u.id || p.collaborative)
+                .filter(|p| p.is_folder || p.owner.1 == u.id || p.collaborative)
                 .collect(),
         }
+    }
+
+    /// Get a list of playlists for the given folder level
+    pub fn folder_playlists(&self, level: i32) -> Vec<&Playlist> {
+        self.playlists
+            .iter()
+            .filter(|p| p.level.0 == level)
+            .collect()
     }
 
     /// Check if a track is a liked track

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -11,6 +11,7 @@ pub type DataReadGuard<'a> = parking_lot::RwLockReadGuard<'a, AppData>;
 #[derive(Debug)]
 pub enum FileCacheKey {
     Playlists,
+    PlaylistFolders,
     FollowedArtists,
     SavedAlbums,
     SavedTracks,
@@ -32,6 +33,7 @@ pub struct AppData {
 pub struct UserData {
     pub user: Option<rspotify_model::PrivateUser>,
     pub playlists: Vec<Playlist>,
+    pub playlist_folder_nodes: Vec<PlaylistFolderNode>,
     pub followed_artists: Vec<Artist>,
     pub saved_albums: Vec<Album>,
     pub saved_tracks: HashMap<String, Track>,
@@ -107,6 +109,11 @@ impl UserData {
             user: None,
             playlists: load_data_from_file_cache(FileCacheKey::Playlists, cache_folder)
                 .unwrap_or_default(),
+            playlist_folder_nodes: load_data_from_file_cache(
+                FileCacheKey::PlaylistFolders,
+                cache_folder,
+            )
+            .unwrap_or_default(),
             followed_artists: load_data_from_file_cache(
                 FileCacheKey::FollowedArtists,
                 cache_folder,

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -32,7 +32,7 @@ pub struct AppData {
 /// current user's data
 pub struct UserData {
     pub user: Option<rspotify_model::PrivateUser>,
-    pub playlists: Vec<Playlist>,
+    pub playlists: Vec<PlaylistFolderItem>,
     pub playlist_folder_node: Option<PlaylistFolderNode>,
     pub followed_artists: Vec<Artist>,
     pub saved_albums: Vec<Album>,
@@ -126,22 +126,28 @@ impl UserData {
     }
 
     /// Get a list of playlists that are **possibly** modifiable by user
-    pub fn modifiable_playlists(&self) -> Vec<&Playlist> {
+    pub fn modifiable_playlists(&self) -> Vec<&PlaylistFolderItem> {
         match self.user {
             None => vec![],
             Some(ref u) => self
                 .playlists
                 .iter()
-                .filter(|p| p.is_folder || p.owner.1 == u.id || p.collaborative)
+                .filter(|item| match item {
+                    PlaylistFolderItem::Playlist(p) => p.owner.1 == u.id || p.collaborative,
+                    PlaylistFolderItem::Folder(_) => true,
+                })
                 .collect(),
         }
     }
 
-    /// Get a list of playlists for the given folder level
-    pub fn folder_playlists(&self, level: usize) -> Vec<&Playlist> {
+    /// Get playlists items for the given folder id
+    pub fn folder_playlists_items(&self, folder_id: usize) -> Vec<&PlaylistFolderItem> {
         self.playlists
             .iter()
-            .filter(|p| p.level.0 == level)
+            .filter(|item| match item {
+                PlaylistFolderItem::Playlist(p) => p.current_id == folder_id,
+                PlaylistFolderItem::Folder(f) => f.current_id == folder_id,
+            })
             .collect()
     }
 

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -33,7 +33,7 @@ pub struct AppData {
 pub struct UserData {
     pub user: Option<rspotify_model::PrivateUser>,
     pub playlists: Vec<Playlist>,
-    pub playlist_folder_nodes: Vec<PlaylistFolderNode>,
+    pub playlist_folder_node: Option<PlaylistFolderNode>,
     pub followed_artists: Vec<Artist>,
     pub saved_albums: Vec<Album>,
     pub saved_tracks: HashMap<String, Track>,
@@ -109,11 +109,10 @@ impl UserData {
             user: None,
             playlists: load_data_from_file_cache(FileCacheKey::Playlists, cache_folder)
                 .unwrap_or_default(),
-            playlist_folder_nodes: load_data_from_file_cache(
+            playlist_folder_node: load_data_from_file_cache(
                 FileCacheKey::PlaylistFolders,
                 cache_folder,
-            )
-            .unwrap_or_default(),
+            ),
             followed_artists: load_data_from_file_cache(
                 FileCacheKey::FollowedArtists,
                 cache_folder,
@@ -139,7 +138,7 @@ impl UserData {
     }
 
     /// Get a list of playlists for the given folder level
-    pub fn folder_playlists(&self, level: i32) -> Vec<&Playlist> {
+    pub fn folder_playlists(&self, level: usize) -> Vec<&Playlist> {
         self.playlists
             .iter()
             .filter(|p| p.level.0 == level)

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -64,7 +64,7 @@ pub struct SearchResults {
     pub tracks: Vec<Track>,
     pub artists: Vec<Artist>,
     pub albums: Vec<Album>,
-    pub playlists: Vec<PlaylistFolderItem>,
+    pub playlists: Vec<Playlist>,
 }
 
 #[derive(Debug)]
@@ -155,16 +155,19 @@ pub struct Playlist {
     pub name: String,
     pub owner: (String, UserId<'static>),
     pub desc: String,
+    /// which folder id the playlist refers to
     #[serde(default)]
-    pub current_id: usize, // which folder id the playlist refers to
+    pub current_folder_id: usize,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A playlist folder, not related to Spotify API yet
 pub struct PlaylistFolder {
     pub name: String,
-    pub current_id: usize, // current folder id in the folders tree
-    pub target_id: usize,  // target folder id it refers to
+    /// current folder id in the folders tree
+    pub current_id: usize,
+    /// target folder id it refers to
+    pub target_id: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -446,7 +449,7 @@ impl From<rspotify_model::SimplifiedPlaylist> for Playlist {
                 playlist.owner.id,
             ),
             desc: String::new(),
-            current_id: 0,
+            current_folder_id: 0,
         }
     }
 }
@@ -467,7 +470,7 @@ impl From<rspotify_model::FullPlaylist> for Playlist {
                 playlist.owner.id,
             ),
             desc,
-            current_id: 0,
+            current_folder_id: 0,
         }
     }
 }

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -155,7 +155,23 @@ pub struct Playlist {
     pub name: String,
     pub owner: (String, UserId<'static>),
     pub desc: String,
+    #[serde(default)]
+    pub is_folder: bool,
+    #[serde(default)]
+    pub level: (i32, i32), // current + target
 }
+
+#[derive(Deserialize, Debug, Clone)]
+/// A node to help building a playlist folder hierarchy
+pub struct PlaylistFolderNode {
+    pub name: Option<String>,
+    #[serde(rename = "type")]
+    pub node_type: String,
+    pub uri: String,
+    #[serde(default = "Vec::new")]
+    pub children: Vec<PlaylistFolderNode>,
+}
+
 
 #[derive(Clone, Debug)]
 /// A Spotify category
@@ -416,6 +432,8 @@ impl From<rspotify_model::SimplifiedPlaylist> for Playlist {
                 playlist.owner.id,
             ),
             desc: String::new(),
+            is_folder: false,
+            level: (0, 0),
         }
     }
 }
@@ -436,13 +454,19 @@ impl From<rspotify_model::FullPlaylist> for Playlist {
                 playlist.owner.id,
             ),
             desc,
+            is_folder: false,
+            level: (0, 0),
         }
     }
 }
 
 impl std::fmt::Display for Playlist {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} • {}", self.name, self.owner.0)
+        if self.is_folder {
+            write!(f, "{}/", self.name)
+        } else {
+            write!(f, "{} • {}", self.name, self.owner.0)
+        }
     }
 }
 

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -158,15 +158,17 @@ pub struct Playlist {
     #[serde(default)]
     pub is_folder: bool,
     #[serde(default)]
-    pub level: (i32, i32), // current + target
+    pub level: (usize, usize), // current, target
 }
 
 #[derive(Deserialize, Debug, Clone)]
-/// A node to help building a playlist folder hierarchy
+/// A reference node retrieved by running https://github.com/mikez/spotify-folders
+/// Helps building a playlist folder hierarchy
 pub struct PlaylistFolderNode {
     pub name: Option<String>,
     #[serde(rename = "type")]
     pub node_type: String,
+    #[serde(default)]
     pub uri: String,
     #[serde(default = "Vec::new")]
     pub children: Vec<PlaylistFolderNode>,

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -172,7 +172,6 @@ pub struct PlaylistFolderNode {
     pub children: Vec<PlaylistFolderNode>,
 }
 
-
 #[derive(Clone, Debug)]
 /// A Spotify category
 pub struct Category {

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -51,6 +51,7 @@ pub struct LibraryPageUIState {
     pub saved_album_list: ListState,
     pub followed_artist_list: ListState,
     pub focus: LibraryFocusState,
+    pub playlist_folder_id: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -89,7 +90,7 @@ pub enum ContextPageUIState {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LibraryFocusState {
-    Playlists(usize), // Playlists in the folder local id
+    Playlists,
     SavedAlbums,
     FollowedArtists,
 }
@@ -165,9 +166,10 @@ impl PageState {
                         saved_album_list,
                         followed_artist_list,
                         focus,
+                        ..
                     },
             } => Some(match focus {
-                LibraryFocusState::Playlists(_) => MutableWindowState::List(playlist_list),
+                LibraryFocusState::Playlists { .. } => MutableWindowState::List(playlist_list),
                 LibraryFocusState::SavedAlbums => MutableWindowState::List(saved_album_list),
                 LibraryFocusState::FollowedArtists => {
                     MutableWindowState::List(followed_artist_list)
@@ -232,7 +234,8 @@ impl LibraryPageUIState {
             playlist_list: ListState::default(),
             saved_album_list: ListState::default(),
             followed_artist_list: ListState::default(),
-            focus: LibraryFocusState::Playlists(0),
+            focus: LibraryFocusState::Playlists,
+            playlist_folder_id: 0,
         }
     }
 }
@@ -387,23 +390,12 @@ macro_rules! impl_focusable {
 	};
 }
 
-impl Focusable for LibraryFocusState {
-    fn next(&mut self) {
-        *self = match self {
-            Self::Playlists(_) => Self::SavedAlbums,
-            Self::SavedAlbums => Self::FollowedArtists,
-            Self::FollowedArtists => Self::Playlists(0),
-        }
-    }
-
-    fn previous(&mut self) {
-        *self = match self {
-            Self::SavedAlbums => Self::Playlists(0),
-            Self::FollowedArtists => Self::SavedAlbums,
-            Self::Playlists(_) => Self::FollowedArtists,
-        }
-    }
-}
+impl_focusable!(
+    LibraryFocusState,
+    [Playlists, SavedAlbums],
+    [SavedAlbums, FollowedArtists],
+    [FollowedArtists, Playlists]
+);
 
 impl_focusable!(
     ArtistFocusState,

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -89,7 +89,7 @@ pub enum ContextPageUIState {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LibraryFocusState {
-    Playlists(usize), // Playlists in the folder level
+    Playlists(usize), // Playlists in the folder local id
     SavedAlbums,
     FollowedArtists,
 }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -89,7 +89,7 @@ pub enum ContextPageUIState {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LibraryFocusState {
-    Playlists,
+    Playlists(i32),
     SavedAlbums,
     FollowedArtists,
 }
@@ -167,7 +167,7 @@ impl PageState {
                         focus,
                     },
             } => Some(match focus {
-                LibraryFocusState::Playlists => MutableWindowState::List(playlist_list),
+                LibraryFocusState::Playlists(_) => MutableWindowState::List(playlist_list),
                 LibraryFocusState::SavedAlbums => MutableWindowState::List(saved_album_list),
                 LibraryFocusState::FollowedArtists => {
                     MutableWindowState::List(followed_artist_list)
@@ -232,7 +232,7 @@ impl LibraryPageUIState {
             playlist_list: ListState::default(),
             saved_album_list: ListState::default(),
             followed_artist_list: ListState::default(),
-            focus: LibraryFocusState::Playlists,
+            focus: LibraryFocusState::Playlists(0),
         }
     }
 }
@@ -387,12 +387,23 @@ macro_rules! impl_focusable {
 	};
 }
 
-impl_focusable!(
-    LibraryFocusState,
-    [Playlists, SavedAlbums],
-    [SavedAlbums, FollowedArtists],
-    [FollowedArtists, Playlists]
-);
+impl Focusable for LibraryFocusState {
+    fn next(&mut self) {
+        *self = match self {
+            Self::Playlists(_) => Self::SavedAlbums,
+            Self::SavedAlbums => Self::FollowedArtists,
+            Self::FollowedArtists => Self::Playlists(0),
+        }
+    }
+
+    fn previous(&mut self) {
+        *self = match self {
+            Self::SavedAlbums => Self::Playlists(0),
+            Self::FollowedArtists => Self::SavedAlbums,
+            Self::Playlists(_) => Self::FollowedArtists,
+        }
+    }
+}
 
 impl_focusable!(
     ArtistFocusState,

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -89,7 +89,7 @@ pub enum ContextPageUIState {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LibraryFocusState {
-    Playlists(i32),
+    Playlists(usize), // Playlists in the folder level
     SavedAlbums,
     FollowedArtists,
 }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -169,7 +169,7 @@ impl PageState {
                         ..
                     },
             } => Some(match focus {
-                LibraryFocusState::Playlists { .. } => MutableWindowState::List(playlist_list),
+                LibraryFocusState::Playlists => MutableWindowState::List(playlist_list),
                 LibraryFocusState::SavedAlbums => MutableWindowState::List(saved_album_list),
                 LibraryFocusState::FollowedArtists => {
                     MutableWindowState::List(followed_artist_list)

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -37,8 +37,8 @@ pub enum ActionListItem {
 /// An action on an item in a playlist popup list
 #[derive(Debug)]
 pub enum PlaylistPopupAction {
-    Browse,
-    AddTrack(TrackId<'static>),
+    Browse(i32),
+    AddTrack(i32, TrackId<'static>),
 }
 
 /// An action on an item in an artist popup list

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -37,8 +37,8 @@ pub enum ActionListItem {
 /// An action on an item in a playlist popup list
 #[derive(Debug)]
 pub enum PlaylistPopupAction {
-    Browse(i32),
-    AddTrack(i32, TrackId<'static>),
+    Browse(usize), // Browse playlists by folder level
+    AddTrack(usize, TrackId<'static>),
 }
 
 /// An action on an item in an artist popup list

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -31,14 +31,19 @@ pub enum ActionListItem {
     Track(Track, Vec<command::Action>),
     Artist(Artist, Vec<command::Action>),
     Album(Album, Vec<command::Action>),
-    Playlist(PlaylistFolderItem, Vec<command::Action>),
+    Playlist(Playlist, Vec<command::Action>),
 }
 
 /// An action on an item in a playlist popup list
 #[derive(Debug)]
 pub enum PlaylistPopupAction {
-    Browse(usize), // Browse playlists by folder local id
-    AddTrack(usize, TrackId<'static>),
+    Browse {
+        folder_id: usize,
+    },
+    AddTrack {
+        folder_id: usize,
+        track_id: TrackId<'static>,
+    },
 }
 
 /// An action on an item in an artist popup list
@@ -109,10 +114,7 @@ impl ActionListItem {
             ActionListItem::Track(track, ..) => &track.name,
             ActionListItem::Artist(artist, ..) => &artist.name,
             ActionListItem::Album(album, ..) => &album.name,
-            ActionListItem::Playlist(item, ..) => match item {
-                PlaylistFolderItem::Playlist(p) => &p.name,
-                PlaylistFolderItem::Folder(f) => &f.name,
-            },
+            ActionListItem::Playlist(playlist, ..) => &playlist.name,
         }
     }
 

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -31,13 +31,13 @@ pub enum ActionListItem {
     Track(Track, Vec<command::Action>),
     Artist(Artist, Vec<command::Action>),
     Album(Album, Vec<command::Action>),
-    Playlist(Playlist, Vec<command::Action>),
+    Playlist(PlaylistFolderItem, Vec<command::Action>),
 }
 
 /// An action on an item in a playlist popup list
 #[derive(Debug)]
 pub enum PlaylistPopupAction {
-    Browse(usize), // Browse playlists by folder level
+    Browse(usize), // Browse playlists by folder local id
     AddTrack(usize, TrackId<'static>),
 }
 
@@ -109,7 +109,10 @@ impl ActionListItem {
             ActionListItem::Track(track, ..) => &track.name,
             ActionListItem::Artist(artist, ..) => &artist.name,
             ActionListItem::Album(album, ..) => &album.name,
-            ActionListItem::Playlist(playlist, ..) => &playlist.name,
+            ActionListItem::Playlist(item, ..) => match item {
+                PlaylistFolderItem::Playlist(p) => &p.name,
+                PlaylistFolderItem::Folder(f) => &f.name,
+            },
         }
     }
 

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -362,9 +362,8 @@ pub fn render_library_page(
         _ => 0,
     };
     let items = ui
-        .search_filtered_items(&data.user_data.playlists)
+        .search_filtered_items(&data.user_data.folder_playlists(playlist_level))
         .into_iter()
-        .filter(|p| p.level.0 == playlist_level)
         .map(|p| (p.to_string(), curr_context_uri == Some(p.id.uri())))
         .collect::<Vec<_>>();
 

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -357,14 +357,19 @@ pub fn render_library_page(
 
     // 3. Construct the page's widgets
     // Construct the playlist window
-    let playlist_level = match focus_state {
-        LibraryFocusState::Playlists(level) => level,
+    let playlist_folder_id = match focus_state {
+        LibraryFocusState::Playlists(folder_id) => folder_id,
         _ => 0,
     };
     let items = ui
-        .search_filtered_items(&data.user_data.folder_playlists(playlist_level))
+        .search_filtered_items(&data.user_data.folder_playlists_items(playlist_folder_id))
         .into_iter()
-        .map(|p| (p.to_string(), curr_context_uri == Some(p.id.uri())))
+        .map(|item| match item {
+            PlaylistFolderItem::Playlist(p) => {
+                (p.to_string(), curr_context_uri == Some(p.id.uri()))
+            }
+            PlaylistFolderItem::Folder(f) => (f.to_string(), false),
+        })
         .collect::<Vec<_>>();
 
     let (playlist_list, n_playlists) = utils::construct_list_widget(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -357,13 +357,23 @@ pub fn render_library_page(
 
     // 3. Construct the page's widgets
     // Construct the playlist window
+    let playlist_level = match focus_state {
+        LibraryFocusState::Playlists(level) => level,
+        _ => 0,
+    };
+    let items = ui
+        .search_filtered_items(&data.user_data.playlists)
+        .into_iter()
+        .filter(|p| p.level.0 == playlist_level)
+        .map(|p| (p.to_string(), curr_context_uri == Some(p.id.uri())))
+        .collect::<Vec<_>>();
+
     let (playlist_list, n_playlists) = utils::construct_list_widget(
         &ui.theme,
-        ui.search_filtered_items(&data.user_data.playlists)
-            .into_iter()
-            .map(|p| (p.to_string(), curr_context_uri == Some(p.id.uri())))
-            .collect(),
-        is_active && focus_state == LibraryFocusState::Playlists,
+        items,
+        is_active
+            && focus_state != LibraryFocusState::SavedAlbums
+            && focus_state != LibraryFocusState::FollowedArtists,
     );
     // Construct the saved album window
     let (album_list, n_albums) = utils::construct_list_widget(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -317,8 +317,8 @@ pub fn render_library_page(
     let data = state.data.read();
     let configs = config::get_config();
 
-    let focus_state = match ui.current_page() {
-        PageState::Library { state } => state.focus,
+    let (focus_state, playlist_folder_id) = match ui.current_page() {
+        PageState::Library { state } => (state.focus, state.playlist_folder_id),
         _ => return,
     };
 
@@ -357,10 +357,6 @@ pub fn render_library_page(
 
     // 3. Construct the page's widgets
     // Construct the playlist window
-    let playlist_folder_id = match focus_state {
-        LibraryFocusState::Playlists(folder_id) => folder_id,
-        _ => 0,
-    };
     let items = ui
         .search_filtered_items(&data.user_data.folder_playlists_items(playlist_folder_id))
         .into_iter()

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -106,18 +106,12 @@ pub fn render_popup(
             PopupState::UserPlaylistList(action, _) => {
                 let data = state.data.read();
                 let playlists: Vec<&PlaylistFolderItem> = match action {
-                    PlaylistPopupAction::Browse(folder_id) => {
+                    PlaylistPopupAction::Browse { folder_id } => {
                         data.user_data.folder_playlists_items(*folder_id)
                     }
-                    PlaylistPopupAction::AddTrack(folder_id, _) => data
-                        .user_data
-                        .modifiable_playlists()
-                        .into_iter()
-                        .filter(|item| match item {
-                            PlaylistFolderItem::Folder(f) => f.current_id == *folder_id,
-                            PlaylistFolderItem::Playlist(p) => p.current_id == *folder_id,
-                        })
-                        .collect(),
+                    PlaylistPopupAction::AddTrack { folder_id, .. } => {
+                        data.user_data.modifiable_playlist_items(Some(*folder_id))
+                    }
                 };
                 let items = playlists
                     .into_iter()

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -105,7 +105,7 @@ pub fn render_popup(
             }
             PopupState::UserPlaylistList(action, _) => {
                 let data = state.data.read();
-                let playlists: Vec<&PlaylistFolderItem> = match action {
+                let items = match action {
                     PlaylistPopupAction::Browse { folder_id } => {
                         data.user_data.folder_playlists_items(*folder_id)
                     }
@@ -113,10 +113,7 @@ pub fn render_popup(
                         data.user_data.modifiable_playlist_items(Some(*folder_id))
                     }
                 };
-                let items = playlists
-                    .into_iter()
-                    .map(|p| (p.to_string(), false))
-                    .collect();
+                let items = items.into_iter().map(|p| (p.to_string(), false)).collect();
 
                 let rect = render_list_popup(frame, rect, "User Playlists", items, 10, ui);
                 (rect, false)

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -105,13 +105,18 @@ pub fn render_popup(
             }
             PopupState::UserPlaylistList(action, _) => {
                 let data = state.data.read();
-                let playlists: Vec<&Playlist> = match action {
-                    PlaylistPopupAction::Browse(level) => data.user_data.folder_playlists(*level),
-                    PlaylistPopupAction::AddTrack(level, _) => data
+                let playlists: Vec<&PlaylistFolderItem> = match action {
+                    PlaylistPopupAction::Browse(folder_id) => {
+                        data.user_data.folder_playlists_items(*folder_id)
+                    }
+                    PlaylistPopupAction::AddTrack(folder_id, _) => data
                         .user_data
                         .modifiable_playlists()
                         .into_iter()
-                        .filter(|p| p.level.0 == *level)
+                        .filter(|item| match item {
+                            PlaylistFolderItem::Folder(f) => f.current_id == *folder_id,
+                            PlaylistFolderItem::Playlist(p) => p.current_id == *folder_id,
+                        })
                         .collect(),
                 };
                 let items = playlists

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -105,9 +105,14 @@ pub fn render_popup(
             }
             PopupState::UserPlaylistList(action, _) => {
                 let data = state.data.read();
-                let playlists = match action {
-                    PlaylistPopupAction::Browse => data.user_data.playlists.iter().collect(),
-                    PlaylistPopupAction::AddTrack(_) => data.user_data.modifiable_playlists(),
+                let playlists: Vec<&Playlist> = match action {
+                    PlaylistPopupAction::Browse(level) => data.user_data.folder_playlists(*level),
+                    PlaylistPopupAction::AddTrack(level, _) => data
+                        .user_data
+                        .modifiable_playlists()
+                        .into_iter()
+                        .filter(|p| p.level.0 == *level)
+                        .collect(),
                 };
                 let items = playlists
                     .into_iter()


### PR DESCRIPTION
Resolves #453

> [!NOTE]  
> Spotify doesn't have an API to retrieve or modify playlist folders. In order to retrieve a folder structure a third party utility is required [mikez/spotify-folders](https://github.com/mikez/spotify-folders). Using this utility you need to create a compatible json file and put it in `~/.cache/spotify-player/PlaylistFolders_cache.json`. You'll need to update this file every time you change your folder structure.

## Demo
https://github.com/user-attachments/assets/7cbf8029-f9a8-43f7-b2c8-37b169bab459

## Configuration

Follow the [mikez/spotify-folders](https://github.com/mikez/spotify-folders) installation instructions. Then run

```bash
spotifyfolders > ~/.cache/spotify-player/PlaylistFolders_cache.json
```

It generates a full playlist folders structure and stores to a json file, like this:

```json
{
  "type": "folder",
  "children": [
    {
      "type": "playlist",
      "uri": "spotify:playlist:00000000000000000000"
    },
    {
      "name": "Folder name",
      "type": "folder",
      "uri": "spotify:user:aaaaaaaaaaa:folder:bbbbbbbbb",
      "children": [
        {
          "type": "playlist",
          "uri": "spotify:playlist:111111111111111111111"
        },
        {
          "type": "playlist",
          "uri": "spotify:playlist:222222222222222222222"
        }
      ]
    }
  ]
}
```