### PR TITLE
Update README.md to include a hint for WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,7 @@ Run `scoop install spotify-player` to install the application.
 
 ### Cargo
 
-Run `cargo install spotify_player` to install the application from [crates.io](https://crates.io/crates/spotify_player).
-
-#### Notes for WSL
-
-If you encounter a compilation error in WSL try running `cargo install spotify_player` with `--locked` (see #560)
+Run `cargo install spotify_player --locked` to install the application from [crates.io](https://crates.io/crates/spotify_player).
 
 ### AUR
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Run `scoop install spotify-player` to install the application.
 
 Run `cargo install spotify_player` to install the application from [crates.io](https://crates.io/crates/spotify_player).
 
+#### Notes for WSL
+
+If you encounter a compilation error in WSL try running `cargo install spotify_player` with `--locked` (see #560)
+
 ### AUR
 
 Run `yay -S spotify-player` to install the application as an AUR package.


### PR DESCRIPTION
added a little bit of text which hints WSL users to run `cargo install spotify_player` with `--locked` so it'll work.
This should avoid further issues being created to find this solution.