### PR TITLE
Remove legacy alias for ratatui

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,4 +424,4 @@ The application stores logs inside the `$APP_CACHE_FOLDER/spotify-player-*.log` 
 
 ## Acknowledgement
 
-`spotify_player` is written in [Rust](https://www.rust-lang.org) and is built on top of awesome libraries such as [tui-rs](https://github.com/fdehau/tui-rs), [rspotify](https://github.com/ramsayleung/rspotify), [librespot](https://github.com/librespot-org/librespot), and [many more](spotify_player/Cargo.toml). It's highly inspired by [spotify-tui](https://github.com/Rigellute/spotify-tui) and [ncspot](https://github.com/hrkfdn/ncspot).
+`spotify_player` is written in [Rust](https://www.rust-lang.org) and is built on top of awesome libraries such as [ratatui](https://github.com/ratatui/ratatui), [rspotify](https://github.com/ramsayleung/rspotify), [librespot](https://github.com/librespot-org/librespot), and [many more](spotify_player/Cargo.toml). It's highly inspired by [spotify-tui](https://github.com/Rigellute/spotify-tui) and [ncspot](https://github.com/hrkfdn/ncspot).

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 description = "A Spotify player in the terminal with full feature parity"
 repository = "https://github.com/aome510/spotify-player"
-keywords = ["spotify", "tui", "player"]
+keywords = ["spotify", "tui", "ratatui", "player"]
 readme = "../README.md"
 
 [dependencies]
@@ -32,7 +32,7 @@ tokio = { version = "1.41.1", features = [
 	"time",
 ] }
 toml = "0.8.19"
-tui = { package = "ratatui", version = "0.29.0" }
+ratatui = { version = "0.29.0" }
 rand = "0.8.5"
 maybe-async = "0.2.10"
 async-trait = "0.1.83"

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use serde::Deserialize;
-use tui::style;
+use ratatui::style;
 
 #[derive(Clone, Debug, Deserialize)]
 /// Application theme configurations.

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -23,7 +23,7 @@ use crate::utils::map_join;
 use anyhow::{Context as _, Result};
 
 use clipboard::{execute_copy_command, get_clipboard_content};
-use tui::widgets::ListState;
+use ratatui::widgets::ListState;
 
 mod clipboard;
 mod page;

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -18,7 +18,7 @@ pub use popup::*;
 #[cfg(feature = "image")]
 pub struct ImageRenderInfo {
     pub url: String,
-    pub render_area: tui::layout::Rect,
+    pub render_area: ratatui::layout::Rect,
     /// indicates if the image is rendered
     pub rendered: bool,
 }
@@ -36,7 +36,7 @@ pub struct UIState {
 
     /// The rectangle representing the playback progress bar,
     /// which is mainly used to handle mouse click events (for seeking command)
-    pub playback_progress_bar_rect: tui::layout::Rect,
+    pub playback_progress_bar_rect: ratatui::layout::Rect,
 
     #[cfg(feature = "image")]
     pub last_cover_image_render_info: ImageRenderInfo,
@@ -116,7 +116,7 @@ impl UIState {
 
 #[cfg(feature = "fzf")]
 use fuzzy_matcher::skim::SkimMatcherV2;
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 #[cfg(feature = "fzf")]
 fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> Vec<&'a T> {

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -2,7 +2,7 @@ use crate::{
     state::model::{Category, ContextId},
     ui::single_line_input::LineInput,
 };
-use tui::widgets::{ListState, TableState};
+use ratatui::widgets::{ListState, TableState};
 
 #[derive(Clone, Debug)]
 pub enum PageState {

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -3,7 +3,7 @@ use crate::{
     state::model::{Album, Artist, Episode, EpisodeId, Playlist, Show, Track, TrackId},
     ui::single_line_input::LineInput,
 };
-use tui::widgets::ListState;
+use ratatui::widgets::ListState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlaylistCreateCurrentField {

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use anyhow::{Context as AnyhowContext, Result};
-use tui::{
+use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span, Text},
@@ -22,7 +22,7 @@ use tui::{
 #[cfg(feature = "image")]
 use crate::state::ImageRenderInfo;
 
-type Terminal = tui::Terminal<tui::backend::CrosstermBackend<std::io::Stdout>>;
+type Terminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>;
 
 mod page;
 mod playback;
@@ -82,8 +82,8 @@ fn init_ui() -> Result<Terminal> {
         crossterm::terminal::EnterAlternateScreen,
         crossterm::event::EnableMouseCapture
     )?;
-    let backend = tui::backend::CrosstermBackend::new(stdout);
-    let mut terminal = tui::Terminal::new(backend)?;
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = ratatui::Terminal::new(backend)?;
     terminal.clear()?;
     Ok(terminal)
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::Display,
 };
 
-use tui::text::Line;
+use ratatui::text::Line;
 
 use crate::{state::Episode, utils::format_duration};
 

--- a/spotify_player/src/ui/single_line_input.rs
+++ b/spotify_player/src/ui/single_line_input.rs
@@ -1,5 +1,5 @@
 use crossterm::event::KeyCode;
-use tui::widgets::Widget;
+use ratatui::widgets::Widget;
 
 use super::{Line, Modifier, Paragraph, Span, Style};
 use crate::key::Key;


### PR DESCRIPTION
Update usages of `tui` to `ratatui` and remove the legacy alias. Also update the readme, which points to the former.