### PR TITLE
Use 'ring' backend as default for rustls.

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -57,7 +57,7 @@ clap_complete = "4.5.35"
 which = "7.0.0"
 fuzzy-matcher = { version = "0.3.7", optional = true }
 html-escape = "0.2.13"
-rustls = "0.23.16"
+rustls = { version = "0.23.16", default-features = false, features = ["ring"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
 version = "0.30.5"

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -221,7 +221,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
 fn main() -> Result<()> {
     // librespot depends on hyper-rustls which requires a crypto provider to be set up.
     // TODO: see if this can be fixed upstream
-    rustls::crypto::aws_lc_rs::default_provider()
+    rustls::crypto::ring::default_provider()
         .install_default()
         .unwrap();
 


### PR DESCRIPTION
Resolves #596