### PR TITLE
feat: add {liked} option to playback_format

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,39 +23,39 @@ All configuration files should be placed inside the application's configuration 
 
 `spotify_player` uses `app.toml` to configure general application configurations:
 
-| Option                            | Description                                                                              | Default                                                 |
-| --------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                      |
-| `client_id_command`               | a shell command that prints the Spotify client ID to stdout (overrides `client_id`)      | `None`                                                  |
-| `login_redirect_uri`              | the redirect URI for authenticating the application                                      | `http://127.0.0.1:8989/login`                           |
-| `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                  |
-| `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                    |
-| `playback_format`                 | the format of the text in the playback's window                                          | `{status} {track} • {artists}\n{album}\n{metadata}`     |
-| `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }` |
-| `notify_timeout_in_secs`          | the timeout (in seconds) of a notification (`notify` feature only)                       | `0` (no timeout)                                        |
-| `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                  |
-| `ap_port`                         | the application's Spotify session connection port                                        | `None`                                                  |
-| `proxy`                           | the application's Spotify session connection proxy                                       | `None`                                                  |
-| `theme`                           | the application's theme                                                                  | `default`                                               |
-| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes                       | `32`                                                    |
-| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                     |
-| `page_size_in_rows`               | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                    |
-| `enable_media_control`            | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)             |
-| `enable_streaming`                | enable streaming (`streaming` feature only)                                              | `Always`                                                |
-| `enable_notify`                   | enable notification (`notify` feature only)                                              | `true`                                                  |
-| `enable_cover_image_cache`        | store album's cover images in the cache folder                                           | `true`                                                  |
-| `notify_streaming_only`           | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                 |
-| `default_device`                  | the default device to connect to on startup if no playing device found                   | `spotify-player`                                        |
-| `play_icon`                       | the icon to indicate playing state of a Spotify item                                     | `▶`                                                    |
-| `pause_icon`                      | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                    |
-| `liked_icon`                      | the icon to indicate the liked state of a song                                           | `♥`                                                    |
-| `border_type`                     | the type of the application's borders                                                    | `Plain`                                                 |
-| `progress_bar_type`               | the type of the playback progress bar                                                    | `Rectangle`                                             |
-| `cover_img_width`                 | the width of the cover image (`image` feature only)                                      | `5`                                                     |
-| `cover_img_length`                | the length of the cover image (`image` feature only)                                     | `9`                                                     |
-| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                      | `1.0`                                                   |
-| `seek_duration_secs`              | the duration (in seconds) to seek when using `SeekForward` and `SeekBackward` commands   | `5`                                                     |
-| `sort_artist_albums_by_type`      | sort albums on artist's pages by type, i.e. album or single                              | `false`                                                 |
+| Option                            | Description                                                                              | Default                                                     |
+| --------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `client_id`                       | the Spotify client's ID                                                                  | `65b708073fc0480ea92a077233ca87bd`                          |
+| `client_id_command`               | a shell command that prints the Spotify client ID to stdout (overrides `client_id`)      | `None`                                                      |
+| `login_redirect_uri`              | the redirect URI for authenticating the application                                      | `http://127.0.0.1:8989/login`                               |
+| `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                      |
+| `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                        |
+| `playback_format`                 | the format of the text in the playback's window                                          | `{status} {track} • {artists} {liked}\n{album}\n{metadata}` |
+| `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }`     |
+| `notify_timeout_in_secs`          | the timeout (in seconds) of a notification (`notify` feature only)                       | `0` (no timeout)                                            |
+| `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                      |
+| `ap_port`                         | the application's Spotify session connection port                                        | `None`                                                      |
+| `proxy`                           | the application's Spotify session connection proxy                                       | `None`                                                      |
+| `theme`                           | the application's theme                                                                  | `default`                                                   |
+| `app_refresh_duration_in_ms`      | the duration (in ms) between two consecutive application refreshes                       | `32`                                                        |
+| `playback_refresh_duration_in_ms` | the duration (in ms) between two consecutive playback refreshes                          | `0`                                                         |
+| `page_size_in_rows`               | a page's size expressed as a number of rows (for page-navigation commands)               | `20`                                                        |
+| `enable_media_control`            | enable application media control support (`media-control` feature only)                  | `true` (Linux), `false` (Windows and MacOS)                 |
+| `enable_streaming`                | enable streaming (`streaming` feature only)                                              | `Always`                                                    |
+| `enable_notify`                   | enable notification (`notify` feature only)                                              | `true`                                                      |
+| `enable_cover_image_cache`        | store album's cover images in the cache folder                                           | `true`                                                      |
+| `notify_streaming_only`           | only send notification when streaming is enabled (`streaming` and `notify` feature only) | `false`                                                     |
+| `default_device`                  | the default device to connect to on startup if no playing device found                   | `spotify-player`                                            |
+| `play_icon`                       | the icon to indicate playing state of a Spotify item                                     | `▶`                                                         |
+| `pause_icon`                      | the icon to indicate pause state of a Spotify item                                       | `▌▌`                                                        |
+| `liked_icon`                      | the icon to indicate the liked state of a song                                           | `♥`                                                         |
+| `border_type`                     | the type of the application's borders                                                    | `Plain`                                                     |
+| `progress_bar_type`               | the type of the playback progress bar                                                    | `Rectangle`                                                 |
+| `cover_img_width`                 | the width of the cover image (`image` feature only)                                      | `5`                                                         |
+| `cover_img_length`                | the length of the cover image (`image` feature only)                                     | `9`                                                         |
+| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                      | `1.0`                                                       |
+| `seek_duration_secs`              | the duration (in seconds) to seek when using `SeekForward` and `SeekBackward` commands   | `5`                                                         |
+| `sort_artist_albums_by_type`      | sort albums on artist's pages by type, i.e. album or single                              | `false`                                                     |
 
 ### Notes
 

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -265,7 +265,9 @@ impl Default for AppConfig {
 
             tracks_playback_limit: 50,
 
-            playback_format: String::from("{status} {track} • {artists} {liked}\n{album}\n{metadata}"),
+            playback_format: String::from(
+                "{status} {track} • {artists} {liked}\n{album}\n{metadata}",
+            ),
             #[cfg(feature = "notify")]
             notify_format: NotifyFormat {
                 summary: String::from("{track} • {artists}"),

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -265,7 +265,7 @@ impl Default for AppConfig {
 
             tracks_playback_limit: 50,
 
-            playback_format: String::from("{status} {track} • {artists}\n{album}\n{metadata}"),
+            playback_format: String::from("{status} {track} • {artists} {liked}\n{album}\n{metadata}"),
             #[cfg(feature = "notify")]
             notify_format: NotifyFormat {
                 summary: String::from("{track} • {artists}"),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -235,7 +235,7 @@ fn construct_playback_text(
                 rspotify::model::PlayableItem::Track(track) => match &track.id {
                     Some(id) => {
                         if data.user_data.saved_tracks.contains_key(&id.uri()) {
-                            ((&configs.app_config.liked_icon).to_owned(), ui.theme.like())
+                            (configs.app_config.liked_icon.clone(), ui.theme.like())
                         } else {
                             continue;
                         }

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -2,6 +2,7 @@
 use crate::state::ImageRenderInfo;
 #[cfg(feature = "image")]
 use anyhow::{Context, Result};
+use rspotify::model::Id;
 
 use super::{
     config, utils::construct_and_render_block, Borders, Constraint, Frame, Gauge, Layout, Line,
@@ -126,7 +127,7 @@ pub fn render_playback_window(
             };
 
             if let Some(ref playback) = player.buffered_playback {
-                let playback_text = construct_playback_text(ui, item, playback);
+                let playback_text = construct_playback_text(ui, state, item, playback);
                 let playback_desc = Paragraph::new(playback_text);
                 frame.render_widget(playback_desc, metadata_rect);
             }
@@ -188,6 +189,7 @@ fn clear_area(frame: &mut Frame, rect: Rect, theme: &config::Theme) {
 
 fn construct_playback_text(
     ui: &UIStateGuard,
+    state: &SharedState,
     playable: &rspotify::model::PlayableItem,
     playback: &PlaybackMetadata,
 ) -> Text<'static> {
@@ -195,6 +197,7 @@ fn construct_playback_text(
     // based on a user-configurable format string (app_config.playback_format)
     let configs = config::get_config();
     let format_str = &configs.app_config.playback_format;
+    let data = state.data.read();
 
     let mut playback_text = Text::default();
     let mut spans = vec![];
@@ -228,6 +231,19 @@ fn construct_playback_text(
                 .to_owned(),
                 ui.theme.playback_status(),
             ),
+            "{liked}" => match playable {
+                rspotify::model::PlayableItem::Track(track) => match &track.id {
+                    Some(id) => {
+                        if data.user_data.saved_tracks.contains_key(&id.uri()) {
+                            ((&configs.app_config.liked_icon).to_owned(), ui.theme.like())
+                        } else {
+                            continue;
+                        }
+                    }
+                    None => continue,
+                },
+                rspotify::model::PlayableItem::Episode(_) => continue,
+            },
             "{track}" => match playable {
                 rspotify::model::PlayableItem::Track(track) => (
                     if track.explicit {


### PR DESCRIPTION
Closes https://github.com/aome510/spotify-player/issues/714
Per default I have added the {liked} option after the artist in the first line.