### PR TITLE
Change important notice link to the valid issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 - Offer a wide range of [CLI commands](#cli-commands)
 
 ## Important Notice
-spotify-player throws error "Login failed with reason: Bad credentials" when authenticating from 7/29/2024 because Spotify removed username & password authentication from API through Mercury/Hermes. Please use [librespot-auth repository](https://github.com/dspearson/librespot-auth). For more details, see [#520](https://github.com/aome510/spotify-player/issues/520)
+spotify-player throws error "Login failed with reason: Bad credentials" when authenticating from 7/29/2024 because Spotify removed username & password authentication from API through Mercury/Hermes. Please use [librespot-auth repository](https://github.com/dspearson/librespot-auth). For more details, see [#580](https://github.com/aome510/spotify-player/issues/580)
 
 ## Examples
 


### PR DESCRIPTION
The url and issue number on the readme are outdated.
I updated them to link to the pinned issue explaining how to do the workaround.