### PR TITLE
add volume modification by mouse scrolling

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -269,6 +269,20 @@ impl Client {
                 playback.volume = Some(volume as u32);
                 playback.mute_state = None;
             }
+            PlayerRequest::VolumeUp => {
+                let volume = std::cmp::min(playback.volume.unwrap_or_default() + 5, 100_u32);
+                self.volume(volume as u8, device_id).await?;
+                
+                playback.volume = Some(volume);
+                playback.mute_state = None;
+            }
+            PlayerRequest::VolumeDown => {
+                let volume = playback.volume.unwrap_or_default().saturating_sub(5_u32);
+                self.volume(volume as u8, device_id).await?;
+
+                playback.volume = Some(volume);
+                playback.mute_state = None;
+            }
             PlayerRequest::ToggleMute => {
                 let new_mute_state = match playback.mute_state {
                     None => {

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -12,6 +12,8 @@ pub enum PlayerRequest {
     Repeat,
     Shuffle,
     Volume(u8),
+    VolumeUp,
+    VolumeDown,
     ToggleMute,
     TransferPlayback(String, bool),
     StartPlayback(Playback, Option<bool>),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -58,27 +58,52 @@ fn handle_mouse_event(
     client_pub: &flume::Sender<ClientRequest>,
     state: &SharedState,
 ) -> Result<()> {
-    // a left click event
-    if let crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) = event.kind
-    {
-        tracing::debug!("Handling mouse event: {event:?}");
-        let rect = state.ui.lock().playback_progress_bar_rect;
-        if event.row == rect.y {
-            // calculate the seek position (in ms) based on the mouse click position,
-            // the progress bar's width and the track's duration (in ms)
-            let duration = state
-                .player
-                .read()
-                .current_playing_track()
-                .map(|t| t.duration);
-            if let Some(duration) = duration {
-                let position_ms =
-                    (duration.num_milliseconds()) * (event.column as i64) / (rect.width as i64);
-                client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
-                    chrono::Duration::try_milliseconds(position_ms).unwrap(),
-                )))?;
+    match event.kind {
+        // a left click event
+        crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) =>
+        {
+            tracing::debug!("Handling mouse event: {event:?}");
+            let rect = state.ui.lock().playback_progress_bar_rect;
+            if event.row == rect.y {
+                // calculate the seek position (in ms) based on the mouse click position,
+                // the progress bar's width and the track's duration (in ms)
+                let duration = state
+                    .player
+                    .read()
+                    .current_playing_track()
+                    .map(|t| t.duration);
+                if let Some(duration) = duration {
+                    let position_ms =
+                        (duration.num_milliseconds()) * (event.column as i64) / (rect.width as i64);
+                    client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
+                        chrono::Duration::try_milliseconds(position_ms).unwrap(),
+                    )))?;
+                }
             }
         }
+        // a mouse scroll up event
+        crossterm::event::MouseEventKind::ScrollUp => {
+            // the key sequence m s u stands for MouseScrollUp,
+            let mouse_scroll_up = "m s u".into();
+            let mouse_volume_up_is_set = &config::get_config().keymap_config.find_command_or_action_from_key_sequence(&mouse_scroll_up);
+
+            // if the MouseScrollUp is set up, raise the volume
+            if mouse_volume_up_is_set.is_some() {
+                client_pub.send(ClientRequest::Player(PlayerRequest::VolumeUp))?;   
+            }
+        }
+        // a mouse scroll down event
+        crossterm::event::MouseEventKind::ScrollDown => {
+            // the key sequence m s d stands for MouseScrollDown
+            let mouse_scroll_down = "m s d".into();
+            let mouse_volume_down_is_set = &config::get_config().keymap_config.find_command_or_action_from_key_sequence(&mouse_scroll_down);
+
+            // if MouseScrollDown is set up, lower the volume
+            if mouse_volume_down_is_set.is_some() {
+                client_pub.send(ClientRequest::Player(PlayerRequest::VolumeDown))?;
+            }
+        }
+        _ => {}
     }
     Ok(())
 }


### PR DESCRIPTION
Resolves [#446](https://github.com/aome510/spotify-player/issues/446)

In this PR we have added two more mouse event listeners, for *scroll up* and for *scroll down* of the mouse's wheel. This event listeners should only work if the **keymap.toml** has the following two entries:

```
[[keymaps]]
command = "VolumeUp"
key_sequence = "m s u"

[[keymaps]]
command = "VolumeDown"
key_sequence = "m s d"
```
where *m s u* stands for MouseScrollUp and *m s d* for MouseScrollDown.

Instead of mixing the key_sequence configuration with the mouse movements, we think that it would be useful to have a separate configuration for mouse events.


