### PR TITLE
Add support for vim like motions, i.e. 5j 8k, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,65 +318,65 @@ To go to the shortcut help page, press `?` or `C-h` (default shortcuts for `Open
 
 List of supported commands:
 
-| Command                        | Description                                                       | Default shortcuts  |
-| ------------------------------ | ----------------------------------------------------------------- | ------------------ |
-| `NextTrack`                    | next track                                                        | `n`                |
-| `PreviousTrack`                | previous track                                                    | `p`                |
-| `ResumePause`                  | resume/pause based on the current playback                        | `space`            |
-| `PlayRandom`                   | play a random track in the current context                        | `.`                |
-| `Repeat`                       | cycle the repeat mode                                             | `C-r`              |
-| `ToggleFakeTrackRepeatMode`    | toggle fake track repeat mode                                     | `M-r`              |
-| `Shuffle`                      | toggle the shuffle mode                                           | `C-s`              |
-| `VolumeChange`                 | change playback volume by an offset (default shortcuts use 5%)    | `+`, `-`           |
-| `Mute`                         | toggle playback volume between 0% and previous level              | `_`                |
-| `SeekForward`                  | seek forward by 5s                                                | `>`                |
-| `SeekBackward`                 | seek backward by 5s                                               | `<`                |
-| `Quit`                         | quit the application                                              | `C-c`, `q`         |
-| `ClosePopup`                   | close a popup                                                     | `esc`              |
-| `SelectNextOrScrollDown`       | select the next item in a list/table or scroll down               | `j`, `C-n`, `down` |
-| `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up             | `k`, `C-p`, `up`   |
-| `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down   | `page_down`, `C-f` |
-| `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up | `page_up`, `C-b`   |
-| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top        | `g g`, `home`      |
-| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom      | `G`, `end`         |
-| `ChooseSelected`               | choose the selected item                                          | `enter`            |
-| `RefreshPlayback`              | manually refresh the current playback                             | `r`                |
-| `RestartIntegratedClient`      | restart the integrated client (`streaming` feature only)          | `R`                |
-| `ShowActionsOnSelectedItem`    | open a popup showing actions on a selected item                   | `g a`, `C-space`   |
-| `ShowActionsOnCurrentTrack`    | open a popup showing actions on the current track                 | `a`                |
-| `AddSelectedItemToQueue`       | add the selected item to queue                                    | `Z`, `C-z`         |
-| `FocusNextWindow`              | focus the next focusable window (if any)                          | `tab`              |
-| `FocusPreviousWindow`          | focus the previous focusable window (if any)                      | `backtab`          |
-| `SwitchTheme`                  | open a popup for switching theme                                  | `T`                |
-| `SwitchDevice`                 | open a popup for switching device                                 | `D`                |
-| `Search`                       | open a popup for searching in the current page                    | `/`                |
-| `BrowseUserPlaylists`          | open a popup for browsing user's playlists                        | `u p`              |
-| `BrowseUserFollowedArtists`    | open a popup for browsing user's followed artists                 | `u a`              |
-| `BrowseUserSavedAlbums`        | open a popup for browsing user's saved albums                     | `u A`              |
-| `CurrentlyPlayingContextPage`  | go to the currently playing context page                          | `g space`          |
-| `TopTrackPage`                 | go to the user top track page                                     | `g t`              |
-| `RecentlyPlayedTrackPage`      | go to the user recently played track page                         | `g r`              |
-| `LikedTrackPage`               | go to the user liked track page                                   | `g y`              |
-| `LyricsPage`                   | go to the lyrics page of the current track                        | `g L`, `l`         |
-| `LibraryPage`                  | go to the user library page                                       | `g l`              |
-| `SearchPage`                   | go to the search page                                             | `g s`              |
-| `BrowsePage`                   | go to the browse page                                             | `g b`              |
-| `Queue`                        | go to the queue page                                              | `z`                |
-| `OpenCommandHelp`              | go to the command help page                                       | `?`, `C-h`         |
-| `PreviousPage`                 | go to the previous page                                           | `backspace`, `C-q` |
-| `OpenSpotifyLinkFromClipboard` | open a Spotify link from clipboard                                | `O`                |
-| `SortTrackByTitle`             | sort the track table (if any) by track's title                    | `s t`              |
-| `SortTrackByArtists`           | sort the track table (if any) by track's artists                  | `s a`              |
-| `SortTrackByAlbum`             | sort the track table (if any) by track's album                    | `s A`              |
-| `SortTrackByAddedDate`         | sort the track table (if any) by track's added date               | `s D`              |
-| `SortTrackByDuration`          | sort the track table (if any) by track's duration                 | `s d`              |
-| `SortLibraryAlphabetically`    | sort the library alphabetically                                   | `s l a`            |
-| `SortLibraryByRecent`          | sort the library (playlists and albums) by recently added items   | `s l r`            |
-| `ReverseOrder`                 | reverse the order of the track table (if any)                     | `s r`              |
-| `MovePlaylistItemUp`           | move playlist item up one position                                | `C-k`              |
-| `MovePlaylistItemDown`         | move playlist item down one position                              | `C-j`              |
-| `CreatePlaylist`               | create a new playlist                                             | `N`                |
-| `JumpToCurrentTrackInContext`  | jump to the current track in the context                          | `g c`              |
+| Command                        | Description                                                                                        | Default shortcuts  |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------ |
+| `NextTrack`                    | next track                                                                                         | `n`                |
+| `PreviousTrack`                | previous track                                                                                     | `p`                |
+| `ResumePause`                  | resume/pause based on the current playback                                                         | `space`            |
+| `PlayRandom`                   | play a random track in the current context                                                         | `.`                |
+| `Repeat`                       | cycle the repeat mode                                                                              | `C-r`              |
+| `ToggleFakeTrackRepeatMode`    | toggle fake track repeat mode                                                                      | `M-r`              |
+| `Shuffle`                      | toggle the shuffle mode                                                                            | `C-s`              |
+| `VolumeChange`                 | change playback volume by an offset (default shortcuts use 5%)                                     | `+`, `-`           |
+| `Mute`                         | toggle playback volume between 0% and previous level                                               | `_`                |
+| `SeekForward`                  | seek forward by 5s                                                                                 | `>`                |
+| `SeekBackward`                 | seek backward by 5s                                                                                | `<`                |
+| `Quit`                         | quit the application                                                                               | `C-c`, `q`         |
+| `ClosePopup`                   | close a popup                                                                                      | `esc`              |
+| `SelectNextOrScrollDown`       | select the next item in a list/table or scroll down (supports vim-style count: 5j)                 | `j`, `C-n`, `down` |
+| `SelectPreviousOrScrollUp`     | select the previous item in a list/table or scroll up (supports vim-style count: 10k)              | `k`, `C-p`, `up`   |
+| `PageSelectNextOrScrollDown`   | select the next page item in a list/table or scroll a page down (supports vim-style count: 3C-f)   | `page_down`, `C-f` |
+| `PageSelectPreviousOrScrollUp` | select the previous page item in a list/table or scroll a page up (supports vim-style count: 2C-b) | `page_up`, `C-b`   |
+| `SelectFirstOrScrollToTop`     | select the first item in a list/table or scroll to the top                                         | `g g`, `home`      |
+| `SelectLastOrScrollToBottom`   | select the last item in a list/table or scroll to the bottom                                       | `G`, `end`         |
+| `ChooseSelected`               | choose the selected item                                                                           | `enter`            |
+| `RefreshPlayback`              | manually refresh the current playback                                                              | `r`                |
+| `RestartIntegratedClient`      | restart the integrated client (`streaming` feature only)                                           | `R`                |
+| `ShowActionsOnSelectedItem`    | open a popup showing actions on a selected item                                                    | `g a`, `C-space`   |
+| `ShowActionsOnCurrentTrack`    | open a popup showing actions on the current track                                                  | `a`                |
+| `AddSelectedItemToQueue`       | add the selected item to queue                                                                     | `Z`, `C-z`         |
+| `FocusNextWindow`              | focus the next focusable window (if any)                                                           | `tab`              |
+| `FocusPreviousWindow`          | focus the previous focusable window (if any)                                                       | `backtab`          |
+| `SwitchTheme`                  | open a popup for switching theme                                                                   | `T`                |
+| `SwitchDevice`                 | open a popup for switching device                                                                  | `D`                |
+| `Search`                       | open a popup for searching in the current page                                                     | `/`                |
+| `BrowseUserPlaylists`          | open a popup for browsing user's playlists                                                         | `u p`              |
+| `BrowseUserFollowedArtists`    | open a popup for browsing user's followed artists                                                  | `u a`              |
+| `BrowseUserSavedAlbums`        | open a popup for browsing user's saved albums                                                      | `u A`              |
+| `CurrentlyPlayingContextPage`  | go to the currently playing context page                                                           | `g space`          |
+| `TopTrackPage`                 | go to the user top track page                                                                      | `g t`              |
+| `RecentlyPlayedTrackPage`      | go to the user recently played track page                                                          | `g r`              |
+| `LikedTrackPage`               | go to the user liked track page                                                                    | `g y`              |
+| `LyricsPage`                   | go to the lyrics page of the current track                                                         | `g L`, `l`         |
+| `LibraryPage`                  | go to the user library page                                                                        | `g l`              |
+| `SearchPage`                   | go to the search page                                                                              | `g s`              |
+| `BrowsePage`                   | go to the browse page                                                                              | `g b`              |
+| `Queue`                        | go to the queue page                                                                               | `z`                |
+| `OpenCommandHelp`              | go to the command help page                                                                        | `?`, `C-h`         |
+| `PreviousPage`                 | go to the previous page                                                                            | `backspace`, `C-q` |
+| `OpenSpotifyLinkFromClipboard` | open a Spotify link from clipboard                                                                 | `O`                |
+| `SortTrackByTitle`             | sort the track table (if any) by track's title                                                     | `s t`              |
+| `SortTrackByArtists`           | sort the track table (if any) by track's artists                                                   | `s a`              |
+| `SortTrackByAlbum`             | sort the track table (if any) by track's album                                                     | `s A`              |
+| `SortTrackByAddedDate`         | sort the track table (if any) by track's added date                                                | `s D`              |
+| `SortTrackByDuration`          | sort the track table (if any) by track's duration                                                  | `s d`              |
+| `SortLibraryAlphabetically`    | sort the library alphabetically                                                                    | `s l a`            |
+| `SortLibraryByRecent`          | sort the library (playlists and albums) by recently added items                                    | `s l r`            |
+| `ReverseOrder`                 | reverse the order of the track table (if any)                                                      | `s r`              |
+| `MovePlaylistItemUp`           | move playlist item up one position                                                                 | `C-k`              |
+| `MovePlaylistItemDown`         | move playlist item down one position                                                               | `C-j`              |
+| `CreatePlaylist`               | create a new playlist                                                                              | `N`                |
+| `JumpToCurrentTrackInContext`  | jump to the current track in the context                                                           | `g c`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -308,15 +308,15 @@ impl Command {
             Self::ClosePopup => "close a popup",
             #[cfg(feature = "streaming")]
             Self::RestartIntegratedClient => "restart the integrated client",
-            Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down",
+            Self::SelectNextOrScrollDown => "select the next item in a list/table or scroll down (supports vim-style count: 5j)",
             Self::SelectPreviousOrScrollUp => {
-                "select the previous item in a list/table or scroll up"
+                "select the previous item in a list/table or scroll up (supports vim-style count: 10k)"
             }
             Self::PageSelectNextOrScrollDown => {
-                "select the next page item in a list/table or scroll a page down"
+                "select the next page item in a list/table or scroll a page down (supports vim-style count: 3C-f)"
             }
             Self::PageSelectPreviousOrScrollUp => {
-                "select the previous page item in a list/table or scroll a page up"
+                "select the previous page item in a list/table or scroll a page up (supports vim-style count: 2C-b)"
             }
             Self::SelectFirstOrScrollToTop => {
                 "select the first item in a list/table or scroll to the top"

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -290,7 +290,8 @@ fn handle_command_for_track_table_window(
         }
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, filtered_tracks.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, filtered_tracks.len(), count) {
         return Ok(true);
     }
 
@@ -347,7 +348,8 @@ pub fn handle_command_for_track_list_window(
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, tracks.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, tracks.len(), count) {
         return Ok(true);
     }
     match command {
@@ -390,7 +392,8 @@ pub fn handle_command_for_artist_list_window(
         return false;
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, artists.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, artists.len(), count) {
         return true;
     }
     match command {
@@ -426,7 +429,8 @@ pub fn handle_command_for_album_list_window(
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, albums.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, albums.len(), count) {
         return Ok(true);
     }
     match command {
@@ -464,7 +468,8 @@ pub fn handle_command_for_playlist_list_window(
         return false;
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, playlists.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, playlists.len(), count) {
         return true;
     }
     match command {
@@ -517,7 +522,8 @@ pub fn handle_command_for_show_list_window(
         return false;
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, shows.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, shows.len(), count) {
         return true;
     }
     match command {
@@ -553,7 +559,8 @@ pub fn handle_command_for_episode_list_window(
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, episodes.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, episodes.len(), count) {
         return Ok(true);
     }
     match command {
@@ -593,7 +600,8 @@ fn handle_command_for_episode_table_window(
         return Ok(false);
     }
 
-    if handle_navigation_command(command, ui.current_page_mut(), id, episodes.len()) {
+    let count = ui.count_prefix;
+    if handle_navigation_command(command, ui.current_page_mut(), id, episodes.len(), count) {
         return Ok(true);
     }
     match command {

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -38,6 +38,9 @@ pub struct UIState {
     /// which is mainly used to handle mouse click events (for seeking command)
     pub playback_progress_bar_rect: ratatui::layout::Rect,
 
+    /// Count prefix for vim-style navigation (e.g., 5j, 10k)
+    pub count_prefix: Option<usize>,
+
     #[cfg(feature = "image")]
     pub last_cover_image_render_info: ImageRenderInfo,
 }
@@ -154,6 +157,8 @@ impl Default for UIState {
             popup: None,
 
             playback_progress_bar_rect: Rect::default(),
+
+            count_prefix: None,
 
             #[cfg(feature = "image")]
             last_cover_image_render_info: ImageRenderInfo::default(),


### PR DESCRIPTION
Added support for vim-motions when navigating.. 

managed to get it working with one function that will listen for keys `c.to_digit(10)`, until a non digit is pressed where it'll call the handler with the count. 

I'm not really a rust developer, so any feedback is welcome.. 