### PR TITLE
feat: client_id_cmd config option

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ All configuration files should be placed inside the application's configuration 
 | Option                            | Description                                                                              | Default                                                 |
 | --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                      |
+| `client_id_cmd`                   | a shell command that prints the Spotify client ID to stdout (overrides `client_id`)      | `None`                                                  |
 | `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                  |
 | `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                    |
 | `playback_format`                 | the format of the text in the playback's window                                          | `{status} {track} • {artists}\n{album}\n{metadata}`     | 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,7 +25,7 @@ All configuration files should be placed inside the application's configuration 
 | Option                            | Description                                                                              | Default                                                 |
 | --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                      |
-| `client_id_cmd`                   | a shell command that prints the Spotify client ID to stdout (overrides `client_id`)      | `None`                                                  |
+| `client_id_command`                   | a shell command that prints the Spotify client ID to stdout (overrides `client_id`)      | `None`                                                  |
 | `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                  |
 | `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                    |
 | `playback_format`                 | the format of the text in the playback's window                                          | `{status} {track} • {artists}\n{album}\n{metadata}`     | 

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -158,8 +158,8 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Resul
             let session = rt.block_on(new_session(&auth_config, false))?;
 
             // create a Spotify API client
-            let client =
-                client::Client::new(session, auth_config, configs.app_config.client_id.clone());
+            let client_id = configs.app_config.get_client_id()?;
+            let client = client::Client::new(session, auth_config, client_id);
             rt.block_on(client.refresh_token())?;
 
             // create a client socket for handling CLI commands

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -143,15 +143,15 @@ pub struct Command {
 }
 
 impl Command {
+     /// Execute a command, returning stdout if succeeded or stderr if failed
     pub fn execute(&self, extra_args: Option<Vec<String>>) -> anyhow::Result<String> {
         let mut args = self.args.clone();
-        extra_args.map_or_else(|| {}, |extra| args.extend(extra));
+        args.extend(extra.unwrap_or_default());
 
         let output = std::process::Command::new(&self.command)
             .args(&args)
             .output()?;
 
-        // running the command failed, report the command's stderr as an error
         if !output.status.success() {
             let stderr = std::str::from_utf8(&output.stderr)?.to_string();
             anyhow::bail!(stderr);
@@ -411,8 +411,8 @@ impl AppConfig {
 
     /// Returns stdout of `client_id_command` if set, otherwise it returns the the value of `client_id`
     pub fn get_client_id(&self) -> Result<String> {
-        match self.client_id_command.clone() {
-            Some(cmd) => cmd.execute(None),
+        match self.client_id_command {
+            Some(ref cmd) => cmd.execute(None),
             None => Ok(self.client_id.clone()),
         }
     }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -143,10 +143,10 @@ pub struct Command {
 }
 
 impl Command {
-     /// Execute a command, returning stdout if succeeded or stderr if failed
+    /// Execute a command, returning stdout if succeeded or stderr if failed
     pub fn execute(&self, extra_args: Option<Vec<String>>) -> anyhow::Result<String> {
         let mut args = self.args.clone();
-        args.extend(extra.unwrap_or_default());
+        args.extend(extra_args.unwrap_or_default());
 
         let output = std::process::Command::new(&self.command)
             .args(&args)

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -117,7 +117,8 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     let session = auth::new_session(&auth_config, !state.is_daemon).await?;
 
     // create a Spotify API client
-    let client = client::Client::new(session, auth_config, configs.app_config.client_id.clone());
+    let client_id = configs.app_config.get_client_id()?;
+    let client = client::Client::new(session, auth_config, client_id);
     client.refresh_token().await?;
 
     // initialize Spotify-related stuff

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -143,8 +143,7 @@ fn execute_player_event_hook_command(
     cmd: &config::Command,
     event: PlayerEvent,
 ) -> anyhow::Result<()> {
-    let args = Some(event.args());
-    cmd.execute(args)?;
+    cmd.execute(Some(event.args()))?;
 
     Ok(())
 }

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -143,18 +143,8 @@ fn execute_player_event_hook_command(
     cmd: &config::Command,
     event: PlayerEvent,
 ) -> anyhow::Result<()> {
-    let mut args = cmd.args.clone();
-    args.extend(event.args());
-
-    let output = std::process::Command::new(&cmd.command)
-        .args(&args)
-        .output()?;
-
-    // running the player hook command failed, report the command's stderr as an error
-    if !output.status.success() {
-        let stderr = std::str::from_utf8(&output.stderr)?.to_string();
-        anyhow::bail!(stderr);
-    }
+    let args = Some(event.args());
+    cmd.execute(args)?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR fixes #537 by adding a new config option `client_id_cmd`. When set, it will run this command and use its stdout as the client_id. I haven't been able to verify it's working on Windows, but that part has been copied from the rust docs so it should be fine.