### PR TITLE
Allow configuring the log directory

### DIFF
--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -37,7 +37,7 @@ pub struct Configs {
 impl Configs {
     pub fn new(config_folder: &std::path::Path, cache_folder: &std::path::Path) -> Result<Self> {
         Ok(Self {
-            app_config: AppConfig::new(config_folder)?,
+            app_config: AppConfig::new(config_folder, cache_folder)?,
             keymap_config: KeymapConfig::new(config_folder)?,
             theme_config: ThemeConfig::new(config_folder)?,
             cache_folder: cache_folder.to_path_buf(),
@@ -56,6 +56,8 @@ pub struct AppConfig {
     pub client_port: u16,
 
     pub login_redirect_uri: String,
+
+    pub log_folder: Option<PathBuf>,
 
     pub player_event_hook_command: Option<Command>,
 
@@ -264,6 +266,9 @@ impl Default for AppConfig {
 
             login_redirect_uri: "http://127.0.0.1:8989/login".to_string(),
 
+            // If this is None, the log folder will be set to the default cache folder.
+            log_folder: None,
+
             tracks_playback_limit: 50,
 
             playback_format: String::from(
@@ -378,10 +383,14 @@ impl LayoutConfig {
 }
 
 impl AppConfig {
-    pub fn new(path: &Path) -> Result<Self> {
+    pub fn new(cfg_file_path: &Path, default_log_folder: &Path) -> Result<Self> {
         let mut config = Self::default();
-        if !config.parse_config_file(path)? {
-            config.write_config_file(path)?;
+        if !config.parse_config_file(cfg_file_path)? {
+            config.write_config_file(cfg_file_path)?;
+        }
+
+        if config.log_folder.is_none() {
+            config.log_folder = Some(PathBuf::from(default_log_folder));
         }
 
         config.layout.check_values()?;

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -36,7 +36,12 @@ fn init_spotify(
     Ok(())
 }
 
-fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
+fn init_logging(log_folder: &std::path::Path) -> Result<()> {
+    if std::env::var_os("RUST_LOG").is_some_and(|x| x == "off") {
+        // Don't create log files if logging is disabled.
+        return Ok(());
+    }
+
     let log_prefix = format!(
         "spotify-player-{}",
         chrono::Local::now().format("%y-%m-%d-%H-%M")
@@ -47,7 +52,10 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
         // default to log the current crate and librespot crates
         std::env::set_var("RUST_LOG", "spotify_player=info,librespot=info");
     }
-    let log_file = std::fs::File::create(cache_folder.join(format!("{log_prefix}.log")))
+    if !log_folder.exists() {
+        std::fs::create_dir_all(log_folder)?;
+    }
+    let log_file = std::fs::File::create(log_folder.join(format!("{log_prefix}.log")))
         .context("failed to create log file")?;
     tracing_subscriber::fmt::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -56,9 +64,8 @@ fn init_logging(cache_folder: &std::path::Path) -> Result<()> {
         .init();
 
     // initialize the application's panic backtrace
-    let backtrace_file =
-        std::fs::File::create(cache_folder.join(format!("{log_prefix}.backtrace")))
-            .context("failed to create backtrace file")?;
+    let backtrace_file = std::fs::File::create(log_folder.join(format!("{log_prefix}.backtrace")))
+        .context("failed to create backtrace file")?;
     let backtrace_file = std::sync::Mutex::new(backtrace_file);
     std::panic::set_hook(Box::new(move |info| {
         let mut file = backtrace_file.lock().unwrap();
@@ -262,7 +269,13 @@ fn main() -> Result<()> {
     match args.subcommand() {
         None => {
             // initialize the application's log
-            init_logging(&cache_folder).context("failed to initialize application's logging")?;
+            let log_folder = config::get_config()
+                .app_config
+                .log_folder
+                .as_deref()
+                .expect("this Option has been initialized with a value");
+
+            init_logging(log_folder).context("failed to initialize application's logging")?;
 
             // log the application's configurations
             tracing::info!("Configurations: {:?}", config::get_config());


### PR DESCRIPTION
New config option in `app.toml`: `log_folder`
This allows the user to change the location of log and backtrace files. The default is still the same (cache directory).

When `RUST_LOG` is set to `off`, the log and backtrace files won't be created.

Closes #774.