### PR TITLE
Fix: Move `fuzzy_search_items` to `utils` to resolve #820

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUST_FEATURES: "rodio-backend,media-control,image,notify"
+  RUST_FEATURES: "rodio-backend,media-control,image,notify,fzf"
 
 jobs:
   rust-ci:

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -97,25 +97,7 @@ impl UIState {
     }
 }
 
-#[cfg(feature = "fzf")]
-use fuzzy_matcher::skim::SkimMatcherV2;
 use ratatui::layout::Rect;
-
-#[cfg(feature = "fzf")]
-fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> Vec<&'a T> {
-    let matcher = SkimMatcherV2::default();
-    let mut result = items
-        .iter()
-        .filter_map(|t| {
-            matcher
-                .fuzzy(&t.to_string(), query, false)
-                .map(|(score, _)| (t, score))
-        })
-        .collect::<Vec<_>>();
-
-    result.sort_by(|(_, a), (_, b)| b.cmp(a));
-    result.into_iter().map(|(t, _)| t).collect::<Vec<_>>()
-}
 
 impl Default for UIState {
     fn default() -> Self {

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -50,6 +50,26 @@ pub fn parse_uri(uri: &str) -> Cow<'_, str> {
     }
 }
 
+
+#[cfg(feature = "fzf")]
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+#[cfg(feature = "fzf")]
+pub fn fuzzy_search_items<'a, T: std::fmt::Display>(items: &'a [T], query: &str) -> Vec<&'a T> {
+    let matcher = SkimMatcherV2::default();
+    let mut result = items
+        .iter()
+        .filter_map(|t| {
+            matcher
+                .fuzzy(&t.to_string(), query, false)
+                .map(|(score, _)| (t, score))
+        })
+        .collect::<Vec<_>>();
+
+    result.sort_by(|(_, a), (_, b)| b.cmp(a));
+    result.into_iter().map(|(t, _)| t).collect::<Vec<_>>()
+}
+
 /// Get a list of items filtered by a search query.
 pub fn filtered_items_from_query<'a, T: std::fmt::Display>(
     query: &str,

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -50,7 +50,6 @@ pub fn parse_uri(uri: &str) -> Cow<'_, str> {
     }
 }
 
-
 #[cfg(feature = "fzf")]
 use fuzzy_matcher::skim::SkimMatcherV2;
 


### PR DESCRIPTION
- Relocated `fuzzy_search_items` from `ui::mod.rs` to `utils.rs` for the caller has been moved.
- Decoupled `ratatui::layout::Rect` import (`state/ui/mod.rs:100`) from the `fzf` feature gate since the dependent code(UIState::default()) does not rely on `fzf`.

- Fixes #820 
- Fixes #822 

Beside the issues mentioned, this patch also fixes building without `fzf` feature would fail due to `ratatui::layout::Rect` requiring `fzf` to be imported and `UIState::default()` was using it. The failing build log would look like
```text
> cargo run --bin spotify_player --no-default-features --features pulseaudio-backend,streaming,sixel,notify,daemon,media-control

=== bunch of log ===

error[E0433]: failed to resolve: use of undeclared type `Rect`
   --> spotify_player/src/state/ui/mod.rs:121:41
    |
121 |             playback_progress_bar_rect: Rect::default(),
    |                                         ^^^^ use of undeclared type `Rect`
    |
    = note: struct `crate::ui::utils::Rect` exists but is inaccessible
help: consider importing one of these structs
    |
1   + use image::math::Rect;
    |
1   + use ratatui::prelude::Rect;
    |
```

