### PR TITLE
Feature: Add ability to jump to search result

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ List of supported commands:
 | `MovePlaylistItemDown`         | move playlist item down one position                              | `C-j`              |
 | `CreatePlaylist`               | create a new playlist                                             | `N`                |
 | `JumpToCurrentTrackInContext`  | jump to the current track in the context                          | `g c`              |
+| `JumpToSelectedTrackInPlaylist`| jump to the currently selected search result in the playlist      | `C-j`              |
 
 To add new shortcuts or modify the default shortcuts, please refer to the [keymaps section](docs/config.md#keymaps) in the configuration documentation.
 

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -53,6 +53,7 @@ pub enum Command {
     ShowActionsOnSelectedItem,
     ShowActionsOnCurrentTrack,
     AddSelectedItemToQueue,
+    JumpToSelectedTrackInPlaylist,
 
     BrowseUserPlaylists,
     BrowseUserFollowedArtists,
@@ -330,6 +331,7 @@ impl Command {
             Self::ShowActionsOnSelectedItem => "open a popup showing actions on a selected item",
             Self::ShowActionsOnCurrentTrack => "open a popup showing actions on the current track",
             Self::AddSelectedItemToQueue => "add the selected item to queue",
+            Self::JumpToSelectedTrackInPlaylist => "jump to the currently selected search result in the playlist",
             Self::FocusNextWindow => "focus the next focusable window (if any)",
             Self::FocusPreviousWindow => "focus the previous focusable window (if any)",
             Self::SwitchTheme => "open a popup for switching theme",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -108,6 +108,10 @@ impl Default for KeymapConfig {
                     command: Command::AddSelectedItemToQueue,
                 },
                 Keymap {
+                    key_sequence: "C-j".into(),
+                    command: Command::JumpToSelectedTrackInPlaylist,
+                },
+                Keymap {
                     key_sequence: "C-space".into(),
                     command: Command::ShowActionsOnSelectedItem,
                 },

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -5,7 +5,7 @@ use crate::{
         construct_album_actions, construct_artist_actions, construct_playlist_actions,
         construct_show_actions,
     },
-    state::{Episode, Show, UIStateGuard},
+    state::{Episode, MutableWindowState, Show, UIStateGuard},
 };
 use command::Action;
 use rand::Rng;
@@ -287,6 +287,24 @@ fn handle_command_for_track_table_window(
             )?
         {
             return Ok(true);
+        }
+
+        // Find a track from the filtered serach and select it in the playlist context
+        if command == Command::JumpToSelectedTrackInPlaylist {
+            ui.popup = None;
+            let selected_track = filtered_tracks[id];
+            let location = tracks.iter().enumerate().find(|(_, track)| {
+                track.id == selected_track.id
+            }).unwrap();
+
+            // Move selection and chnage the offset so selection is at the top
+            ui.current_page_mut().select(location.0);
+            match ui.current_page_mut().focus_window_state_mut().unwrap() {
+                MutableWindowState::Table(table) => *table.offset_mut() = location.0,
+                _ => unreachable!("playlist context should be a table")
+            }
+
+            return Ok(true)
         }
     }
 

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -297,7 +297,7 @@ fn handle_command_for_track_table_window(
                 track.id == selected_track.id
             }).unwrap();
 
-            // Move selection and chnage the offset so selection is at the top
+            // Move selection and change the offset so selection is at the top
             ui.current_page_mut().select(location.0);
             match ui.current_page_mut().focus_window_state_mut().unwrap() {
                 MutableWindowState::Table(table) => *table.offset_mut() = location.0,


### PR DESCRIPTION
Currently, there's no way to jump to a search result within a playlist without first playing the song and using `JumpToCurrentTrackInContext`. This PR adds the ability to jump directly to any search result in a playlist. After searching, highlight a result and press C-j to jump to its location in the playlist.

The default keybind is C-j, which overlaps with `MovePlaylistItemDown`. Whilst, the two don't conflict during search, I recognise this may not be desirable, so I can change the default if desired.