### PR TITLE
docs: add rhel/fedora systems dependencies documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ A Spotify Premium account is **required**.
     ```shell
     sudo apt install libssl-dev libasound2-dev libdbus-1-dev
     ```
+  - On RHEL/Fedora based systems, run the below command to install application's dependencies :
+
+    ```shell
+    sudo dnf install openssl-devel alsa-lib-devel dbus-devel
+    ```
+    or if you're using `yum`:
+    ```shell
+    sudo yum install openssl-devel alsa-lib-devel dbus-devel
+    ```
 
 ### Binaries
 


### PR DESCRIPTION
This PR adds commands to the documentation for installing the necessary dependencies on RHEL/Fedora-based systems using the `yum` or `dnf` package managers.