### PR TITLE
fix #454 overflowing of song title

### DIFF
--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -102,7 +102,7 @@ pub fn render_playback_window(
 
             if let Some(ref playback) = player.buffered_playback {
                 let playback_text = construct_playback_text(ui, track, playback);
-                let playback_desc = Paragraph::new(playback_text).wrap(Wrap { trim: false });
+                let playback_desc = Paragraph::new(playback_text);
                 frame.render_widget(playback_desc, metadata_rect);
             }
 


### PR DESCRIPTION
~This PR needs to be merged after #482~ resolved

Fix #454 by splitting the metadata text and the "title" text into two
different rects. This means that the title text being cut off to long
won't cause the metadata text to overflow outside the viewport.

This does however mean that the `playback_format` config option should
no longer contain the `{metadata}` placeholder.
