### PR TITLE
feat: add playback state command to CLI

### DIFF
--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -124,6 +124,7 @@ pub fn init_playback_subcommand() -> Command {
                         .required(true),
                 ),
         )
+        .subcommand(Command::new("state").about("Get current playback state"))
 }
 
 pub fn init_search_command() -> Command {

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -132,6 +132,9 @@ fn handle_playback_subcommand(args: &ArgMatches) -> Result<Request> {
                 .expect("position_offset_ms is required");
             Command::Seek(*position_offset_ms)
         }
+        "state" => {
+            return Ok(Request::Get(GetRequest::Key(Key::Playback)));
+        }
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
Adds a new `playback state` subcommand that returns the current playback information in JSON format, matching the Spotify Web API's current playback endpoint.

Usage: `spotify_player playback state`

The command leverages existing infrastructure by using the Key::Playback enum variant and current_playback() function to provide complete playback context including track info, device details, progress, and playback settings.

🤖 Generated with [Claude Code](https://claude.ai/code)