### PR TITLE
fix bug #753 - Action menu shorcut numbers not working anymore

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -101,22 +101,25 @@ fn handle_key_event(
     let mut ui = state.ui.lock();
 
     // Check if the key is a digit and handle count prefix
-    if let Key::None(KeyCode::Char(c)) = key {
-        if c.is_ascii_digit() {
-            let digit = c.to_digit(10).unwrap() as usize;
-            // If we have an existing count prefix, append the digit
-            // Otherwise, start a new count (but ignore leading zeros)
-            ui.count_prefix = match ui.count_prefix {
-                Some(count) => Some(count * 10 + digit),
-                None => {
-                    if digit > 0 {
-                        Some(digit)
-                    } else {
-                        None
+    // Only handle vim motions when not in a popup to avoid interfering with action selection
+    if ui.popup.is_none() {
+        if let Key::None(KeyCode::Char(c)) = key {
+            if c.is_ascii_digit() {
+                let digit = c.to_digit(10).unwrap() as usize;
+                // If we have an existing count prefix, append the digit
+                // Otherwise, start a new count (but ignore leading zeros)
+                ui.count_prefix = match ui.count_prefix {
+                    Some(count) => Some(count * 10 + digit),
+                    None => {
+                        if digit > 0 {
+                            Some(digit)
+                        } else {
+                            None
+                        }
                     }
-                }
-            };
-            return Ok(());
+                };
+                return Ok(());
+            }
         }
     }
 

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -192,7 +192,7 @@ mod windows {
                     ..Default::default()
                 };
 
-                if RegisterClassExW(&wnd_class) == 0 {
+                if RegisterClassExW(&raw const wnd_class) == 0 {
                     return Err(format!(
                         "Registering class failed: {}",
                         Error::last_os_error()
@@ -246,14 +246,14 @@ mod windows {
     pub fn pump_event_queue() -> bool {
         unsafe {
             let mut msg: MSG = std::mem::zeroed();
-            let mut has_message = PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool();
+            let mut has_message = PeekMessageW(&raw mut msg, None, 0, 0, PM_REMOVE).as_bool();
             while msg.message != WM_QUIT && has_message {
-                if !IsDialogMessageW(GetAncestor(msg.hwnd, GA_ROOT), &msg).as_bool() {
-                    let _ = TranslateMessage(&msg);
-                    let _ = DispatchMessageW(&msg);
+                if !IsDialogMessageW(GetAncestor(msg.hwnd, GA_ROOT), &raw const msg).as_bool() {
+                    let _ = TranslateMessage(&raw const msg);
+                    let _ = DispatchMessageW(&raw const msg);
                 }
 
-                has_message = PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool();
+                has_message = PeekMessageW(&raw mut msg, None, 0, 0, PM_REMOVE).as_bool();
             }
 
             msg.message == WM_QUIT


### PR DESCRIPTION
Fixes #753 
Fixes #764

This PR updates the logic to only update `count_prefix` if the pressed digit key is not handled as bind command or action