### PR TITLE
Change script shebangs, fix minor doc typeo

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -276,7 +276,7 @@ page_desc = { fg = "Cyan", modifiers = ["Bold"] }
 playlist_desc = { fg = "BrightBlack", modifiers = ["Dim"] }
 table_header = { fg = "Blue" }
 secondary_row = {}
-like = {]
+like = {}
 lyrics_played = { modifiers = ["Dim"] }
 ```
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 

--- a/scripts/theme_parse
+++ b/scripts/theme_parse
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python3
 
 import sys
 import requests


### PR DESCRIPTION
Change the shebangs in scripts to use /usr/bin/env bash/python3 for better cross-platform and python virtual environment support.

Fix a typo in the component_style example  