### PR TITLE
Read client_id from a file in the config folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ docker run --rm \
 
 To enable a full [Spotify connect](https://www.spotify.com/us/connect/) support, users will need to enable a _"user-provided client integration"_.
 
-This integration can be done by following [this documentation](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to register a Spotify app and then specifying the app's `client_id` in the [general configuration file](docs/config.md#general). **NOTE**: please make sure that you specify `http://127.0.0.1:8989/login` (default value of `login_redirect_uri` config option) in the **Redirect URI** section when creating the app.
+This integration can be done by following [this documentation](https://developer.spotify.com/documentation/general/guides/authorization/app-settings/) to register a Spotify app and then specifying the app's `client_id` in the [general configuration file](docs/config.md#general). You can also create a file called `client_id` in the [config folder](#configurations) and put the ID there. **NOTE**: please make sure that you specify `http://127.0.0.1:8989/login` (default value of `login_redirect_uri` config option) in the **Redirect URI** section when creating the app.
 
 Upon running `spotify_player` with a user-provided `client_id`, user will be prompted to authenticate the app described earlier. **NOTE** that this prompt is different from the prompt to authenticate `spotify_player`. Upon accepting the authentication request, `spotify_player` will retrieve an access token of the app to finish setting up the integration.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,7 +129,10 @@ esac
 
 ### Client id command
 
-If you prefer not to include your own `client_id` directly in your configuration, you can retrieve it at runtime using the `client_id_command` option.
+If you prefer not to include your own `client_id` directly in your configuration, you have two options:
+
+1. you can create a file called `client_id` with the value of the client_id in the [config folder](../README.md#configurations), which will be picked up if it is not empty.
+2. you can retrieve it at runtime using the `client_id_command` option.
 
 If specified, `client_id_command` should be an object with two fields `command` and `args`, just like `player_event_hook_command`.
 For example to read your client_id from a file your could use `client_id_command = { command = "cat", args = ["/path/to/file"] }`

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -76,26 +76,30 @@ impl AppClient {
         // Construct user-provided client.
         // This custom client is needed for Spotify Connect integration because the custom Spotify client (`AppClient::spotify`),
         // which `spotify-player` uses to retrieve Spotify data from official API server, doesn't have access to user available devices
-        let mut user_client = configs.app_config.get_user_client_id(&configs.config_folder)?.clone().map(|id| {
-            let creds = rspotify::Credentials { id, secret: None };
-            let mut scopes = auth::OAUTH_SCOPES
-                .iter()
-                .map(ToString::to_string)
-                .collect::<HashSet<_>>();
-            // `user-personalized` scope is not supported by user-provided client and only available to the official Spotify client
-            scopes.remove("user-personalized");
-            let oauth = rspotify::OAuth {
-                redirect_uri: configs.app_config.login_redirect_uri.clone(),
-                scopes,
-                ..Default::default()
-            };
-            let config = rspotify::Config {
-                token_cached: true,
-                cache_path: configs.cache_folder.join("user_client_token.json"),
-                ..Default::default()
-            };
-            rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config)
-        });
+        let mut user_client = configs
+            .app_config
+            .get_user_client_id(&configs.config_folder)?
+            .clone()
+            .map(|id| {
+                let creds = rspotify::Credentials { id, secret: None };
+                let mut scopes = auth::OAUTH_SCOPES
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<HashSet<_>>();
+                // `user-personalized` scope is not supported by user-provided client and only available to the official Spotify client
+                scopes.remove("user-personalized");
+                let oauth = rspotify::OAuth {
+                    redirect_uri: configs.app_config.login_redirect_uri.clone(),
+                    scopes,
+                    ..Default::default()
+                };
+                let config = rspotify::Config {
+                    token_cached: true,
+                    cache_path: configs.cache_folder.join("user_client_token.json"),
+                    ..Default::default()
+                };
+                rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config)
+            });
 
         if let Some(client) = &mut user_client {
             let url = client

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -70,7 +70,7 @@ impl AppClient {
         // Construct user-provided client.
         // This custom client is needed for Spotify Connect integration because the Spotify client (`AppConfig::spotify`),
         // which `spotify-player` uses to retrieve Spotify data, doesn't have access to user available devices
-        let mut user_client = configs.app_config.get_user_client_id()?.clone().map(|id| {
+        let mut user_client = configs.app_config.get_user_client_id(&configs.config_folder)?.clone().map(|id| {
             let creds = rspotify::Credentials { id, secret: None };
             let oauth = rspotify::OAuth {
                 scopes: rspotify::scopes!("user-read-playback-state"),

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -70,20 +70,24 @@ impl AppClient {
         // Construct user-provided client.
         // This custom client is needed for Spotify Connect integration because the Spotify client (`AppConfig::spotify`),
         // which `spotify-player` uses to retrieve Spotify data, doesn't have access to user available devices
-        let mut user_client = configs.app_config.get_user_client_id(&configs.config_folder)?.clone().map(|id| {
-            let creds = rspotify::Credentials { id, secret: None };
-            let oauth = rspotify::OAuth {
-                scopes: rspotify::scopes!("user-read-playback-state"),
-                redirect_uri: configs.app_config.login_redirect_uri.clone(),
-                ..Default::default()
-            };
-            let config = rspotify::Config {
-                token_cached: true,
-                cache_path: configs.cache_folder.join("user_client_token.json"),
-                ..Default::default()
-            };
-            rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config)
-        });
+        let mut user_client = configs
+            .app_config
+            .get_user_client_id(&configs.config_folder)?
+            .clone()
+            .map(|id| {
+                let creds = rspotify::Credentials { id, secret: None };
+                let oauth = rspotify::OAuth {
+                    scopes: rspotify::scopes!("user-read-playback-state"),
+                    redirect_uri: configs.app_config.login_redirect_uri.clone(),
+                    ..Default::default()
+                };
+                let config = rspotify::Config {
+                    token_cached: true,
+                    cache_path: configs.cache_folder.join("user_client_token.json"),
+                    ..Default::default()
+                };
+                rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config)
+            });
 
         if let Some(client) = &mut user_client {
             let url = client

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -31,6 +31,7 @@ pub struct Configs {
     pub app_config: AppConfig,
     pub keymap_config: KeymapConfig,
     pub theme_config: ThemeConfig,
+    pub config_folder: std::path::PathBuf,
     pub cache_folder: std::path::PathBuf,
 }
 
@@ -40,6 +41,7 @@ impl Configs {
             app_config: AppConfig::new(config_folder)?,
             keymap_config: KeymapConfig::new(config_folder)?,
             theme_config: ThemeConfig::new(config_folder)?,
+            config_folder: config_folder.to_path_buf(),
             cache_folder: cache_folder.to_path_buf(),
         })
     }
@@ -450,8 +452,19 @@ impl AppConfig {
         }
     }
 
-    /// Returns stdout of `client_id_command` if set, otherwise it returns the the value of `client_id`
-    pub fn get_user_client_id(&self) -> Result<Option<String>> {
+    /// Returns the user's client ID by checking the following sources in order:
+    /// 1. `client_id` file in the config folder (if it exists and is not empty)
+    /// 2. stdout of `client_id_command` if set
+    /// 3. the value of `client_id` field
+    pub fn get_user_client_id(&self, config_folder: &Path) -> Result<Option<String>> {
+        let client_id_file = config_folder.join("client_id");
+        if let Ok(file_content) = std::fs::read_to_string(&client_id_file) {
+            let trimmed = file_content.trim();
+            if !trimmed.is_empty() {
+                return Ok(Some(trimmed.to_string()));
+            }
+        }
+
         match self.client_id_command {
             Some(ref cmd) => cmd.execute(None).map(|out| Some(out.trim().to_string())),
             None => Ok(self.client_id.clone()),


### PR DESCRIPTION
Related: #537 

This PR introduces a default lookup for a file containing the client_id, eliminating the need to add an external command to read it from the filesystem. 

It is a plaintext file called `client_id` present alongside app.toml (in the ~/.config/spotify-player) directory, which contains the ID - if such a file exists we can read it first, and then fallback to other mechanisms. 

My main motivation for this change is that shelling out to an external command is an expensive operation, and not all systems have straightforward ways to do that (i.e. Windows does not have the `cat` command, although there are ways to achieve similar functionality via the `findstr` or `more` commands). Of course this is assuming the commands are being invoked without a shell (where stuff like `echo` is available). But external shell -> external command is even more expensive. 