### PR TITLE
Add working shell.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ cd /usr/pkgsrc/audio/spotify-player
 make install
 ```
 
+### NixOS
+
+[spotify-player](https://search.nixos.org/packages?channel=unstable&show=spotify-player&from=0&size=50&sort=relevance&type=packages&query=spotify-player) is available as a Nix package and can be installed via `nix-shell -p spotify-player` or as part of your system configuration.
+
+If you want to build the source locally you can run `nix-shell` in the root of a checkout of the source code. The provided `shell.nix` file will install the build prerequisites.
+
 ### Docker
 
 **Note**: [streaming](#streaming) feature is disabled when using the docker image.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+let
+  # Pinned nixpkgs, deterministic. Last updated: 2025-02-28
+  pkgs = import (fetchTarball("https://github.com/NixOS/nixpkgs/archive/f44bd8ca21e026135061a0a57dcf3d0775b67a49.tar.gz")) {};
+
+  # Rolling updates, not deterministic.
+  # pkgs = import (fetchTarball("channel:nixpkgs-unstable")) {};
+in pkgs.mkShell {
+  buildInputs = [
+    pkgs.alsa-lib
+    pkgs.cargo
+    pkgs.dbus-glib
+    pkgs.libsixel
+    pkgs.openssl
+    pkgs.pkg-config
+    pkgs.rustc
+  ];
+}


### PR DESCRIPTION
This is useful for developers, like me, that use NixOS for reproducible developer environments. This will get everything you need to build the default feature set as of today.

Created this while investigating https://github.com/aome510/spotify-player/issues/684