### PR TITLE
Clarify `client_id_command` option & trim output

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,7 @@
   - [Notes](#notes)
   - [Media control](#media-control)
   - [Player event hook command](#player-event-hook-command)
+  - [Client id command](#client-id-command)
   - [Device configurations](#device-configurations)
   - [Layout configurations](#layout-configurations)
 - [Themes](#themes)
@@ -121,6 +122,17 @@ case "$1" in
     "EndOfTrack") echo "command: $1, track_id: $2" >> /tmp/log.txt ;;
 esac
 ```
+
+### Client id command
+
+If you prefer not to include your own `client_id` directly in your configuration, you can retrieve it at runtime using the `client_id_command` option.
+
+If specified, `client_id_command` should be an object with two fields `command` and `args`, just like `player_event_hook_command`.
+For example to read your client_id from a file your could use `client_id_command = { command = "cat", args = ["/path/to/file"] }`
+
+> [!NOTE]
+> When passing a path as an argument, always use the full path.
+> The `~` symbol will not automatically expand to your home directory.
 
 ### Device configurations
 

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -420,7 +420,7 @@ impl AppConfig {
     /// Returns stdout of `client_id_command` if set, otherwise it returns the the value of `client_id`
     pub fn get_client_id(&self) -> Result<String> {
         match self.client_id_command {
-            Some(ref cmd) => cmd.execute(None),
+            Some(ref cmd) => cmd.execute(None).map(|out| out.trim().into()),
             None => Ok(self.client_id.clone()),
         }
     }


### PR DESCRIPTION
Based on some feedback in #537 I've added some docs on how to use the `client_id_command` option, and ensured the output is trimmed before being returned.