### PR TITLE
Add Support for RTL text in lyrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5337,6 +5337,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ttl_cache",
+ "unicode-bidi",
  "viuer",
  "which 7.0.3",
  "windows 0.58.0",
@@ -6123,6 +6124,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -56,6 +56,7 @@ which = "7.0.3"
 fuzzy-matcher = { version = "0.3.7", optional = true }
 html-escape = "0.2.13"
 rustls = { version = "0.23.27", default-features = false, features = ["ring"] }
+unicode-bidi = "0.3.18"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies.winit]
 version = "0.30.10"

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -730,8 +730,6 @@ pub struct Lyrics {
 
 impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
     fn from(value: librespot_metadata::lyrics::Lyrics) -> Self {
-
-
         let mut lines = value
             .lyrics
             .lines
@@ -746,8 +744,10 @@ impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
                 let bidi_info = BidiInfo::new(&l.words, None);
 
                 let words = if bidi_info.has_rtl() && bidi_info.paragraphs.len() > 0 {
-                    bidi_info.reorder_line(&bidi_info.paragraphs[0], 0..l.words.len()).into_owned()
-                } else { 
+                    bidi_info
+                        .reorder_line(&bidi_info.paragraphs[0], 0..l.words.len())
+                        .into_owned()
+                } else {
                     l.words
                 };
 

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -743,7 +743,7 @@ impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
                 // Therefore rtl formatting needs to be done on a per-line basis.
                 let bidi_info = BidiInfo::new(&l.words, None);
 
-                let words = if bidi_info.has_rtl() && bidi_info.paragraphs.len() > 0 {
+                let words = if bidi_info.has_rtl() && !bidi_info.paragraphs.is_empty() {
                     bidi_info
                         .reorder_line(&bidi_info.paragraphs[0], 0..l.words.len())
                         .into_owned()

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -741,7 +741,8 @@ impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
                     l.start_time_ms.parse::<i64>().expect("invalid number"),
                 );
 
-                // Some songs use multiple languages and may contain some rtl and ltr text.
+                // Some songs use multiple languages and may contain a mix of rtl and ltr text.
+                // Therefore rtl formatting needs to be done on a per-line basis.
                 let bidi_info = BidiInfo::new(&l.words, None);
 
                 let words = if bidi_info.has_rtl() && bidi_info.paragraphs.len() > 0 {

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -6,6 +6,7 @@ pub use rspotify::model::{
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Write;
+use unicode_bidi::BidiInfo;
 
 #[derive(Serialize, Clone, Debug)]
 #[serde(untagged)]
@@ -729,6 +730,8 @@ pub struct Lyrics {
 
 impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
     fn from(value: librespot_metadata::lyrics::Lyrics) -> Self {
+
+
         let mut lines = value
             .lyrics
             .lines
@@ -737,7 +740,17 @@ impl From<librespot_metadata::lyrics::Lyrics> for Lyrics {
                 let t = chrono::Duration::milliseconds(
                     l.start_time_ms.parse::<i64>().expect("invalid number"),
                 );
-                (t, l.words)
+
+                // Some songs use multiple languages and may contain some rtl and ltr text.
+                let bidi_info = BidiInfo::new(&l.words, None);
+
+                let words = if bidi_info.has_rtl() && bidi_info.paragraphs.len() > 0 {
+                    bidi_info.reorder_line(&bidi_info.paragraphs[0], 0..l.words.len()).into_owned()
+                } else { 
+                    l.words
+                };
+
+                (t, words)
             })
             .collect::<Vec<_>>();
         lines.sort_by_key(|l| l.0);


### PR DESCRIPTION
# Changes
- Adds *per-line* RTL text detection and formatting.
- Adds new dependency `unicode-bidi`

Note: Using `unicode_bidi` instead of just reversing the line also allows for properly formatting line with multi-lingual words.

# Screenshot
![image](https://github.com/user-attachments/assets/d17be04e-db1b-44a5-a988-aae9fa762c34)


# Testing
Example Songs:
- Desert Rose - Sting, Cheb Mami (https://open.spotify.com/track/3zYufmyv6HOuiHn1eMR6Ja?si=5623fc1c30e34131)
- Forgive me - Saint Levant (https://open.spotify.com/track/6GZ1fXt4LMbYxqsh4KkzoU?si=d20d147d3c2a4fec)

Tested on:
- Ghostty
- Kitty
- Alacritty

Resolves #750 