### PR TITLE
handling `client_id` scoping for Spotify Connect feature with `librespot 0.5.0`

### DIFF
--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -5,8 +5,10 @@ use librespot_oauth::get_access_token;
 use crate::config;
 
 pub const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
-pub const CLIENT_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
-pub const OAUTH_SCOPES: &[&str] = &[
+const CLIENT_REDIRECT_URI: &str = "http://127.0.0.1:8989/login";
+// based on https://github.com/librespot-org/librespot/blob/f96f36c064795011f9fee912291eecb1aa46fff6/src/main.rs#L173
+const OAUTH_SCOPES: &[&str] = &[
+    "app-remote-control",
     "playlist-modify",
     "playlist-modify-private",
     "playlist-modify-public",
@@ -14,6 +16,7 @@ pub const OAUTH_SCOPES: &[&str] = &[
     "playlist-read-collaborative",
     "playlist-read-private",
     "streaming",
+    "ugc-image-upload",
     "user-follow-modify",
     "user-follow-read",
     "user-library-modify",
@@ -22,6 +25,7 @@ pub const OAUTH_SCOPES: &[&str] = &[
     "user-modify-playback-state",
     "user-modify-private",
     "user-personalized",
+    "user-read-birthdate",
     "user-read-currently-playing",
     "user-read-email",
     "user-read-play-history",

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -68,7 +68,7 @@ impl Client {
                 // The main playback initialization logic is simple:
                 // if there is no playback, connect to an available device
                 //
-                // However, because it takes for Spotify server to show up new changes,
+                // However, because it takes time for Spotify server to show up new changes,
                 // a retry logic is implemented to ensure the application's state is properly initialized
                 let delay = std::time::Duration::from_secs(1);
 

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -413,8 +413,6 @@ impl AppConfig {
     }
 
     /// Returns stdout of `client_id_command` if set, otherwise it returns the the value of `client_id`
-    // TODO: figure out how to use user-provided client_id for Spotify Connect integration
-    #[allow(dead_code)]
     pub fn get_client_id(&self) -> Result<String> {
         match self.client_id_command {
             Some(ref cmd) => cmd.execute(None),

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -23,10 +23,7 @@ async fn init_spotify(
     client: &client::Client,
     state: &state::SharedState,
 ) -> Result<()> {
-    client
-        .initialize_playback(state)
-        .await
-        .context("initialize playback")?;
+    client.initialize_playback(state);
 
     // request user data
     client_pub.send(client::ClientRequest::GetCurrentUser)?;

--- a/spotify_player/src/token.rs
+++ b/spotify_player/src/token.rs
@@ -3,17 +3,53 @@ use std::collections::HashSet;
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use librespot_core::session::Session;
-use rspotify::Token;
-
-use crate::auth::OAUTH_SCOPES;
 
 const TIMEOUT_IN_SECS: u64 = 5;
 
-pub async fn get_token(session: &Session) -> Result<Token> {
+/// The application authentication token's permission scopes
+const SCOPES: [&str; 15] = [
+    "user-read-recently-played",
+    "user-top-read",
+    "user-read-playback-position",
+    "user-read-playback-state",
+    "user-modify-playback-state",
+    "user-read-currently-playing",
+    "streaming",
+    "playlist-read-private",
+    "playlist-modify-private",
+    "playlist-modify-public",
+    "playlist-read-collaborative",
+    "user-follow-read",
+    "user-follow-modify",
+    "user-library-read",
+    "user-library-modify",
+];
+
+async fn retrieve_token(
+    session: &Session,
+    client_id: &str,
+) -> Result<librespot_core::token::Token> {
+    let query_uri = format!(
+        "hm://keymaster/token/authenticated?scope={}&client_id={}&device_id={}",
+        SCOPES.join(","),
+        client_id,
+        session.device_id(),
+    );
+    let request = session.mercury().get(query_uri)?;
+    let response = request.await?;
+    let data = response
+        .payload
+        .first()
+        .ok_or(librespot_core::token::TokenError::Empty)?
+        .to_vec();
+    let token = librespot_core::token::Token::from_json(String::from_utf8(data)?)?;
+    Ok(token)
+}
+
+pub async fn get_token(session: &Session, client_id: &str) -> Result<rspotify::Token> {
     tracing::info!("Getting a new authentication token...");
 
-    let scopes = OAUTH_SCOPES.join(",");
-    let fut = session.token_provider().get_token(&scopes);
+    let fut = retrieve_token(session, client_id);
     let token =
         match tokio::time::timeout(std::time::Duration::from_secs(TIMEOUT_IN_SECS), fut).await {
             Ok(Ok(token)) => token,
@@ -34,7 +70,7 @@ pub async fn get_token(session: &Session) -> Result<Token> {
     // let expires_in = Duration::from_std(std::time::Duration::from_secs(5))?;
     let expires_at = Utc::now() + expires_in;
 
-    let token = Token {
+    let token = rspotify::Token {
         access_token: token.access_token,
         expires_in,
         expires_at: Some(expires_at),


### PR DESCRIPTION
- update `token::get_token` to support user-provided `client_id` (required for Spotify Connect feature)
- refactor playback initialization logic upon startup or new session