### PR TITLE
Allow changing of volume in different steps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,7 @@ List of supported commands:
 | `Repeat`                       | cycle the repeat mode                                                   | `C-r`              |
 | `ToggleFakeTrackRepeatMode`    | toggle fake track repeat mode                                           | `M-r`              |
 | `Shuffle`                      | toggle the shuffle mode                                                 | `C-s`              |
-| `VolumeUp`                     | increase playback volume by 5%                                          | `+`                |
-| `VolumeDown`                   | decrease playback volume by 5%                                          | `-`                |
+| `VolumeChange`                 | change playback volume by an offset (default shortcuts use 5%)          | `+`, `-`           |
 | `Mute`                         | toggle playback volume between 0% and previous level                    | `_`                |
 | `SeekForward`                  | seek forward by 5s                                                      | `>`                |
 | `SeekBackward`                 | seek backward by 5s                                                     | `<`                |

--- a/docs/config.md
+++ b/docs/config.md
@@ -285,7 +285,7 @@ key_sequence = "M-enter"
 command = "None"
 key_sequence = "q"
 [[keymaps]]
-command = "VolumeChange -5"
+command = { VolumeChange = { offset = 1 } }
 key_sequence = "-"
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -284,6 +284,9 @@ key_sequence = "M-enter"
 [[keymaps]]
 command = "None"
 key_sequence = "q"
+[[keymaps]]
+command = "VolumeChange -5"
+key_sequence = "-"
 ```
 
 ## Actions

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -16,8 +16,9 @@ pub enum Command {
     Repeat,
     ToggleFakeTrackRepeatMode,
     Shuffle,
-    VolumeUp,
-    VolumeDown,
+    VolumeChange {
+        offset: i32,
+    },
     Mute,
     SeekForward,
     SeekBackward,
@@ -284,7 +285,11 @@ pub fn construct_episode_actions(episode: &Episode, _data: &DataReadGuard) -> Ve
 }
 
 impl Command {
-    pub fn desc(self) -> &'static str {
+    pub fn desc(self) -> String {
+        if let Self::VolumeChange { offset } = self {
+            return format!("change playback volume by {}", offset);
+        }
+
         match self {
             Self::None => "do nothing",
             Self::NextTrack => "next track",
@@ -294,8 +299,6 @@ impl Command {
             Self::Repeat => "cycle the repeat mode",
             Self::ToggleFakeTrackRepeatMode => "toggle fake track repeat mode",
             Self::Shuffle => "toggle the shuffle mode",
-            Self::VolumeUp => "increase playback volume by 5%",
-            Self::VolumeDown => "decrease playback volume by 5%",
             Self::Mute => "toggle playback volume between 0% and previous level",
             Self::SeekForward => "seek forward by 5s",
             Self::SeekBackward => "seek backward by 5s",
@@ -355,6 +358,8 @@ impl Command {
             Self::MovePlaylistItemUp => "move playlist item up one position",
             Self::MovePlaylistItemDown => "move playlist item down one position",
             Self::CreatePlaylist => "create a new playlist",
+            _ => unreachable!(),
         }
+        .to_string()
     }
 }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -358,7 +358,7 @@ impl Command {
             Self::MovePlaylistItemUp => "move playlist item up one position",
             Self::MovePlaylistItemDown => "move playlist item down one position",
             Self::CreatePlaylist => "create a new playlist",
-            _ => unreachable!(),
+            Self::VolumeChange { offset: _ } => unreachable!(),
         }
         .to_string()
     }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -287,7 +287,7 @@ pub fn construct_episode_actions(episode: &Episode, _data: &DataReadGuard) -> Ve
 impl Command {
     pub fn desc(self) -> String {
         if let Self::VolumeChange { offset } = self {
-            return format!("change playback volume by {}", offset);
+            return format!("change playback volume by {offset}");
         }
 
         match self {

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -65,11 +65,11 @@ impl Default for KeymapConfig {
                 },
                 Keymap {
                     key_sequence: "+".into(),
-                    command: Command::VolumeUp,
+                    command: Command::VolumeChange { offset: 5 },
                 },
                 Keymap {
                     key_sequence: "-".into(),
-                    command: Command::VolumeDown,
+                    command: Command::VolumeChange { offset: -5 },
                 },
                 Keymap {
                     key_sequence: "_".into(),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -547,18 +547,10 @@ fn handle_global_command(
         Command::Shuffle => {
             client_pub.send(ClientRequest::Player(PlayerRequest::Shuffle))?;
         }
-        Command::VolumeUp => {
+        Command::VolumeChange { offset } => {
             if let Some(ref playback) = state.player.read().buffered_playback {
                 if let Some(volume) = playback.volume {
-                    let volume = std::cmp::min(volume + 5, 100_u32);
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
-                }
-            }
-        }
-        Command::VolumeDown => {
-            if let Some(ref playback) = state.player.read().buffered_playback {
-                if let Some(volume) = playback.volume {
-                    let volume = volume.saturating_sub(5_u32);
+                    let volume = std::cmp::min(volume as i32 + offset, 100_i32);
                     client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
                 }
             }


### PR DESCRIPTION
Resolves #616 

This change implements what was requested in #616, but would require users to re-write their `keymap.toml`.

The new format for `keymap.toml`would be: 

```toml
[[keymaps]]
key_sequence = "+"
command = { type = "VolumeChange", args = { offset = 1 } }

[[keymaps]]
key_sequence = "-"
command = { type = "VolumeChange", args = { offset = -1 } }

[[keymaps]]
key_sequence = "n"
command = { type = "NextTrack" }
```

I'm looking for input on whether this is a good idea to implement this way. Or if an alternative would be better. 

There is also the option of leaving the configuration syntax as is and setting the offset like this: 

```toml
[[keymaps]]
key_sequence = "+"
command = "VolumeChange 1"
```

And this approach has some advantages and disadvantages. 

For one, the config format for the other commands wouldn't change, but as far as I can tell I would have to write some custom deserialization logic, since TOML doesn't support this syntax out of the box. And any future commands, which have arguments, would need to do the same. 

Personally, I don't have a preference either way.