### PR TITLE
Play playlist 'CTRL+o' added #488

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -236,71 +236,71 @@ impl Client {
             PlayerRequest::NextTrack => self.next_track(device_id).await?,
             PlayerRequest::PreviousTrack => self.previous_track(device_id).await?,
             PlayerRequest::Resume => {
-                        if !playback.is_playing {
-                            self.resume_playback(device_id, None).await?;
-                            playback.is_playing = true;
-                        }
-                    }
+                if !playback.is_playing {
+                    self.resume_playback(device_id, None).await?;
+                    playback.is_playing = true;
+                }
+            }
             PlayerRequest::Pause => {
-                        if playback.is_playing {
-                            self.pause_playback(device_id).await?;
-                            playback.is_playing = false;
-                        }
-                    }
+                if playback.is_playing {
+                    self.pause_playback(device_id).await?;
+                    playback.is_playing = false;
+                }
+            }
             PlayerRequest::ResumePause => {
-                        if playback.is_playing {
-                            self.pause_playback(device_id).await?;
-                        } else {
-                            self.resume_playback(device_id, None).await?;
-                        }
-                        playback.is_playing = !playback.is_playing;
-                    }
+                if playback.is_playing {
+                    self.pause_playback(device_id).await?;
+                } else {
+                    self.resume_playback(device_id, None).await?;
+                }
+                playback.is_playing = !playback.is_playing;
+            }
             PlayerRequest::SeekTrack(position_ms) => {
-                        self.seek_track(position_ms, device_id).await?;
-                    }
+                self.seek_track(position_ms, device_id).await?;
+            }
             PlayerRequest::Repeat => {
-                        let next_repeat_state = match playback.repeat_state {
-                            rspotify::model::RepeatState::Off => rspotify::model::RepeatState::Track,
-                            rspotify::model::RepeatState::Track => rspotify::model::RepeatState::Context,
-                            rspotify::model::RepeatState::Context => rspotify::model::RepeatState::Off,
-                        };
+                let next_repeat_state = match playback.repeat_state {
+                    rspotify::model::RepeatState::Off => rspotify::model::RepeatState::Track,
+                    rspotify::model::RepeatState::Track => rspotify::model::RepeatState::Context,
+                    rspotify::model::RepeatState::Context => rspotify::model::RepeatState::Off,
+                };
 
-                        self.repeat(next_repeat_state, device_id).await?;
+                self.repeat(next_repeat_state, device_id).await?;
 
-                        playback.repeat_state = next_repeat_state;
-                    }
+                playback.repeat_state = next_repeat_state;
+            }
             PlayerRequest::Shuffle => {
-                        self.shuffle(!playback.shuffle_state, device_id).await?;
+                self.shuffle(!playback.shuffle_state, device_id).await?;
 
-                        playback.shuffle_state = !playback.shuffle_state;
-                    }
+                playback.shuffle_state = !playback.shuffle_state;
+            }
             PlayerRequest::Volume(volume) => {
-                        self.volume(volume, device_id).await?;
+                self.volume(volume, device_id).await?;
 
-                        playback.volume = Some(u32::from(volume));
-                        playback.mute_state = None;
-                    }
+                playback.volume = Some(u32::from(volume));
+                playback.mute_state = None;
+            }
             PlayerRequest::ToggleMute => {
-                        let new_mute_state = match playback.mute_state {
-                            None => {
-                                self.volume(0, device_id).await?;
-                                Some(playback.volume.unwrap_or_default())
-                            }
-                            Some(volume) => {
-                                self.volume(volume as u8, device_id).await?;
-                                None
-                            }
-                        };
+                let new_mute_state = match playback.mute_state {
+                    None => {
+                        self.volume(0, device_id).await?;
+                        Some(playback.volume.unwrap_or_default())
+                    }
+                    Some(volume) => {
+                        self.volume(volume as u8, device_id).await?;
+                        None
+                    }
+                };
 
-                        playback.mute_state = new_mute_state;
-                    }
+                playback.mute_state = new_mute_state;
+            }
             PlayerRequest::StartPlayback(..) => {
-                        anyhow::bail!("`StartPlayback` should be handled earlier")
-                    }
+                anyhow::bail!("`StartPlayback` should be handled earlier")
+            }
             PlayerRequest::TransferPlayback(..) => {
-                        anyhow::bail!("`TransferPlayback` should be handled earlier")
-                    }
-PlayerRequest::PlayCurrentPlaylist => todo!(),
+                anyhow::bail!("`TransferPlayback` should be handled earlier")
+            }
+            PlayerRequest::PlayCurrentPlaylist => todo!(),
         };
 
         Ok(Some(playback))

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -236,71 +236,71 @@ impl Client {
             PlayerRequest::NextTrack => self.next_track(device_id).await?,
             PlayerRequest::PreviousTrack => self.previous_track(device_id).await?,
             PlayerRequest::Resume => {
-                if !playback.is_playing {
-                    self.resume_playback(device_id, None).await?;
-                    playback.is_playing = true;
-                }
-            }
-
+                        if !playback.is_playing {
+                            self.resume_playback(device_id, None).await?;
+                            playback.is_playing = true;
+                        }
+                    }
             PlayerRequest::Pause => {
-                if playback.is_playing {
-                    self.pause_playback(device_id).await?;
-                    playback.is_playing = false;
-                }
-            }
+                        if playback.is_playing {
+                            self.pause_playback(device_id).await?;
+                            playback.is_playing = false;
+                        }
+                    }
             PlayerRequest::ResumePause => {
-                if playback.is_playing {
-                    self.pause_playback(device_id).await?;
-                } else {
-                    self.resume_playback(device_id, None).await?;
-                }
-                playback.is_playing = !playback.is_playing;
-            }
+                        if playback.is_playing {
+                            self.pause_playback(device_id).await?;
+                        } else {
+                            self.resume_playback(device_id, None).await?;
+                        }
+                        playback.is_playing = !playback.is_playing;
+                    }
             PlayerRequest::SeekTrack(position_ms) => {
-                self.seek_track(position_ms, device_id).await?;
-            }
+                        self.seek_track(position_ms, device_id).await?;
+                    }
             PlayerRequest::Repeat => {
-                let next_repeat_state = match playback.repeat_state {
-                    rspotify::model::RepeatState::Off => rspotify::model::RepeatState::Track,
-                    rspotify::model::RepeatState::Track => rspotify::model::RepeatState::Context,
-                    rspotify::model::RepeatState::Context => rspotify::model::RepeatState::Off,
-                };
+                        let next_repeat_state = match playback.repeat_state {
+                            rspotify::model::RepeatState::Off => rspotify::model::RepeatState::Track,
+                            rspotify::model::RepeatState::Track => rspotify::model::RepeatState::Context,
+                            rspotify::model::RepeatState::Context => rspotify::model::RepeatState::Off,
+                        };
 
-                self.repeat(next_repeat_state, device_id).await?;
+                        self.repeat(next_repeat_state, device_id).await?;
 
-                playback.repeat_state = next_repeat_state;
-            }
+                        playback.repeat_state = next_repeat_state;
+                    }
             PlayerRequest::Shuffle => {
-                self.shuffle(!playback.shuffle_state, device_id).await?;
+                        self.shuffle(!playback.shuffle_state, device_id).await?;
 
-                playback.shuffle_state = !playback.shuffle_state;
-            }
+                        playback.shuffle_state = !playback.shuffle_state;
+                    }
             PlayerRequest::Volume(volume) => {
-                self.volume(volume, device_id).await?;
+                        self.volume(volume, device_id).await?;
 
-                playback.volume = Some(u32::from(volume));
-                playback.mute_state = None;
-            }
+                        playback.volume = Some(u32::from(volume));
+                        playback.mute_state = None;
+                    }
             PlayerRequest::ToggleMute => {
-                let new_mute_state = match playback.mute_state {
-                    None => {
-                        self.volume(0, device_id).await?;
-                        Some(playback.volume.unwrap_or_default())
-                    }
-                    Some(volume) => {
-                        self.volume(volume as u8, device_id).await?;
-                        None
-                    }
-                };
+                        let new_mute_state = match playback.mute_state {
+                            None => {
+                                self.volume(0, device_id).await?;
+                                Some(playback.volume.unwrap_or_default())
+                            }
+                            Some(volume) => {
+                                self.volume(volume as u8, device_id).await?;
+                                None
+                            }
+                        };
 
-                playback.mute_state = new_mute_state;
-            }
+                        playback.mute_state = new_mute_state;
+                    }
             PlayerRequest::StartPlayback(..) => {
-                anyhow::bail!("`StartPlayback` should be handled earlier")
-            }
+                        anyhow::bail!("`StartPlayback` should be handled earlier")
+                    }
             PlayerRequest::TransferPlayback(..) => {
-                anyhow::bail!("`TransferPlayback` should be handled earlier")
-            }
+                        anyhow::bail!("`TransferPlayback` should be handled earlier")
+                    }
+PlayerRequest::PlayCurrentPlaylist => todo!(),
         };
 
         Ok(Some(playback))

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -10,6 +10,7 @@ pub enum PlayerRequest {
     Resume,
     Pause,
     ResumePause,
+    PlayCurrentPlaylist,
     SeekTrack(chrono::Duration),
     Repeat,
     Shuffle,

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -233,11 +233,7 @@ pub fn construct_album_actions(album: &Album, data: &DataReadGuard) -> Vec<Actio
 
 /// constructs a list of actions on an artist
 pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![
-        Action::PlayContext,
-        Action::GoToRadio,
-        Action::CopyLink,
-    ];
+    let mut actions = vec![Action::PlayContext, Action::GoToRadio, Action::CopyLink];
 
     if data
         .user_data
@@ -254,11 +250,7 @@ pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Ac
 
 /// constructs a list of actions on an playlist
 pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![
-        Action::PlayContext,
-        Action::GoToRadio,
-        Action::CopyLink,
-    ];
+    let mut actions = vec![Action::PlayContext, Action::GoToRadio, Action::CopyLink];
 
     if data
         .user_data
@@ -275,10 +267,7 @@ pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> 
 
 /// constructs a list of actions on a show
 pub fn construct_show_actions(show: &Show, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![
-        Action::PlayContext,
-        Action::CopyLink,
-    ];
+    let mut actions = vec![Action::PlayContext, Action::CopyLink];
     if data.user_data.saved_shows.iter().any(|s| s.id == show.id) {
         actions.push(Action::DeleteFromLibrary);
     } else {

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -80,6 +80,7 @@ pub enum Command {
     MovePlaylistItemDown,
 
     CreatePlaylist,
+    PlaySelectedPlaylist,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -102,6 +103,7 @@ pub enum Action {
     CopyLink,
     Follow,
     Unfollow,
+    PlayContext,
 }
 
 #[derive(Debug)]
@@ -214,6 +216,7 @@ pub fn construct_track_actions(track: &Track, data: &DataReadGuard) -> Vec<Actio
 /// constructs a list of actions on an album
 pub fn construct_album_actions(album: &Album, data: &DataReadGuard) -> Vec<Action> {
     let mut actions = vec![
+        Action::PlayContext,
         Action::GoToArtist,
         Action::GoToRadio,
         Action::ShowActionsOnArtist,
@@ -230,7 +233,11 @@ pub fn construct_album_actions(album: &Album, data: &DataReadGuard) -> Vec<Actio
 
 /// constructs a list of actions on an artist
 pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![Action::GoToRadio, Action::CopyLink];
+    let mut actions = vec![
+        Action::PlayContext,
+        Action::GoToRadio,
+        Action::CopyLink,
+    ];
 
     if data
         .user_data
@@ -247,7 +254,11 @@ pub fn construct_artist_actions(artist: &Artist, data: &DataReadGuard) -> Vec<Ac
 
 /// constructs a list of actions on an playlist
 pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![Action::GoToRadio, Action::CopyLink];
+    let mut actions = vec![
+        Action::PlayContext,
+        Action::GoToRadio,
+        Action::CopyLink,
+    ];
 
     if data
         .user_data
@@ -264,7 +275,10 @@ pub fn construct_playlist_actions(playlist: &Playlist, data: &DataReadGuard) -> 
 
 /// constructs a list of actions on a show
 pub fn construct_show_actions(show: &Show, data: &DataReadGuard) -> Vec<Action> {
-    let mut actions = vec![Action::CopyLink];
+    let mut actions = vec![
+        Action::PlayContext,
+        Action::CopyLink,
+    ];
     if data.user_data.saved_shows.iter().any(|s| s.id == show.id) {
         actions.push(Action::DeleteFromLibrary);
     } else {
@@ -356,6 +370,7 @@ impl Command {
             Self::MovePlaylistItemUp => "move playlist item up one position",
             Self::MovePlaylistItemDown => "move playlist item down one position",
             Self::CreatePlaylist => "create a new playlist",
+            Self::PlaySelectedPlaylist => "play the selected playlist",
             Self::VolumeChange { offset: _ } => unreachable!(),
         }
         .to_string()

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -316,6 +316,11 @@ impl Default for KeymapConfig {
                     key_sequence: "g c".into(),
                     command: Command::JumpToCurrentTrackInContext,
                 },
+                Keymap {
+                    key_sequence: "C-o".into(),
+                    command: Command::PlaySelectedPlaylist,
+                },
+                
             ],
         }
     }

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -320,7 +320,6 @@ impl Default for KeymapConfig {
                     key_sequence: "C-o".into(),
                     command: Command::PlaySelectedPlaylist,
                 },
-                
             ],
         }
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -484,7 +484,10 @@ pub fn handle_action_in_context(
                 if let Some(show) = &episode.show {
                     let context_id = ContextId::Show(show.id.clone());
                     client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
-                        Playback::Context(context_id, Some(rspotify::model::Offset::Uri(episode.id.uri()))),
+                        Playback::Context(
+                            context_id,
+                            Some(rspotify::model::Offset::Uri(episode.id.uri())),
+                        ),
                         None,
                     )))?;
                 } else {

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -298,6 +298,25 @@ fn handle_command_for_context_page(
             ui.new_search_popup();
             Ok(true)
         }
+        Command::PlaySelectedPlaylist => {
+            if let PageState::Context {
+                context_page_type: ContextPageType::Browsing(context_id),
+                ..
+            } = ui.current_page()
+            {
+                if let ContextId::Playlist(_) = context_id {
+                    client_pub.send(ClientRequest::Player(PlayerRequest::StartPlayback(
+                        Playback::Context(context_id.clone(), None),
+                        None,
+                    )))?;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            } else {
+                Ok(false)
+            }
+        }
         _ => window::handle_command_for_focused_context_window(command, client_pub, ui, state),
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -287,14 +287,24 @@ pub fn render_context_page(
     let data = state.data.read();
     match data.caches.context.get(&id.uri()) {
         Some(context) => {
-            // render context description
-            let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
+            let chunks = Layout::vertical([Constraint::Length(2), Constraint::Fill(0)]).split(rect);
+            // Render context description
             frame.render_widget(
                 Paragraph::new(context.description()).style(ui.theme.page_desc()),
                 chunks[0],
             );
-            let rect = chunks[1];
 
+            // Insert a "Play Context" button
+            let button_rect = Layout::horizontal([Constraint::Length(14), Constraint::Fill(0)])
+                .split(chunks[0])[0];
+            frame.render_widget(
+                Paragraph::new("Playing")
+                    .alignment(tui::layout::Alignment::Center)
+                    .style(ui.theme.app()),
+                button_rect,
+            );
+
+            let rect = chunks[1];
             match context {
                 Context::Artist {
                     top_tracks,


### PR DESCRIPTION
This pull request introduces new playback functionalities and key bindings to the Spotify player, enhancing the user experience by allowing more control over playback actions. The most important changes include adding new commands and actions for playing selected playlists and contexts, as well as updating key bindings and UI elements to support these new features.

### New Playback Functionalities:

* Added `PlayCurrentPlaylist` to `PlayerRequest` enum in `spotify_player/src/client/request.rs` to handle playing the current playlist.
* Implemented handling for `PlayCurrentPlaylist` in `Client` in `spotify_player/src/client/mod.rs`.

### New Commands and Actions:

* Added `PlaySelectedPlaylist` to `Command` enum and `PlayContext` to `Action` enum in `spotify_player/src/command.rs`. [[1]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edR83) [[2]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edR106)
* Updated action constructors to include `PlayContext` for various entities like albums, artists, playlists, and shows in `spotify_player/src/command.rs`. [[1]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edR219) [[2]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edL233-R240) [[3]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edL250-R261) [[4]](diffhunk://#diff-aaa651a1b85c3377b86aecc56c92a0ceed8bc99d8c65025356684c2eea3b55edL267-R281)

### Key Bindings and Event Handling:

* Added a key binding for `Alt+P` to play the current playlist in `spotify_player/src/event/mod.rs`.
* Implemented handling for `PlayContext` action in different contexts (album, artist, playlist, show, episode) in `spotify_player/src/event/mod.rs`. [[1]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R264-R271) [[2]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R314-R322) [[3]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R352-R360) [[4]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R393-R401) [[5]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R421-R429) [[6]](diffhunk://#diff-f440642b9f2e310f3369f009ab015f1bc6a06c64fba4a545372c67e0d55e4720R483-R498)

### UI Updates:

* Updated `render_context_page` function to include a "Play Context" button in the UI in `spotify_player/src/ui/page.rs`.
* Added a default key binding for `PlaySelectedPlaylist` in `KeymapConfig` in `spotify_player/src/config/keymap.rs`.
[Copilot is generating a summary...]