### PR TITLE
fix copy command blocking

### DIFF
--- a/spotify_player/src/event/clipboard.rs
+++ b/spotify_player/src/event/clipboard.rs
@@ -34,8 +34,8 @@ impl ClipboardProvider for CommandProvider {
         let mut child = std::process::Command::new(&self.copy_command.command)
             .args(&self.copy_command.args)
             .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .spawn()?;
 
         if let Some(mut stdin) = child.stdin.take() {
@@ -46,7 +46,7 @@ impl ClipboardProvider for CommandProvider {
         if output.status.success() {
             Ok(())
         } else {
-            anyhow::bail!("copy command failed: {}", String::from_utf8(output.stderr)?);
+            anyhow::bail!("copy command failed");
         }
     }
 }


### PR DESCRIPTION
Fixes #538. It turns out that `child.wait_with_output()` blocks for a long time when either stdin or stderr is piped. I’ve tried multiple workarounds, but they all yield the same result.

This fix resolves the blocking issue, though we won't be able to read any output, making error messages completely useless.

Interestingly, when there is actually an error (e.g., passing invalid arguments), it doesn’t block and correctly reads from stderr.
I can share a small reproduction of this issue if that would be helpful.