### PR TITLE
Added description to show if a playlist is favorited/followed

### DIFF
--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -185,6 +185,14 @@ impl UserData {
     pub fn is_liked_track(&self, track: &Track) -> bool {
         self.saved_tracks.contains_key(&track.id.uri())
     }
+
+    /// Check if a playlist is followed
+    pub fn is_followed_playlist(&self, playlist: &Playlist) -> bool {
+        self.playlists.iter().any(|x| match x {
+            PlaylistFolderItem::Playlist(p) => p.id == playlist.id,
+            PlaylistFolderItem::Folder(_) => false,
+        })
+    }
 }
 
 pub fn store_data_into_file_cache<T: Serialize>(

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -289,8 +289,22 @@ pub fn render_context_page(
         Some(context) => {
             // render context description
             let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
+            let is_followed_string = if let Context::Playlist { playlist, ..} = context {
+                if data.user_data.is_followed_playlist(playlist) {
+                    "Followed"
+                } else {
+                    "Not Followed"
+                }
+            } else {
+                ""
+            };
+                
             frame.render_widget(
-                Paragraph::new(context.description()).style(ui.theme.page_desc()),
+                Paragraph::new(format!(
+                    "{} | {}",
+                    context.description(),
+                    is_followed_string
+                )).style(ui.theme.page_desc()),
                 chunks[0],
             );
             let rect = chunks[1];


### PR DESCRIPTION
When using the spotify_player application, I noticed that I was unable to view whether I had favorited a playlist or not. To remedy this, I created a public function to check whether the currently viewed playlist is in the user's library or not, returning a boolean. This is implemented in the page render to either display "Followed" or "Not Followed".

If there are any needed changes, please ping me. I would love to see this pull request through to implementation!