### PR TITLE
feat: add currently playing lyric highlight

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -245,6 +245,7 @@ To define application's component styles, the user can specify any of the below 
 - `secondary_row`
 - `like`
 - `lyrics_played`
+- `lyrics_playing`
 
 A field in `component_style` is a struct with three **optional** fields: `fg` (foreground), `bg` (background) and `modifiers` (terminal effects):
 
@@ -278,6 +279,7 @@ table_header = { fg = "Blue" }
 secondary_row = {}
 like = {}
 lyrics_played = { modifiers = ["Dim"] }
+lyrics_playing = { fg = "Green", modifiers = ["Bold"] }
 ```
 
 ## Keymaps

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -79,6 +79,7 @@ struct ComponentStyle {
     secondary_row: Option<Style>,
     like: Option<Style>,
     lyrics_played: Option<Style>,
+    lyrics_playing: Option<Style>,
 }
 
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -345,6 +346,18 @@ impl Theme {
             .lyrics_played
             .as_ref()
             .unwrap_or(&Style::default().modifiers([StyleModifier::Dim]))
+            .style(&self.palette)
+    }
+
+    pub fn lyrics_playing(&self) -> style::Style {
+        self.component_style
+            .lyrics_playing
+            .as_ref()
+            .unwrap_or(
+                &Style::default()
+                    .fg(StyleColor::Green)
+                    .modifiers([StyleModifier::Bold]),
+            )
             .style(&self.palette)
     }
 }

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     collections::{btree_map::Entry, BTreeMap},
     fmt::Display,
 };
@@ -610,12 +611,10 @@ pub fn render_lyrics_page(
         .lines
         .iter()
         .enumerate()
-        .map(|(id, (_, line))| {
-            if id < last_played_line_id {
-                Line::styled(line, ui.theme.lyrics_played())
-            } else {
-                Line::raw(line)
-            }
+        .map(|(id, (_, line))| match (id + 1).cmp(&last_played_line_id) {
+            Ordering::Equal => Line::styled(line, ui.theme.lyrics_playing()),
+            Ordering::Less => Line::styled(line, ui.theme.lyrics_played()),
+            Ordering::Greater => Line::raw(line),
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
I found it a little confusing the first time I opened the Lyrics panel and the currently playing lyric is dimmed.
I added a highlight for the current playing lyric

<img width="778" alt="Screenshot 2025-05-24 at 20 15 46" src="https://github.com/user-attachments/assets/f0b93f14-ef3f-4a50-8370-59e8fc8e5079" />
