### PR TITLE
Fixing bug when performing an action on an album

### DIFF
--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -1,5 +1,6 @@
 use super::page::handle_navigation_command;
 use super::*;
+use crate::utils::sort_albums_by_type;
 use crate::{
     command::{
         construct_album_actions, construct_artist_actions, construct_playlist_actions,
@@ -163,13 +164,17 @@ pub fn handle_command_for_focused_context_window(
                 };
 
                 match focus {
-                    ArtistFocusState::Albums => handle_command_for_album_list_window(
-                        command,
-                        &ui.search_filtered_items(albums),
-                        &data,
-                        ui,
-                        client_pub,
-                    ),
+                    ArtistFocusState::Albums => {
+                        let sorted_albums = sort_albums_by_type(&ui.search_filtered_items(albums));
+
+                        handle_command_for_album_list_window(
+                            command,
+                            &sorted_albums,
+                            &data,
+                            ui,
+                            client_pub,
+                        )
+                    }
                     ArtistFocusState::RelatedArtists => Ok(handle_command_for_artist_list_window(
                         command,
                         &ui.search_filtered_items(related_artists),

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -5,8 +5,6 @@ use std::{
 
 use tui::text::Line;
 
-use crate::{state::Episode, utils::format_duration};
-
 use super::{
     config, utils, utils::construct_and_render_block, Album, Artist, ArtistFocusState, Borders,
     BrowsePageUIState, Cell, Constraint, Context, ContextPageUIState, DataReadGuard, Frame, Id,
@@ -14,6 +12,8 @@ use super::{
     PlaylistFolderItem, Rect, Row, SearchFocusState, SharedState, Style, Table, Track,
     UIStateGuard,
 };
+use crate::utils::sort_albums_by_type;
+use crate::{state::Episode, utils::format_duration};
 
 const COMMAND_TABLE_CONSTRAINTS: [Constraint; 3] = [
     Constraint::Percentage(25),
@@ -800,7 +800,6 @@ fn render_artist_context_page_windows(
     rect: Rect,
     artist_data: (&[Track], &[Album], &[Artist]),
 ) {
-    let configs = config::get_config();
     // 1. Get data
     let (tracks, mut albums, artists) = (
         ui.search_filtered_items(artist_data.0),
@@ -835,18 +834,7 @@ fn render_artist_context_page_windows(
 
     // 3. Construct the page's widgets
     // album table
-    if configs.app_config.sort_artist_albums_by_type {
-        fn get_priority(album_type: &str) -> usize {
-            match album_type {
-                "album" => 0,
-                "single" => 1,
-                "appears_on" => 2,
-                "compilation" => 3,
-                _ => 4,
-            }
-        }
-        albums.sort_by_key(|a| get_priority(&a.album_type()));
-    }
+    albums = sort_albums_by_type(&albums);
 
     let is_albums_active = is_active && focus_state == ArtistFocusState::Albums;
     let n_albums = albums.len();

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -1,3 +1,5 @@
+use crate::config;
+use crate::state::Album;
 use std::borrow::Cow;
 
 /// formats a time duration into a "{minutes}:{seconds}" format
@@ -48,4 +50,20 @@ pub fn parse_uri(uri: &str) -> Cow<str> {
     } else {
         Cow::Borrowed(uri)
     }
+}
+
+pub fn sort_albums_by_type<'a>(albums: &[&'a Album]) -> Vec<&'a Album> {
+    let mut sorted_albums = albums.to_vec();
+
+    if config::get_config().app_config.sort_artist_albums_by_type {
+        sorted_albums.sort_by_key(|a| match a.album_type().as_str() {
+            "album" => 0,
+            "single" => 1,
+            "appears_on" => 2,
+            "compilation" => 3,
+            _ => 4,
+        });
+    }
+
+    sorted_albums
 }


### PR DESCRIPTION
Fixing a bug where performing an action on an album can apply that action to the wrong album.

Introduced in my last PR https://github.com/aome510/spotify-player/pull/654

My original PR sorted the UI, but I didn't realize actions on albums happen based on the selected _index_ (not the selected album).  So I'm adding album sorting to the album event window as well.