### PR TITLE
fix(search): remove double border when in vertical orientation

### DIFF
--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -116,7 +116,11 @@ pub fn render_search_page(
     let show_rect = construct_and_render_block(
         "Shows",
         &ui.theme,
-        Borders::TOP | Borders::RIGHT,
+        if ui.orientation == Orientation::Horizontal {
+            Borders::TOP | Borders::RIGHT
+        } else {
+            Borders::TOP
+        },
         frame,
         chunks[4],
     );


### PR DESCRIPTION
The "Shows" section of the search results had two borders, when in vertical orientation.

All that was missing was the conditional check, that all the other section have.