### PR TITLE
Changed binary (executable) file name in Cargo.toml

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/aome510/spotify-player"
 keywords = ["spotify", "tui", "player"]
 readme = "../README.md"
 
+[[bin]]
+name = "sptplay"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0.91"
 clap = { version = "4.5.20", features = ["derive", "string"] }


### PR DESCRIPTION
Hi! I changed Cargo.toml to save the output of binary with file name “sptplay”.  You can recommend another name, too. 
It makes running application easier. 