### PR TITLE
Fix black image border

### DIFF
--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -66,8 +66,12 @@ pub fn render_playback_window(
                             if needs_clear {
                                 // clear the image's both new and old areas to ensure no remaining artifacts before rendering the image
                                 // See: https://github.com/aome510/spotify-player/issues/389
-                                clear_area(frame, ui.last_cover_image_render_info.render_area);
-                                clear_area(frame, cover_img_rect);
+                                clear_area(
+                                    frame,
+                                    ui.last_cover_image_render_info.render_area,
+                                    &ui.theme,
+                                );
+                                clear_area(frame, cover_img_rect, &ui.theme);
                             } else {
                                 if !ui.last_cover_image_render_info.rendered {
                                     if let Err(err) = render_playback_cover_image(state, ui) {
@@ -123,7 +127,11 @@ pub fn render_playback_window(
         #[cfg(feature = "image")]
         {
             if ui.last_cover_image_render_info.rendered {
-                clear_area(frame, ui.last_cover_image_render_info.render_area);
+                clear_area(
+                    frame,
+                    ui.last_cover_image_render_info.render_area,
+                    &ui.theme,
+                );
                 ui.last_cover_image_render_info = Default::default();
             }
         }
@@ -143,14 +151,15 @@ pub fn render_playback_window(
 }
 
 #[cfg(feature = "image")]
-fn clear_area(frame: &mut Frame, rect: Rect) {
+fn clear_area(frame: &mut Frame, rect: Rect, theme: &config::Theme) {
     for x in rect.left()..rect.right() {
         for y in rect.top()..rect.bottom() {
             frame
                 .buffer_mut()
                 .cell_mut((x, y))
                 .expect("invalid cell")
-                .reset();
+                .set_char(' ')
+                .set_style(theme.app());
         }
     }
 }
@@ -330,6 +339,7 @@ fn render_playback_cover_image(state: &SharedState, ui: &mut UIStateGuard) -> Re
                 width: Some(width),
                 height: Some(height),
                 restore_cursor: true,
+                transparent: true,
                 ..Default::default()
             },
         )


### PR DESCRIPTION
Closes #612

- clearing the image area now sets its background to the theme background color.
- images are rendered with `transparent: true` as to not overwrite the background with black pixels when rendering album art with `scale < 1.0`

preview:
![image](https://github.com/user-attachments/assets/92b2dc78-e02c-432d-982b-c14c28dcfb01)
notice the lack of any black border around the album cover.