### PR TITLE
ci: fix ci failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5251,7 +5251,6 @@ dependencies = [
  "log",
  "maybe-async",
  "notify-rust",
- "once_cell",
  "parking_lot",
  "rand 0.9.0",
  "ratatui",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -48,7 +48,6 @@ notify-rust = { version = "4.11.6", optional = true, default-features = false, f
 ] }
 flume = "0.11.1"
 serde_json = "1.0.140"
-once_cell = "1.21.3"
 regex = "1.11.1"
 daemonize = { version = "0.5.0", optional = true }
 ttl_cache = "0.5.1"

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    fmt::Write as _,
     fs::{create_dir_all, remove_dir_all},
     io::Write,
     net::SocketAddr,
@@ -511,7 +512,7 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
 
             let mut out = String::new();
             for pl in resp {
-                out += &format!("{}: {}\n", pl.id.id(), pl.name);
+                writeln!(out, "{}: {}", pl.id.id(), pl.name).unwrap();
             }
             out = out.trim().to_string();
 
@@ -587,10 +588,7 @@ async fn handle_playlist_request(client: &Client, command: PlaylistCommand) -> R
                     }
                 } else {
                     remove_dir_all(&to_dir)?;
-                    result += &format!(
-                        "Not following playlist '{}'. Deleted its import data in the cache folder...\n",
-                        to_id.id()
-                    );
+                    writeln!(result, "Not following playlist '{}'. Deleted its import data in the cache folder...", to_id.id()).unwrap();
                 }
             }
 
@@ -656,13 +654,15 @@ async fn playlist_import(
     let mut new_tracks_hash_set = &from_hash_set - &to_hash_set;
 
     let mut result = String::new();
-    result += &format!(
-        "Importing from {}:{} to {}:{}...\n",
+    writeln!(
+        result,
+        "Importing from {}:{} to {}:{}...",
         import_from.id(),
         from_name,
         import_to.id(),
         to_name
-    );
+    )
+    .unwrap();
 
     let mut track_buff = Vec::new();
     if from_file.exists() {
@@ -700,17 +700,21 @@ async fn playlist_import(
                     .playlist_remove_all_occurrences_of_items(import_to.as_ref(), track_buff, None)
                     .await?;
             }
-            result += &format!("Tracks deleted from {from_name}: \n");
+            writeln!(result, "Tracks deleted from {from_name}: \n").unwrap();
         } else {
-            result += &format!("Tracks that are no longer in {from_name} since last import: \n");
+            writeln!(
+                result,
+                "Tracks that are no longer in {from_name} since last import: "
+            )
+            .unwrap();
         }
 
         for t in &deleted_hash_set {
-            result += &format!("    {}: {}\n", t.id.id(), t.name);
+            writeln!(result, "    {}: {}", t.id.id(), t.name).unwrap();
         }
     }
 
-    result += &format!("New tracks imported to {to_name}: \n");
+    writeln!(result, "New tracks imported to {to_name}: ").unwrap();
 
     track_buff = Vec::new();
     for t in &new_tracks_hash_set {
@@ -723,7 +727,7 @@ async fn playlist_import(
             track_buff = Vec::new();
         }
 
-        result += &format!("    {}: {}\n", t.id.id(), t.name);
+        writeln!(result, "    {}: {}", t.id.id(), t.name).unwrap();
     }
 
     if !track_buff.is_empty() {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -301,7 +301,7 @@ impl Client {
             PlayerRequest::TransferPlayback(..) => {
                 anyhow::bail!("`TransferPlayback` should be handled earlier")
             }
-        };
+        }
 
         Ok(Some(playback))
     }
@@ -592,7 +592,7 @@ impl Client {
                 )
                 .await?;
             }
-        };
+        }
 
         tracing::info!(
             "Successfully handled the client request, took: {}ms",
@@ -1768,7 +1768,7 @@ impl Client {
                             text += &episode.show.name;
                         }
                     },
-                    _ => continue,
+                    &_ => {}
                 }
             }
             if ptr < format_str.len() {

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -509,7 +509,7 @@ fn handle_global_action(
                 }
             }
         }
-    };
+    }
 
     Ok(false)
 }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -425,42 +425,40 @@ fn handle_command_for_browse_page(
         return Ok(true);
     }
     match command {
-        Command::ChooseSelected => {
-            match page_state {
-                PageState::Browse { state } => match state {
-                    BrowsePageUIState::CategoryList { .. } => {
-                        let categories = ui.search_filtered_items(&data.browse.categories);
-                        client_pub.send(ClientRequest::GetBrowseCategoryPlaylists(
-                            categories[selected].clone(),
-                        ))?;
-                        ui.new_page(PageState::Browse {
-                            state: BrowsePageUIState::CategoryPlaylistList {
-                                category: categories[selected].clone(),
-                                state: ListState::default(),
-                            },
-                        });
-                    }
-                    BrowsePageUIState::CategoryPlaylistList { category, .. } => {
-                        let playlists =
-                            data.browse
-                                .category_playlists
-                                .get(&category.id)
-                                .context(format!(
-                                    "expect to have playlists data for {category} category"
-                                ))?;
-                        let context_id = ContextId::Playlist(
-                            ui.search_filtered_items(playlists)[selected].id.clone(),
-                        );
-                        ui.new_page(PageState::Context {
-                            id: None,
-                            context_page_type: ContextPageType::Browsing(context_id),
-                            state: None,
-                        });
-                    }
-                },
-                _ => anyhow::bail!("expect a browse page state"),
-            };
-        }
+        Command::ChooseSelected => match page_state {
+            PageState::Browse { state } => match state {
+                BrowsePageUIState::CategoryList { .. } => {
+                    let categories = ui.search_filtered_items(&data.browse.categories);
+                    client_pub.send(ClientRequest::GetBrowseCategoryPlaylists(
+                        categories[selected].clone(),
+                    ))?;
+                    ui.new_page(PageState::Browse {
+                        state: BrowsePageUIState::CategoryPlaylistList {
+                            category: categories[selected].clone(),
+                            state: ListState::default(),
+                        },
+                    });
+                }
+                BrowsePageUIState::CategoryPlaylistList { category, .. } => {
+                    let playlists =
+                        data.browse
+                            .category_playlists
+                            .get(&category.id)
+                            .context(format!(
+                                "expect to have playlists data for {category} category"
+                            ))?;
+                    let context_id = ContextId::Playlist(
+                        ui.search_filtered_items(playlists)[selected].id.clone(),
+                    );
+                    ui.new_page(PageState::Context {
+                        id: None,
+                        context_page_type: ContextPageType::Browsing(context_id),
+                        state: None,
+                    });
+                }
+            },
+            _ => anyhow::bail!("expect a browse page state"),
+        },
         Command::Search => {
             ui.new_search_popup();
         }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -457,7 +457,7 @@ fn handle_command_for_list_popup(
             on_close_func(ui);
         }
         _ => return Ok(false),
-    };
+    }
     Ok(true)
 }
 

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -238,7 +238,7 @@ fn handle_playlist_modify_command(
                     snapshot_id: None,
                 })?;
                 ui.current_page_mut().select(id + 1);
-            };
+            }
             return Ok(true);
         }
         Command::ShowActionsOnSelectedItem => {
@@ -480,7 +480,7 @@ pub fn handle_command_for_playlist_list_window(
                             state.playlist_folder_id = f.target_id;
                         }
                         _ => return false,
-                    };
+                    }
                 }
                 PlaylistFolderItem::Playlist(p) => {
                     let context_id = ContextId::Playlist(p.id.clone());

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -60,7 +60,7 @@ fn update_control_metadata(
                         *prev_info = episode_info;
                     }
                 }
-            };
+            }
         }
     }
 

--- a/spotify_player/src/state/constant.rs
+++ b/spotify_player/src/state/constant.rs
@@ -1,15 +1,15 @@
 pub use super::*;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static USER_TOP_TRACKS_ID: Lazy<TracksId> =
-    Lazy::new(|| TracksId::new("tracks:user-top-tracks", "Top Tracks"));
+pub static USER_TOP_TRACKS_ID: LazyLock<TracksId> =
+    LazyLock::new(|| TracksId::new("tracks:user-top-tracks", "Top Tracks"));
 
-pub static USER_RECENTLY_PLAYED_TRACKS_ID: Lazy<TracksId> = Lazy::new(|| {
+pub static USER_RECENTLY_PLAYED_TRACKS_ID: LazyLock<TracksId> = LazyLock::new(|| {
     TracksId::new(
         "tracks:user-recently-played-tracks",
         "Recently Played Tracks",
     )
 });
 
-pub static USER_LIKED_TRACKS_ID: Lazy<TracksId> =
-    Lazy::new(|| TracksId::new("tracks:user-liked-tracks", "Liked Tracks"));
+pub static USER_LIKED_TRACKS_ID: LazyLock<TracksId> =
+    LazyLock::new(|| TracksId::new("tracks:user-liked-tracks", "Liked Tracks"));

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -1,8 +1,8 @@
 use std::io::{BufReader, BufWriter};
 use std::{collections::HashMap, path::Path};
 
-use once_cell::sync::Lazy;
 use serde::{de::DeserializeOwned, Serialize};
+use std::sync::LazyLock;
 
 use super::model::{
     Album, Artist, Category, Context, ContextId, Id, Playlist, PlaylistFolderItem,
@@ -23,8 +23,8 @@ pub enum FileCacheKey {
 }
 
 /// default time-to-live cache duration
-pub static TTL_CACHE_DURATION: Lazy<std::time::Duration> =
-    Lazy::new(|| std::time::Duration::from_secs(60 * 60));
+pub static TTL_CACHE_DURATION: LazyLock<std::time::Duration> =
+    LazyLock::new(|| std::time::Duration::from_secs(60 * 60));
 
 /// the application's data
 pub struct AppData {


### PR DESCRIPTION
Minor changes to make CI pass.

This also removes the need for `once_cel`as a dependency. (At least a direct one)