### PR TITLE
fix: building with notify only

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -1666,7 +1666,7 @@ impl Client {
 
         #[cfg(all(feature = "notify", not(feature = "streaming")))]
         if configs.app_config.enable_notify {
-            Self::notify_new_track(&track, &path)?;
+            Self::notify_new_playback(&curr_item, &path)?;
         }
 
         Ok(())


### PR DESCRIPTION
While (#562) implemented conditional compilation for notify without streaming the used function seems to be deprecated with &track out of scope. Replacing it with Self::notify_new_track(&track, &path)?; fixes the issue.