### PR TITLE
recommend official Arch package instead of AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Run `scoop install spotify-player` to install the application.
 
 Run `cargo install spotify_player --locked` to install the application from [crates.io](https://crates.io/crates/spotify_player).
 
-### AUR
+### Arch Linux
 
-Run `yay -S spotify-player` to install the application as an AUR package.
+Run `pacman -S spotify-player` to install the application.
 
 Alternatively, run `yay -S spotify-player-full` to install an AUR package compiled with full feature support and Pulseaudio/Pipewire instead of rodio.
 


### PR DESCRIPTION
An official Arch package has been available since 2025-02-05. Since this is the simplest way to install packages on Arch, it makes sense for most users to prefer this over the AUR packages. The AUR package that is currently recommended in the documentation is also no longer available because of the adoption in the official repositories.