### PR TITLE
Improved Lyric_finder to retrieve correct lyrics instead of its translation

### DIFF
--- a/lyric_finder/src/lib.rs
+++ b/lyric_finder/src/lib.rs
@@ -113,20 +113,21 @@ impl Client {
     pub async fn get_lyric(&self, query: &str) -> anyhow::Result<LyricResult> {
         // Perform the search for songs
         let results = self.search_songs(query).await?;
-    
+
         // Filter to find the first result where the artist names do not contain 'Genius'
-        let result = results.into_iter()
+        let result = results
+            .into_iter()
             .find(|result| !result.artist_names.contains("Genius"));
-    
+
         // If no valid result is found, return LyricResult::None
         let result = match result {
             Some(res) => res,
             None => return Ok(LyricResult::None),
         };
-    
+
         // Retrieve the song lyrics from the URL of the result
         let lyric = self.retrieve_lyric(&result.url).await?;
-    
+
         // Return a LyricResult::Some with the song information
         Ok(LyricResult::Some {
             track: result.title,
@@ -134,7 +135,6 @@ impl Client {
             lyric: Self::process_lyric(lyric),
         })
     }
-    
 }
 
 impl Default for Client {


### PR DESCRIPTION
Hi, 
I noticed that for some lyrics, one of its translation is shown instead of the actual lyric, and this because for some obscure reason Genius responses by putting these translations at the top of the results. You can reproduce this behavior by playing the song "Kingslayer" by "Bring Me The Horizon".
Fortunately, all the results results (at least the bunch of those I checked manually to implement this fix) have "Genius < language > <_translation_ written in that language>" as `artist_name` so a `find()` is used to exclude the results with keyword `Genius` in that field.
The rest of the code hasn't changed, so the first result is chosen.
