### PR TITLE
feat: make playback metadata fields configurable

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -31,6 +31,7 @@ All configuration files should be placed inside the application's configuration 
 | `client_port`                     | the port that the application's client is running on to handle CLI commands              | `8080`                                                      |
 | `tracks_playback_limit`           | the limit for the number of tracks played in a **tracks** playback                       | `50`                                                        |
 | `playback_format`                 | the format of the text in the playback's window                                          | `{status} {track} • {artists} {liked}\n{album}\n{metadata}` |
+| `playback_metadata_fields`        | (optional) list of metadata fields to display in the playback UI's `{metadata}` section. Possible values: `"repeat"`, `"shuffle"`, `"volume"`, `"device"` | `["repeat", "shuffle", "volume", "device"]` |
 | `notify_format`                   | the format of a notification (`notify` feature only)                                     | `{ summary = "{track} • {artists}", body = "{album}" }`     |
 | `notify_timeout_in_secs`          | the timeout (in seconds) of a notification (`notify` feature only)                       | `0` (no timeout)                                            |
 | `player_event_hook_command`       | the hook command executed when there is a new player event                               | `None`                                                      |
@@ -326,3 +327,11 @@ target = "PlayingTrack"
 action="ToggleLiked"
 key_sequence="C-l"
 ```
+
+- `playback_metadata_fields` lets you control which metadata fields are shown in the `{metadata}` section of the playback UI. For example, to show only repeat, shuffle, and volume, add:
+
+  ```toml
+  playback_metadata_fields = ["repeat", "shuffle", "volume"]
+  ```
+
+  You can use any combination and order of: `"repeat"`, `"shuffle"`, `"volume"`, `"device"`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -328,10 +328,3 @@ action="ToggleLiked"
 key_sequence="C-l"
 ```
 
-- `playback_metadata_fields` lets you control which metadata fields are shown in the `{metadata}` section of the playback UI. For example, to show only repeat, shuffle, and volume, add:
-
-  ```toml
-  playback_metadata_fields = ["repeat", "shuffle", "volume"]
-  ```
-
-  You can use any combination and order of: `"repeat"`, `"shuffle"`, `"volume"`, `"device"`.

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -60,6 +60,7 @@ pub struct AppConfig {
     pub player_event_hook_command: Option<Command>,
 
     pub playback_format: String,
+    pub playback_metadata_fields: Option<Vec<String>>,
     #[cfg(feature = "notify")]
     pub notify_format: NotifyFormat,
     #[cfg(feature = "notify")]
@@ -268,6 +269,7 @@ impl Default for AppConfig {
             playback_format: String::from(
                 "{status} {track} • {artists} {liked}\n{album}\n{metadata}",
             ),
+            playback_metadata_fields: None,
             #[cfg(feature = "notify")]
             notify_format: NotifyFormat {
                 summary: String::from("{track} • {artists}"),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -282,32 +282,38 @@ fn construct_playback_text(
             "{metadata}" => {
                 let fields = configs.app_config
                     .playback_metadata_fields
-                    .as_ref()
-                    .cloned()
+                    .clone()
                     .unwrap_or_else(|| vec![
                         "repeat".to_string(),
                         "shuffle".to_string(),
                         "volume".to_string(),
                         "device".to_string(),
                     ]);
+
+                let repeat_value = if playback.fake_track_repeat_state {
+                    "track (fake)".to_string()
+                } else {
+                    <&'static str>::from(playback.repeat_state).to_string()
+                };
+
+                let volume_value = if let Some(volume) = playback.mute_state {
+                    format!("{volume}% (muted)")
+                } else {
+                    format!("{}%", playback.volume.unwrap_or_default())
+                };
+
                 let mut parts = vec![];
+
                 for field in &fields {
                     match field.as_str() {
-                        "repeat" => parts.push(format!("repeat: {}", if playback.fake_track_repeat_state {
-                            "track (fake)"
-                        } else {
-                            <&'static str>::from(playback.repeat_state)
-                        })),
+                        "repeat" => parts.push(format!("repeat: {}", repeat_value)),
                         "shuffle" => parts.push(format!("shuffle: {}", playback.shuffle_state)),
-                        "volume" => parts.push(format!("volume: {}", if let Some(volume) = playback.mute_state {
-                            format!("{volume}% (muted)")
-                        } else {
-                            format!("{}%", playback.volume.unwrap_or_default())
-                        })),
+                        "volume" => parts.push(format!("volume: {}", volume_value)),
                         "device" => parts.push(format!("device: {}", playback.device_name)),
                         _ => {}
                     }
                 }
+
                 let metadata_str = parts.join(" | ");
                 (metadata_str, ui.theme.playback_metadata())
             },

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -280,15 +280,16 @@ fn construct_playback_text(
                 }
             },
             "{metadata}" => {
+                let default_fields = vec![
+                    "repeat".to_string(),
+                    "shuffle".to_string(),
+                    "volume".to_string(),
+                    "device".to_string(),
+                ];
                 let fields = configs.app_config
                     .playback_metadata_fields
-                    .clone()
-                    .unwrap_or_else(|| vec![
-                        "repeat".to_string(),
-                        "shuffle".to_string(),
-                        "volume".to_string(),
-                        "device".to_string(),
-                    ]);
+                    .as_ref()
+                    .unwrap_or(&default_fields);
 
                 let repeat_value = if playback.fake_track_repeat_state {
                     "track (fake)".to_string()
@@ -304,7 +305,7 @@ fn construct_playback_text(
 
                 let mut parts = vec![];
 
-                for field in &fields {
+                for field in fields {
                     match field.as_str() {
                         "repeat" => parts.push(format!("repeat: {}", repeat_value)),
                         "shuffle" => parts.push(format!("shuffle: {}", playback.shuffle_state)),


### PR DESCRIPTION
- Add `playback_metadata_fields` option to config, allowing users to
control which metadata fields (repeat, shuffle, volume, device) are
shown in the playback UI.
- Update documentation to reflect the new option.
- Users can now specify any combination and order of metadata fields to
display in the `{metadata}` section.