### PR TITLE
Update ArchLinux Install Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Run `cargo install spotify_player --locked` to install the application from [cra
 
 Run `pacman -S spotify-player` to install the application.
 
-Alternatively, run `yay -S spotify-player-full` to install an AUR package compiled with full feature support and Pulseaudio/Pipewire instead of rodio.
+**Note**: Defaults to PulseAudio / Pipewire audio backend. For a different one, please consider modifying the [official PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/spotify-player) and rebuilding it manually. See [Audio Backends](#audio-backend) for a list of options.
+
 
 ### Void Linux
 


### PR DESCRIPTION
Official ArchLinux Package [now supports all features](https://gitlab.archlinux.org/archlinux/packaging/packages/spotify-player/-/commit/4f099eb4270ba3584ab1356a15002989e485470c), but exclusively with pulseaudio-backend. This makes it now identical to the AUR package, so there's no point on having a reference to it anymore.

- Removed AUR reference. 
- Added a quick reference to point users on how to build it with a different audio backend.

