### PR TITLE
Add native-tls-alpn feature to reqwest

### DIFF
--- a/lyric_finder/Cargo.toml
+++ b/lyric_finder/Cargo.toml
@@ -14,7 +14,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 
 [dependencies]
-reqwest = { version = "0.12.4", features = ["json"], default-features = false }
+reqwest = { version = "0.12.4", features = ["json", "native-tls-alpn"], default-features = false }
 anyhow = "1.0.86"
 serde = { version = "1.0.202", features = ["derive"] }
 html5ever = "0.27.0"


### PR DESCRIPTION
I encountered a problem similar to one described in #34.
For unknown reason Genius was blocking my requests for some time, response for the search request was:

> Sorry, you have been blocked
> You are unable to access genius.com
 
Both browser and curl sucessfully returned the expected json.
I came across [this discusion](https://github.com/seanmonstar/reqwest/discussions/2227#discussioncomment-9403885) in reqwest library and after trying the solution it lyric finder finally start working again.