### PR TITLE
Does not return removed commands

### DIFF
--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -397,6 +397,7 @@ impl KeymapConfig {
         self.keymaps
             .iter()
             .find(|&keymap| keymap.key_sequence == *key_sequence)
+            .filter(|keymap| keymap.command != Command::None)
             .map(|keymap| keymap.command)
     }
 

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -396,8 +396,7 @@ impl KeymapConfig {
     pub fn find_command_from_key_sequence(&self, key_sequence: &KeySequence) -> Option<Command> {
         self.keymaps
             .iter()
-            .find(|&keymap| keymap.key_sequence == *key_sequence)
-            .filter(|keymap| keymap.command != Command::None)
+            .find(|&keymap| keymap.key_sequence == *key_sequence && keymap.command != Command::None)
             .map(|keymap| keymap.command)
     }
 


### PR DESCRIPTION
Commands set to None to remove the keybinding, where immediately returned by **find_command_or_action_from_key_sequence** on l.418.
Instead of looking for action keybinding.

Fix #523