### PR TITLE
fix: add reqwest missing feature to run lyric finder example

### DIFF
--- a/lyric_finder/Cargo.toml
+++ b/lyric_finder/Cargo.toml
@@ -14,7 +14,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 
 [dependencies]
-reqwest = { version = "0.12.15", features = ["json", "native-tls-alpn"], default-features = false }
+reqwest = { version = "0.12.15", features = ["json", "native-tls-alpn", "http2"], default-features = false }
 anyhow = "1.0.98"
 serde = { version = "1.0.219", features = ["derive"] }
 html5ever = "=0.27.0"


### PR DESCRIPTION
This PR adds the "http2" feature to the reqwest dependency in the lyric finder example.

Without this feature, the example might fail to run correctly in some environments.

- Updated Cargo.toml to include `features = ["json", "native-tls-alpn", "http2"]`

This should improve compatibility and fix potential local runtime issues related to HTTP/2 support.
