### PR TITLE
Add # j and # k to jump # number up and down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,65 +318,65 @@ To go to the shortcut help page, press `?` or `C-h` (default shortcuts for `Open
 
 List of supported commands:
 
-| Command                        | Description                                                       | Default shortcuts  |
-| ------------------------------ | ----------------------------------------------------------------- | ------------------ |
-| `NextTrack`                    | next track                                                        | `n`                |
-| `PreviousTrack`                | previous track                                                    | `p`                |
-| `ResumePause`                  | resume/pause based on the current playback                        | `space`            |
-| `PlayRandom`                   | play a random track in the current context                        | `.`                |
-| `Repeat`                       | cycle the repeat mode                                             | `C-r`              |
-| `ToggleFakeTrackRepeatMode`    | toggle fake track repeat mode                                     | `M-r`              |
-| `Shuffle`                      | toggle the shuffle mode                                           | `C-s`              |
-| `VolumeChange`                 | change playback volume by an offset (default shortcuts use 5%)    | `+`, `-`           |
-| `Mute`                         | toggle playback volume between 0% and previous level              | `_`                |
-| `SeekForward`                  | seek forward by 5s                                                | `>`                |
-| `SeekBackward`                 | seek backward by 5s                                               | `<`                |
-| `Quit`                         | quit the application                                              | `C-c`, `q`         |
-| `ClosePopup`                   | close a popup                                                     | `esc`              |
-| `SelectNextOrScrollDown`       | select the next item in a list/table or scroll down               | `j`, `C-n`, `down` |
-| `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up             | `k`, `C-p`, `up`   |
-| `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down   | `page_down`, `C-f` |
-| `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up | `page_up`, `C-b`   |
-| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top        | `g g`, `home`      |
-| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom      | `G`, `end`         |
-| `ChooseSelected`               | choose the selected item                                          | `enter`            |
-| `RefreshPlayback`              | manually refresh the current playback                             | `r`                |
-| `RestartIntegratedClient`      | restart the integrated client (`streaming` feature only)          | `R`                |
-| `ShowActionsOnSelectedItem`    | open a popup showing actions on a selected item                   | `g a`, `C-space`   |
-| `ShowActionsOnCurrentTrack`    | open a popup showing actions on the current track                 | `a`                |
-| `AddSelectedItemToQueue`       | add the selected item to queue                                    | `Z`, `C-z`         |
-| `FocusNextWindow`              | focus the next focusable window (if any)                          | `tab`              |
-| `FocusPreviousWindow`          | focus the previous focusable window (if any)                      | `backtab`          |
-| `SwitchTheme`                  | open a popup for switching theme                                  | `T`                |
-| `SwitchDevice`                 | open a popup for switching device                                 | `D`                |
-| `Search`                       | open a popup for searching in the current page                    | `/`                |
-| `BrowseUserPlaylists`          | open a popup for browsing user's playlists                        | `u p`              |
-| `BrowseUserFollowedArtists`    | open a popup for browsing user's followed artists                 | `u a`              |
-| `BrowseUserSavedAlbums`        | open a popup for browsing user's saved albums                     | `u A`              |
-| `CurrentlyPlayingContextPage`  | go to the currently playing context page                          | `g space`          |
-| `TopTrackPage`                 | go to the user top track page                                     | `g t`              |
-| `RecentlyPlayedTrackPage`      | go to the user recently played track page                         | `g r`              |
-| `LikedTrackPage`               | go to the user liked track page                                   | `g y`              |
-| `LyricsPage`                   | go to the lyrics page of the current track                        | `g L`, `l`         |
-| `LibraryPage`                  | go to the user library page                                       | `g l`              |
-| `SearchPage`                   | go to the search page                                             | `g s`              |
-| `BrowsePage`                   | go to the browse page                                             | `g b`              |
-| `Queue`                        | go to the queue page                                              | `z`                |
-| `OpenCommandHelp`              | go to the command help page                                       | `?`, `C-h`         |
-| `PreviousPage`                 | go to the previous page                                           | `backspace`, `C-q` |
-| `OpenSpotifyLinkFromClipboard` | open a Spotify link from clipboard                                | `O`                |
-| `SortTrackByTitle`             | sort the track table (if any) by track's title                    | `s t`              |
-| `SortTrackByArtists`           | sort the track table (if any) by track's artists                  | `s a`              |
-| `SortTrackByAlbum`             | sort the track table (if any) by track's album                    | `s A`              |
-| `SortTrackByAddedDate`         | sort the track table (if any) by track's added date               | `s D`              |
-| `SortTrackByDuration`          | sort the track table (if any) by track's duration                 | `s d`              |
-| `SortLibraryAlphabetically`    | sort the library alphabetically                                   | `s l a`            |
-| `SortLibraryByRecent`          | sort the library (playlists and albums) by recently added items   | `s l r`            |
-| `ReverseOrder`                 | reverse the order of the track table (if any)                     | `s r`              |
-| `MovePlaylistItemUp`           | move playlist item up one position                                | `C-k`              |
-| `MovePlaylistItemDown`         | move playlist item down one position                              | `C-j`              |
-| `CreatePlaylist`               | create a new playlist                                             | `N`                |
-| `JumpToCurrentTrackInContext`  | jump to the current track in the context                          | `g c`              |
+| Command                        | Description                                                       | Default shortcuts        |
+| ------------------------------ | ----------------------------------------------------------------- | ------------------------ |
+| `NextTrack`                    | next track                                                        | `n`                      |
+| `PreviousTrack`                | previous track                                                    | `p`                      |
+| `ResumePause`                  | resume/pause based on the current playback                        | `space`                  |
+| `PlayRandom`                   | play a random track in the current context                        | `.`                      |
+| `Repeat`                       | cycle the repeat mode                                             | `C-r`                    |
+| `ToggleFakeTrackRepeatMode`    | toggle fake track repeat mode                                     | `M-r`                    |
+| `Shuffle`                      | toggle the shuffle mode                                           | `C-s`                    |
+| `VolumeChange`                 | change playback volume by an offset (default shortcuts use 5%)    | `+`, `-`                 |
+| `Mute`                         | toggle playback volume between 0% and previous level              | `_`                      |
+| `SeekForward`                  | seek forward by 5s                                                | `>`                      |
+| `SeekBackward`                 | seek backward by 5s                                               | `<`                      |
+| `Quit`                         | quit the application                                              | `C-c`, `q`               |
+| `ClosePopup`                   | close a popup                                                     | `esc`                    |
+| `SelectNextOrScrollDown`       | select the next item in a list/table or scroll down               | `j`, `# j` `C-n`, `down` |
+| `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up             | `k`, `# k` `C-p`, `up`   |
+| `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down   | `page_down`, `C-f`       | 
+| `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up | `page_up`, `C-b`         | 
+| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top        | `g g`, `home`            | 
+| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom      | `G`, `end`               | 
+| `ChooseSelected`               | choose the selected item                                          | `enter`                  | 
+| `RefreshPlayback`              | manually refresh the current playback                             | `r`                      | 
+| `RestartIntegratedClient`      | restart the integrated client (`streaming` feature only)          | `R`                      | 
+| `ShowActionsOnSelectedItem`    | open a popup showing actions on a selected item                   | `g a`, `C-space`         | 
+| `ShowActionsOnCurrentTrack`    | open a popup showing actions on the current track                 | `a`                      | 
+| `AddSelectedItemToQueue`       | add the selected item to queue                                    | `Z`, `C-z`               | 
+| `FocusNextWindow`              | focus the next focusable window (if any)                          | `tab`                    | 
+| `FocusPreviousWindow`          | focus the previous focusable window (if any)                      | `backtab`                | 
+| `SwitchTheme`                  | open a popup for switching theme                                  | `T`                      | 
+| `SwitchDevice`                 | open a popup for switching device                                 | `D`                      | 
+| `Search`                       | open a popup for searching in the current page                    | `/`                      | 
+| `BrowseUserPlaylists`          | open a popup for browsing user's playlists                        | `u p`                    | 
+| `BrowseUserFollowedArtists`    | open a popup for browsing user's followed artists                 | `u a`                    | 
+| `BrowseUserSavedAlbums`        | open a popup for browsing user's saved albums                     | `u A`                    | 
+| `CurrentlyPlayingContextPage`  | go to the currently playing context page                          | `g space`                | 
+| `TopTrackPage`                 | go to the user top track page                                     | `g t`                    | 
+| `RecentlyPlayedTrackPage`      | go to the user recently played track page                         | `g r`                    | 
+| `LikedTrackPage`               | go to the user liked track page                                   | `g y`                    | 
+| `LyricsPage`                   | go to the lyrics page of the current track                        | `g L`, `l`               | 
+| `LibraryPage`                  | go to the user library page                                       | `g l`                    | 
+| `SearchPage`                   | go to the search page                                             | `g s`                    | 
+| `BrowsePage`                   | go to the browse page                                             | `g b`                    | 
+| `Queue`                        | go to the queue page                                              | `z`                      | 
+| `OpenCommandHelp`              | go to the command help page                                       | `?`, `C-h`               | 
+| `PreviousPage`                 | go to the previous page                                           | `backspace`, `C-q`       | 
+| `OpenSpotifyLinkFromClipboard` | open a Spotify link from clipboard                                | `O`                      | 
+| `SortTrackByTitle`             | sort the track table (if any) by track's title                    | `s t`                    | 
+| `SortTrackByArtists`           | sort the track table (if any) by track's artists                  | `s a`                    | 
+| `SortTrackByAlbum`             | sort the track table (if any) by track's album                    | `s A`                    | 
+| `SortTrackByAddedDate`         | sort the track table (if any) by track's added date               | `s D`                    | 
+| `SortTrackByDuration`          | sort the track table (if any) by track's duration                 | `s d`                    | 
+| `SortLibraryAlphabetically`    | sort the library alphabetically                                   | `s l a`                  | 
+| `SortLibraryByRecent`          | sort the library (playlists and albums) by recently added items   | `s l r`                  | 
+| `ReverseOrder`                 | reverse the order of the track table (if any)                     | `s r`                    | 
+| `MovePlaylistItemUp`           | move playlist item up one position                                | `C-k`                    | 
+| `MovePlaylistItemDown`         | move playlist item down one position                              | `C-j`                    | 
+| `CreatePlaylist`               | create a new playlist                                             | `N`                      | 
+| `JumpToCurrentTrackInContext`  | jump to the current track in the context                          | `g c`                    | 
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -27,8 +27,12 @@ pub enum Command {
     OpenCommandHelp,
     ClosePopup,
 
-    SelectNextOrScrollDown,
-    SelectPreviousOrScrollUp,
+    SelectNextOrScrollDown {
+        count: usize,
+    },
+    SelectPreviousOrScrollUp {
+        count: usize,
+    },
     PageSelectNextOrScrollDown,
     PageSelectPreviousOrScrollUp,
     SelectFirstOrScrollToTop,
@@ -308,8 +312,10 @@ impl Command {
             Self::ClosePopup => "close a popup",
             #[cfg(feature = "streaming")]
             Self::RestartIntegratedClient => "restart the integrated client",
-            Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down",
-            Self::SelectPreviousOrScrollUp => {
+            Self::SelectNextOrScrollDown { count: _ } => {
+                "select the next item in a list/table or scroll down"
+            }
+            Self::SelectPreviousOrScrollUp { count: _ } => {
                 "select the previous item in a list/table or scroll up"
             }
             Self::PageSelectNextOrScrollDown => {

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -32,299 +32,322 @@ pub struct ActionMap {
 
 impl Default for KeymapConfig {
     fn default() -> Self {
+        // Generate keymaps for `j` and `k` keys with a count in front
+        // i.e. 4 j -> SelectNextOrScrollDown { count: 4 }
+        fn generate_keymap_for_up_and_down() -> Vec<Keymap> {
+            let mut keymaps = vec![];
+
+            for i in 1..=9 {
+                keymaps.push(Keymap {
+                    key_sequence: format!("{i} j").as_str().into(),
+                    command: Command::SelectNextOrScrollDown { count: i },
+                });
+                keymaps.push(Keymap {
+                    key_sequence: format!("{i} k").as_str().into(),
+                    command: Command::SelectPreviousOrScrollUp { count: i },
+                });
+            }
+
+            keymaps
+        }
+
+        let mut keymaps = vec![
+            Keymap {
+                key_sequence: "n".into(),
+                command: Command::NextTrack,
+            },
+            Keymap {
+                key_sequence: "p".into(),
+                command: Command::PreviousTrack,
+            },
+            Keymap {
+                key_sequence: ".".into(),
+                command: Command::PlayRandom,
+            },
+            Keymap {
+                key_sequence: "space".into(),
+                command: Command::ResumePause,
+            },
+            Keymap {
+                key_sequence: "C-r".into(),
+                command: Command::Repeat,
+            },
+            Keymap {
+                key_sequence: "M-r".into(),
+                command: Command::ToggleFakeTrackRepeatMode,
+            },
+            Keymap {
+                key_sequence: "C-s".into(),
+                command: Command::Shuffle,
+            },
+            Keymap {
+                key_sequence: "+".into(),
+                command: Command::VolumeChange { offset: 5 },
+            },
+            Keymap {
+                key_sequence: "-".into(),
+                command: Command::VolumeChange { offset: -5 },
+            },
+            Keymap {
+                key_sequence: "_".into(),
+                command: Command::Mute,
+            },
+            Keymap {
+                key_sequence: ">".into(),
+                command: Command::SeekForward,
+            },
+            Keymap {
+                key_sequence: "<".into(),
+                command: Command::SeekBackward,
+            },
+            Keymap {
+                key_sequence: "enter".into(),
+                command: Command::ChooseSelected,
+            },
+            Keymap {
+                key_sequence: "r".into(),
+                command: Command::RefreshPlayback,
+            },
+            Keymap {
+                key_sequence: "/".into(),
+                command: Command::Search,
+            },
+            Keymap {
+                key_sequence: "z".into(),
+                command: Command::Queue,
+            },
+            Keymap {
+                key_sequence: "C-z".into(),
+                command: Command::AddSelectedItemToQueue,
+            },
+            Keymap {
+                key_sequence: "Z".into(),
+                command: Command::AddSelectedItemToQueue,
+            },
+            Keymap {
+                key_sequence: "C-space".into(),
+                command: Command::ShowActionsOnSelectedItem,
+            },
+            Keymap {
+                key_sequence: "g a".into(),
+                command: Command::ShowActionsOnSelectedItem,
+            },
+            Keymap {
+                key_sequence: "a".into(),
+                command: Command::ShowActionsOnCurrentTrack,
+            },
+            #[cfg(feature = "streaming")]
+            Keymap {
+                key_sequence: "R".into(),
+                command: Command::RestartIntegratedClient,
+            },
+            Keymap {
+                key_sequence: "tab".into(),
+                command: Command::FocusNextWindow,
+            },
+            Keymap {
+                key_sequence: "backtab".into(),
+                command: Command::FocusPreviousWindow,
+            },
+            Keymap {
+                key_sequence: "T".into(),
+                command: Command::SwitchTheme,
+            },
+            Keymap {
+                key_sequence: "D".into(),
+                command: Command::SwitchDevice,
+            },
+            Keymap {
+                key_sequence: "u p".into(),
+                command: Command::BrowseUserPlaylists,
+            },
+            Keymap {
+                key_sequence: "u a".into(),
+                command: Command::BrowseUserFollowedArtists,
+            },
+            Keymap {
+                key_sequence: "u A".into(),
+                command: Command::BrowseUserSavedAlbums,
+            },
+            Keymap {
+                key_sequence: "g space".into(),
+                command: Command::CurrentlyPlayingContextPage,
+            },
+            Keymap {
+                key_sequence: "g t".into(),
+                command: Command::TopTrackPage,
+            },
+            Keymap {
+                key_sequence: "g r".into(),
+                command: Command::RecentlyPlayedTrackPage,
+            },
+            Keymap {
+                key_sequence: "g y".into(),
+                command: Command::LikedTrackPage,
+            },
+            Keymap {
+                key_sequence: "g L".into(),
+                command: Command::LyricsPage,
+            },
+            Keymap {
+                key_sequence: "l".into(),
+                command: Command::LyricsPage,
+            },
+            Keymap {
+                key_sequence: "g l".into(),
+                command: Command::LibraryPage,
+            },
+            Keymap {
+                key_sequence: "g s".into(),
+                command: Command::SearchPage,
+            },
+            Keymap {
+                key_sequence: "g b".into(),
+                command: Command::BrowsePage,
+            },
+            Keymap {
+                key_sequence: "backspace".into(),
+                command: Command::PreviousPage,
+            },
+            Keymap {
+                key_sequence: "C-q".into(),
+                command: Command::PreviousPage,
+            },
+            Keymap {
+                key_sequence: "O".into(),
+                command: Command::OpenSpotifyLinkFromClipboard,
+            },
+            Keymap {
+                key_sequence: "?".into(),
+                command: Command::OpenCommandHelp,
+            },
+            Keymap {
+                key_sequence: "C-h".into(),
+                command: Command::OpenCommandHelp,
+            },
+            Keymap {
+                key_sequence: "q".into(),
+                command: Command::Quit,
+            },
+            Keymap {
+                key_sequence: "C-c".into(),
+                command: Command::Quit,
+            },
+            Keymap {
+                key_sequence: "esc".into(),
+                command: Command::ClosePopup,
+            },
+            Keymap {
+                key_sequence: "j".into(),
+                command: Command::SelectNextOrScrollDown { count: 1 },
+            },
+            Keymap {
+                key_sequence: "C-n".into(),
+                command: Command::SelectNextOrScrollDown { count: 1 },
+            },
+            Keymap {
+                key_sequence: "down".into(),
+                command: Command::SelectNextOrScrollDown { count: 1 },
+            },
+            Keymap {
+                key_sequence: "k".into(),
+                command: Command::SelectPreviousOrScrollUp { count: 1 },
+            },
+            Keymap {
+                key_sequence: "C-p".into(),
+                command: Command::SelectPreviousOrScrollUp { count: 1 },
+            },
+            Keymap {
+                key_sequence: "up".into(),
+                command: Command::SelectPreviousOrScrollUp { count: 1 },
+            },
+            Keymap {
+                key_sequence: "page_up".into(),
+                command: Command::PageSelectPreviousOrScrollUp,
+            },
+            Keymap {
+                key_sequence: "C-b".into(),
+                command: Command::PageSelectPreviousOrScrollUp,
+            },
+            Keymap {
+                key_sequence: "page_down".into(),
+                command: Command::PageSelectNextOrScrollDown,
+            },
+            Keymap {
+                key_sequence: "C-f".into(),
+                command: Command::PageSelectNextOrScrollDown,
+            },
+            Keymap {
+                key_sequence: "g g".into(),
+                command: Command::SelectFirstOrScrollToTop,
+            },
+            Keymap {
+                key_sequence: "home".into(),
+                command: Command::SelectFirstOrScrollToTop,
+            },
+            Keymap {
+                key_sequence: "G".into(),
+                command: Command::SelectLastOrScrollToBottom,
+            },
+            Keymap {
+                key_sequence: "end".into(),
+                command: Command::SelectLastOrScrollToBottom,
+            },
+            Keymap {
+                key_sequence: "s t".into(),
+                command: Command::SortTrackByTitle,
+            },
+            Keymap {
+                key_sequence: "s a".into(),
+                command: Command::SortTrackByArtists,
+            },
+            Keymap {
+                key_sequence: "s A".into(),
+                command: Command::SortTrackByAlbum,
+            },
+            Keymap {
+                key_sequence: "s d".into(),
+                command: Command::SortTrackByDuration,
+            },
+            Keymap {
+                key_sequence: "s D".into(),
+                command: Command::SortTrackByAddedDate,
+            },
+            Keymap {
+                key_sequence: "s r".into(),
+                command: Command::ReverseTrackOrder,
+            },
+            Keymap {
+                key_sequence: "s l a".into(),
+                command: Command::SortLibraryAlphabetically,
+            },
+            Keymap {
+                key_sequence: "s l r".into(),
+                command: Command::SortLibraryByRecent,
+            },
+            Keymap {
+                key_sequence: "C-k".into(),
+                command: Command::MovePlaylistItemUp,
+            },
+            Keymap {
+                key_sequence: "C-j".into(),
+                command: Command::MovePlaylistItemDown,
+            },
+            Keymap {
+                key_sequence: "N".into(),
+                command: Command::CreatePlaylist,
+            },
+            Keymap {
+                key_sequence: "g c".into(),
+                command: Command::JumpToCurrentTrackInContext,
+            },
+        ];
+
+        keymaps.extend(generate_keymap_for_up_and_down());
+
         KeymapConfig {
             actions: vec![],
-            keymaps: vec![
-                Keymap {
-                    key_sequence: "n".into(),
-                    command: Command::NextTrack,
-                },
-                Keymap {
-                    key_sequence: "p".into(),
-                    command: Command::PreviousTrack,
-                },
-                Keymap {
-                    key_sequence: ".".into(),
-                    command: Command::PlayRandom,
-                },
-                Keymap {
-                    key_sequence: "space".into(),
-                    command: Command::ResumePause,
-                },
-                Keymap {
-                    key_sequence: "C-r".into(),
-                    command: Command::Repeat,
-                },
-                Keymap {
-                    key_sequence: "M-r".into(),
-                    command: Command::ToggleFakeTrackRepeatMode,
-                },
-                Keymap {
-                    key_sequence: "C-s".into(),
-                    command: Command::Shuffle,
-                },
-                Keymap {
-                    key_sequence: "+".into(),
-                    command: Command::VolumeChange { offset: 5 },
-                },
-                Keymap {
-                    key_sequence: "-".into(),
-                    command: Command::VolumeChange { offset: -5 },
-                },
-                Keymap {
-                    key_sequence: "_".into(),
-                    command: Command::Mute,
-                },
-                Keymap {
-                    key_sequence: ">".into(),
-                    command: Command::SeekForward,
-                },
-                Keymap {
-                    key_sequence: "<".into(),
-                    command: Command::SeekBackward,
-                },
-                Keymap {
-                    key_sequence: "enter".into(),
-                    command: Command::ChooseSelected,
-                },
-                Keymap {
-                    key_sequence: "r".into(),
-                    command: Command::RefreshPlayback,
-                },
-                Keymap {
-                    key_sequence: "/".into(),
-                    command: Command::Search,
-                },
-                Keymap {
-                    key_sequence: "z".into(),
-                    command: Command::Queue,
-                },
-                Keymap {
-                    key_sequence: "C-z".into(),
-                    command: Command::AddSelectedItemToQueue,
-                },
-                Keymap {
-                    key_sequence: "Z".into(),
-                    command: Command::AddSelectedItemToQueue,
-                },
-                Keymap {
-                    key_sequence: "C-space".into(),
-                    command: Command::ShowActionsOnSelectedItem,
-                },
-                Keymap {
-                    key_sequence: "g a".into(),
-                    command: Command::ShowActionsOnSelectedItem,
-                },
-                Keymap {
-                    key_sequence: "a".into(),
-                    command: Command::ShowActionsOnCurrentTrack,
-                },
-                #[cfg(feature = "streaming")]
-                Keymap {
-                    key_sequence: "R".into(),
-                    command: Command::RestartIntegratedClient,
-                },
-                Keymap {
-                    key_sequence: "tab".into(),
-                    command: Command::FocusNextWindow,
-                },
-                Keymap {
-                    key_sequence: "backtab".into(),
-                    command: Command::FocusPreviousWindow,
-                },
-                Keymap {
-                    key_sequence: "T".into(),
-                    command: Command::SwitchTheme,
-                },
-                Keymap {
-                    key_sequence: "D".into(),
-                    command: Command::SwitchDevice,
-                },
-                Keymap {
-                    key_sequence: "u p".into(),
-                    command: Command::BrowseUserPlaylists,
-                },
-                Keymap {
-                    key_sequence: "u a".into(),
-                    command: Command::BrowseUserFollowedArtists,
-                },
-                Keymap {
-                    key_sequence: "u A".into(),
-                    command: Command::BrowseUserSavedAlbums,
-                },
-                Keymap {
-                    key_sequence: "g space".into(),
-                    command: Command::CurrentlyPlayingContextPage,
-                },
-                Keymap {
-                    key_sequence: "g t".into(),
-                    command: Command::TopTrackPage,
-                },
-                Keymap {
-                    key_sequence: "g r".into(),
-                    command: Command::RecentlyPlayedTrackPage,
-                },
-                Keymap {
-                    key_sequence: "g y".into(),
-                    command: Command::LikedTrackPage,
-                },
-                Keymap {
-                    key_sequence: "g L".into(),
-                    command: Command::LyricsPage,
-                },
-                Keymap {
-                    key_sequence: "l".into(),
-                    command: Command::LyricsPage,
-                },
-                Keymap {
-                    key_sequence: "g l".into(),
-                    command: Command::LibraryPage,
-                },
-                Keymap {
-                    key_sequence: "g s".into(),
-                    command: Command::SearchPage,
-                },
-                Keymap {
-                    key_sequence: "g b".into(),
-                    command: Command::BrowsePage,
-                },
-                Keymap {
-                    key_sequence: "backspace".into(),
-                    command: Command::PreviousPage,
-                },
-                Keymap {
-                    key_sequence: "C-q".into(),
-                    command: Command::PreviousPage,
-                },
-                Keymap {
-                    key_sequence: "O".into(),
-                    command: Command::OpenSpotifyLinkFromClipboard,
-                },
-                Keymap {
-                    key_sequence: "?".into(),
-                    command: Command::OpenCommandHelp,
-                },
-                Keymap {
-                    key_sequence: "C-h".into(),
-                    command: Command::OpenCommandHelp,
-                },
-                Keymap {
-                    key_sequence: "q".into(),
-                    command: Command::Quit,
-                },
-                Keymap {
-                    key_sequence: "C-c".into(),
-                    command: Command::Quit,
-                },
-                Keymap {
-                    key_sequence: "esc".into(),
-                    command: Command::ClosePopup,
-                },
-                Keymap {
-                    key_sequence: "j".into(),
-                    command: Command::SelectNextOrScrollDown,
-                },
-                Keymap {
-                    key_sequence: "C-n".into(),
-                    command: Command::SelectNextOrScrollDown,
-                },
-                Keymap {
-                    key_sequence: "down".into(),
-                    command: Command::SelectNextOrScrollDown,
-                },
-                Keymap {
-                    key_sequence: "k".into(),
-                    command: Command::SelectPreviousOrScrollUp,
-                },
-                Keymap {
-                    key_sequence: "C-p".into(),
-                    command: Command::SelectPreviousOrScrollUp,
-                },
-                Keymap {
-                    key_sequence: "up".into(),
-                    command: Command::SelectPreviousOrScrollUp,
-                },
-                Keymap {
-                    key_sequence: "page_up".into(),
-                    command: Command::PageSelectPreviousOrScrollUp,
-                },
-                Keymap {
-                    key_sequence: "C-b".into(),
-                    command: Command::PageSelectPreviousOrScrollUp,
-                },
-                Keymap {
-                    key_sequence: "page_down".into(),
-                    command: Command::PageSelectNextOrScrollDown,
-                },
-                Keymap {
-                    key_sequence: "C-f".into(),
-                    command: Command::PageSelectNextOrScrollDown,
-                },
-                Keymap {
-                    key_sequence: "g g".into(),
-                    command: Command::SelectFirstOrScrollToTop,
-                },
-                Keymap {
-                    key_sequence: "home".into(),
-                    command: Command::SelectFirstOrScrollToTop,
-                },
-                Keymap {
-                    key_sequence: "G".into(),
-                    command: Command::SelectLastOrScrollToBottom,
-                },
-                Keymap {
-                    key_sequence: "end".into(),
-                    command: Command::SelectLastOrScrollToBottom,
-                },
-                Keymap {
-                    key_sequence: "s t".into(),
-                    command: Command::SortTrackByTitle,
-                },
-                Keymap {
-                    key_sequence: "s a".into(),
-                    command: Command::SortTrackByArtists,
-                },
-                Keymap {
-                    key_sequence: "s A".into(),
-                    command: Command::SortTrackByAlbum,
-                },
-                Keymap {
-                    key_sequence: "s d".into(),
-                    command: Command::SortTrackByDuration,
-                },
-                Keymap {
-                    key_sequence: "s D".into(),
-                    command: Command::SortTrackByAddedDate,
-                },
-                Keymap {
-                    key_sequence: "s r".into(),
-                    command: Command::ReverseTrackOrder,
-                },
-                Keymap {
-                    key_sequence: "s l a".into(),
-                    command: Command::SortLibraryAlphabetically,
-                },
-                Keymap {
-                    key_sequence: "s l r".into(),
-                    command: Command::SortLibraryByRecent,
-                },
-                Keymap {
-                    key_sequence: "C-k".into(),
-                    command: Command::MovePlaylistItemUp,
-                },
-                Keymap {
-                    key_sequence: "C-j".into(),
-                    command: Command::MovePlaylistItemDown,
-                },
-                Keymap {
-                    key_sequence: "N".into(),
-                    command: Command::CreatePlaylist,
-                },
-                Keymap {
-                    key_sequence: "g c".into(),
-                    command: Command::JumpToCurrentTrackInContext,
-                },
-            ],
+            keymaps,
         }
     }
 }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -501,15 +501,15 @@ pub fn handle_navigation_command(
 
     let configs = config::get_config();
     match command {
-        Command::SelectNextOrScrollDown => {
-            if id + 1 < len {
-                page.select(id + 1);
+        Command::SelectNextOrScrollDown { count } => {
+            if id + count < len {
+                page.select(id + count);
             }
             true
         }
-        Command::SelectPreviousOrScrollUp => {
-            if id > 0 {
-                page.select(id - 1);
+        Command::SelectPreviousOrScrollUp { count } => {
+            if id - count > 0 {
+                page.select(id - count);
             }
             true
         }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -436,16 +436,20 @@ fn handle_command_for_list_popup(
     let current_id = popup.list_selected().unwrap_or_default();
 
     match command {
-        Command::SelectPreviousOrScrollUp => {
-            if current_id > 0 {
-                popup.list_select(Some(current_id - 1));
-                on_select_func(ui, current_id - 1);
+        Command::SelectPreviousOrScrollUp { count } => {
+            let step = count.min(current_id);
+            if step > 0 {
+                let new_id = current_id - step;
+                popup.list_select(Some(new_id));
+                on_select_func(ui, new_id);
             }
         }
-        Command::SelectNextOrScrollDown => {
-            if current_id + 1 < n_items {
-                popup.list_select(Some(current_id + 1));
-                on_select_func(ui, current_id + 1);
+        Command::SelectNextOrScrollDown { count } => {
+            let step = count.min(n_items.saturating_sub(current_id + 1));
+            if step > 0 {
+                let new_id = current_id + step;
+                popup.list_select(Some(new_id));
+                on_select_func(ui, new_id)
             }
         }
         Command::ChooseSelected => {


### PR DESCRIPTION
This pull request adds the ability to mimic vim's j & k commands. 

Now we you can do `[1-9] j` or `[1-9] k` to move up or down that many lines. 

i.e. you can `4 j` to go down 4 lines. or `3 k` to go up 3 lines. 
