### PR TITLE
Feature: Add ability to change position of progress bar

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -53,14 +53,13 @@ All configuration files should be placed inside the application's configuration 
 | `border_type`                     | the type of the application's borders                                                                                                                  | `Plain`                                                        |
 | `progress_bar_type`               | the type of the playback progress bar                                                                                                                  | `Rectangle`                                                    |
 | `progress_bar_position`           | the position of the playback progress bar                                                                                                              | `Bottom`                                                       |
-
-| `genre_num` | the maximum number of genres to display in the playback text (if `{genres}` is used) | `2` |
-| `cover_img_width` | the width of the cover image (`image` feature only) | `5` |
-| `cover_img_length` | the length of the cover image (`image` feature only) | `9` |
-| `cover_img_scale` | the scale of the cover image (`image` feature only) | `1.0` |
-| `cover_img_pixels` | the amount of pixels per side of the cover image (`image` and `pixelate` feature only) | `16` |
-| `seek_duration_secs` | the duration (in seconds) to seek when using `SeekForward` and `SeekBackward` commands | `5` |
-| `sort_artist_albums_by_type` | sort albums on artist's pages by type, i.e. album or single | `false` |
+| `genre_num`                       | the maximum number of genres to display in the playback text (if `{genres}` is used)                                                                   | `2`                                                            |
+| `cover_img_width`                 | the width of the cover image (`image` feature only)                                                                                                    | `5`                                                            |
+| `cover_img_length`                | the length of the cover image (`image` feature only)                                                                                                   | `9`                                                            |
+| `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                                                                                    | `1.0`                                                          |
+| `cover_img_pixels`                | the amount of pixels per side of the cover image (`image` and `pixelate` feature only)                                                                 | `16`                                                           |
+| `seek_duration_secs`              | the duration (in seconds) to seek when using `SeekForward` and `SeekBackward` commands                                                                 | `5`                                                            |
+| `sort_artist_albums_by_type`      | sort albums on artist's pages by type, i.e. album or single                                                                                            | `false`                                                        |
 
 ### Notes
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,6 +52,7 @@ All configuration files should be placed inside the application's configuration 
 | `liked_icon`                      | the icon to indicate the liked state of a song                                                                                                         | `♥`                                                         |
 | `border_type`                     | the type of the application's borders                                                                                                                  | `Plain`                                                     |
 | `progress_bar_type`               | the type of the playback progress bar                                                                                                                  | `Rectangle`                                                 |
+| `progress_bar_position`               | the position of the playback progress bar                                                                                                                  | `Bottom`                                                 |
 | `cover_img_width`                 | the width of the cover image (`image` feature only)                                                                                                    | `5`                                                         |
 | `cover_img_length`                | the length of the cover image (`image` feature only)                                                                                                   | `9`                                                         |
 | `cover_img_scale`                 | the scale of the cover image (`image` feature only)                                                                                                    | `1.0`                                                       |
@@ -84,6 +85,7 @@ All configuration files should be placed inside the application's configuration 
 - `playback_window_position` can only be either `Top` or `Bottom`.
 - `border_type` can be either `Hidden`, `Plain`, `Rounded`, `Double` or `Thick`.
 - `progress_bar_type` can be either `Rectangle` or `Line`.
+- `progress_bar_position` can be either `Bottom` or `Right`.
 - `notify_streaming_only=true` and `enable_streaming=DaemonOnly` can be set to avoid sending multiple notifications when both daemon and UI are running.
 
 #### Media control

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -86,6 +86,7 @@ pub struct AppConfig {
     // layout configs
     pub border_type: BorderType,
     pub progress_bar_type: ProgressBarType,
+    pub progress_bar_position: ProgressBarPosition,
 
     pub layout: LayoutConfig,
 
@@ -144,6 +145,13 @@ pub enum ProgressBarType {
     Rectangle,
 }
 config_parser_impl!(ProgressBarType);
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub enum ProgressBarPosition {
+    Bottom,
+    Right,
+}
+config_parser_impl!(ProgressBarPosition);
 
 #[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 pub struct Command {
@@ -300,6 +308,7 @@ impl Default for AppConfig {
 
             border_type: BorderType::Plain,
             progress_bar_type: ProgressBarType::Rectangle,
+            progress_bar_position: ProgressBarPosition::Bottom,
 
             layout: LayoutConfig::default(),
 

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -110,7 +110,6 @@ pub fn render_playback_window(
                     let chunks = split_rect_for_progress_bar(rect);
                     (chunks.0, chunks.1)
                 }
-
             };
 
             if let Some(ref playback) = player.buffered_playback {
@@ -161,11 +160,7 @@ pub fn render_playback_window(
 }
 
 fn split_rect_for_progress_bar(rect: Rect) -> (Rect, Rect) {
-    let chunks = Layout::vertical([
-        Constraint::Fill(0),
-        Constraint::Length(1),
-    ])
-    .split(rect);
+    let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(1)]).split(rect);
     (chunks[0], chunks[1])
 }
 
@@ -179,7 +174,7 @@ fn split_rect_for_cover_img(rect: Rect) -> (Rect, Rect) {
     .split(rect);
     let ver_chunks = Layout::vertical([
         Constraint::Length(configs.app_config.cover_img_width as u16), // cover_img_rect
-        // Constraint::Fill(0), // empty space
+                                                                       // Constraint::Fill(0), // empty space
     ])
     .split(hor_chunks[0]);
 

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -164,6 +164,7 @@ fn split_rect_for_progress_bar(rect: Rect) -> (Rect, Rect) {
     (chunks[0], chunks[1])
 }
 
+#[cfg(feature = "image")]
 fn split_rect_for_cover_img(rect: Rect) -> (Rect, Rect) {
     let configs = config::get_config();
     let hor_chunks = Layout::horizontal([
@@ -174,7 +175,6 @@ fn split_rect_for_cover_img(rect: Rect) -> (Rect, Rect) {
     .split(rect);
     let ver_chunks = Layout::vertical([
         Constraint::Length(configs.app_config.cover_img_width as u16), // cover_img_rect
-                                                                       // Constraint::Fill(0), // empty space
     ])
     .split(hor_chunks[0]);
 
@@ -457,12 +457,12 @@ fn split_rect_for_playback_window(rect: Rect) -> (Rect, Rect) {
     #[cfg(feature = "image")]
     let playback_width = std::cmp::max(configs.app_config.cover_img_width + 1, playback_width);
 
-    // add lines for top/bottom borders
-    let bold_border = match configs.app_config.progress_bar_position {
-        config::ProgressBarPosition::Bottom => true,
-        config::ProgressBarPosition::Right => false,
+    // add lines for top/bottom borders depending on the progress bar's position
+    let num_lines = match configs.app_config.progress_bar_position {
+        config::ProgressBarPosition::Bottom => 2,
+        config::ProgressBarPosition::Right => 1,
     };
-    let playback_width = (playback_width + if bold_border { 2 } else { 1 }) as u16;
+    let playback_width = (playback_width + num_lines) as u16;
 
     match configs.app_config.layout.playback_window_position {
         config::Position::Top => {

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -28,102 +28,89 @@ pub fn render_playback_window(
     if let Some(ref playback) = player.playback {
         if let Some(item) = &playback.item {
             let (metadata_rect, progress_bar_rect) = {
-                // allocate the progress bar rect
-                let (rect, progress_bar_rect) = {
-                    let chunks =
-                        Layout::vertical([Constraint::Fill(0), Constraint::Length(1)]).split(rect);
-
-                    (chunks[0], chunks[1])
-                };
-
-                let metadata_rect = {
-                    // Render the track's cover image if `image` feature is enabled
-                    #[cfg(feature = "image")]
-                    {
-                        let configs = config::get_config();
-                        // Split the allocated rectangle into `metadata_rect` and `cover_img_rect`
-                        let (metadata_rect, cover_img_rect) = {
-                            let hor_chunks = Layout::horizontal([
-                                Constraint::Length(configs.app_config.cover_img_length as u16),
-                                Constraint::Fill(0), // metadata_rect
-                            ])
-                            .spacing(1)
-                            .split(rect);
-                            let ver_chunks = Layout::vertical([
-                                Constraint::Length(configs.app_config.cover_img_width as u16), // cover_img_rect
-                                Constraint::Fill(0), // empty space
-                            ])
-                            .split(hor_chunks[0]);
-
-                            (hor_chunks[1], ver_chunks[0])
-                        };
-
-                        let url = match item {
-                            rspotify::model::PlayableItem::Track(track) => {
-                                crate::utils::get_track_album_image_url(track).map(String::from)
+                // Render the track's cover image if `image` feature is enabled
+                #[cfg(feature = "image")]
+                {
+                    let configs = config::get_config();
+                    // Split the allocated rectangle into `metadata_rect`, `cover_img_rect` and `progress_bar_rect`
+                    let (metadata_rect, cover_img_rect, progress_bar_rect) =
+                        match configs.app_config.progress_bar_position {
+                            config::ProgressBarPosition::Bottom => {
+                                let ver_chunks = split_rect_for_progress_bar(rect); // rect, progress_bar_rect
+                                let hor_chunks = split_rect_for_cover_img(ver_chunks.0); // cover_img_rect, metadata_rect
+                                (hor_chunks.1, hor_chunks.0, ver_chunks.1)
                             }
-                            rspotify::model::PlayableItem::Episode(episode) => {
-                                crate::utils::get_episode_show_image_url(episode).map(String::from)
+                            config::ProgressBarPosition::Right => {
+                                let hor_chunks = split_rect_for_cover_img(rect); // cover_img_rect, rect
+                                let ver_chunks = split_rect_for_progress_bar(hor_chunks.1); // metadata_rect, progress_bar_rect
+                                (ver_chunks.0, hor_chunks.0, ver_chunks.1)
                             }
                         };
-                        if let Some(url) = url {
-                            let needs_clear = if ui.last_cover_image_render_info.url != url
-                                || ui.last_cover_image_render_info.render_area != cover_img_rect
-                            {
-                                ui.last_cover_image_render_info = ImageRenderInfo {
-                                    url,
-                                    render_area: cover_img_rect,
-                                    rendered: false,
-                                };
-                                true
-                            } else {
-                                false
+
+                    let url = match item {
+                        rspotify::model::PlayableItem::Track(track) => {
+                            crate::utils::get_track_album_image_url(track).map(String::from)
+                        }
+                        rspotify::model::PlayableItem::Episode(episode) => {
+                            crate::utils::get_episode_show_image_url(episode).map(String::from)
+                        }
+                    };
+                    if let Some(url) = url {
+                        let needs_clear = if ui.last_cover_image_render_info.url != url
+                            || ui.last_cover_image_render_info.render_area != cover_img_rect
+                        {
+                            ui.last_cover_image_render_info = ImageRenderInfo {
+                                url,
+                                render_area: cover_img_rect,
+                                rendered: false,
                             };
+                            true
+                        } else {
+                            false
+                        };
 
-                            if needs_clear {
-                                // clear the image's both new and old areas to ensure no remaining artifacts before rendering the image
-                                // See: https://github.com/aome510/spotify-player/issues/389
-                                clear_area(
-                                    frame,
-                                    ui.last_cover_image_render_info.render_area,
-                                    &ui.theme,
-                                );
-                                clear_area(frame, cover_img_rect, &ui.theme);
-                            } else {
-                                if !ui.last_cover_image_render_info.rendered {
-                                    if let Err(err) = render_playback_cover_image(state, ui) {
-                                        tracing::error!(
-                                            "Failed to render playback's cover image: {err:#}"
-                                        );
-                                    }
+                        if needs_clear {
+                            // clear the image's both new and old areas to ensure no remaining artifacts before rendering the image
+                            // See: https://github.com/aome510/spotify-player/issues/389
+                            clear_area(
+                                frame,
+                                ui.last_cover_image_render_info.render_area,
+                                &ui.theme,
+                            );
+                            clear_area(frame, cover_img_rect, &ui.theme);
+                        } else {
+                            if !ui.last_cover_image_render_info.rendered {
+                                if let Err(err) = render_playback_cover_image(state, ui) {
+                                    tracing::error!(
+                                        "Failed to render playback's cover image: {err:#}"
+                                    );
                                 }
+                            }
 
-                                // set the `skip` state of cells in the cover image area
-                                // to prevent buffer from overwriting the image's rendered area
-                                // NOTE: `skip` should not be set when clearing the render area.
-                                // Otherwise, nothing will be clear as the buffer doesn't handle cells with `skip=true`.
-                                for x in cover_img_rect.left()..cover_img_rect.right() {
-                                    for y in cover_img_rect.top()..cover_img_rect.bottom() {
-                                        frame
-                                            .buffer_mut()
-                                            .cell_mut((x, y))
-                                            .expect("invalid cell")
-                                            .set_skip(true);
-                                    }
+                            // set the `skip` state of cells in the cover image area
+                            // to prevent buffer from overwriting the image's rendered area
+                            // NOTE: `skip` should not be set when clearing the render area.
+                            // Otherwise, nothing will be clear as the buffer doesn't handle cells with `skip=true`.
+                            for x in cover_img_rect.left()..cover_img_rect.right() {
+                                for y in cover_img_rect.top()..cover_img_rect.bottom() {
+                                    frame
+                                        .buffer_mut()
+                                        .cell_mut((x, y))
+                                        .expect("invalid cell")
+                                        .set_skip(true);
                                 }
                             }
                         }
-
-                        metadata_rect
                     }
+                    (metadata_rect, progress_bar_rect)
+                }
 
-                    #[cfg(not(feature = "image"))]
-                    {
-                        rect
-                    }
-                };
+                #[cfg(not(feature = "image"))]
+                {
+                    let chunks = split_rect_for_progress_bar(rect);
+                    (chunks.0, chunks.1)
+                }
 
-                (metadata_rect, progress_bar_rect)
             };
 
             if let Some(ref playback) = player.buffered_playback {
@@ -171,6 +158,32 @@ pub fn render_playback_window(
         );
 
     other_rect
+}
+
+fn split_rect_for_progress_bar(rect: Rect) -> (Rect, Rect) {
+    let chunks = Layout::vertical([
+        Constraint::Fill(0),
+        Constraint::Length(1),
+    ])
+    .split(rect);
+    (chunks[0], chunks[1])
+}
+
+fn split_rect_for_cover_img(rect: Rect) -> (Rect, Rect) {
+    let configs = config::get_config();
+    let hor_chunks = Layout::horizontal([
+        Constraint::Length(configs.app_config.cover_img_length as u16),
+        Constraint::Fill(0), // metadata_rect
+    ])
+    .spacing(1)
+    .split(rect);
+    let ver_chunks = Layout::vertical([
+        Constraint::Length(configs.app_config.cover_img_width as u16), // cover_img_rect
+        // Constraint::Fill(0), // empty space
+    ])
+    .split(hor_chunks[0]);
+
+    (ver_chunks[0], hor_chunks[1])
 }
 
 #[cfg(feature = "image")]
@@ -437,8 +450,12 @@ fn split_rect_for_playback_window(rect: Rect) -> (Rect, Rect) {
     #[cfg(feature = "image")]
     let playback_width = std::cmp::max(configs.app_config.cover_img_width + 1, playback_width);
 
-    // +2 for top/bottom borders
-    let playback_width = (playback_width + 2) as u16;
+    // add lines for top/bottom borders
+    let bold_border = match configs.app_config.progress_bar_position {
+        config::ProgressBarPosition::Bottom => true,
+        config::ProgressBarPosition::Right => false,
+    };
+    let playback_width = (playback_width + if bold_border { 2 } else { 1 }) as u16;
 
     match configs.app_config.layout.playback_window_position {
         config::Position::Top => {


### PR DESCRIPTION
<img width="888" height="126" alt="image" src="https://github.com/user-attachments/assets/6080f0d5-9f85-416b-826e-ee2b1b06d638" />
The progress bar can now be placed to the right of the album cover instead of under it. To set the position in the app.toml file, specify the Bottom (default) or Right value for the progress_bar_position parameter.