### PR TITLE
Feature: add `{track_number}` to playback_format

### DIFF
--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -285,6 +285,16 @@ fn construct_playback_text(
                     continue;
                 }
             },
+            "{track_number}" => match playable {
+                rspotify::model::PlayableItem::Track(track) => (
+                    { to_bidi_string(&track.track_number.to_string()) },
+                    ui.theme.playback_track(),
+                ),
+                rspotify::model::PlayableItem::Episode(_)
+                | rspotify::model::PlayableItem::Unknown(_) => {
+                    continue;
+                }
+            },
             "{artists}" => match playable {
                 rspotify::model::PlayableItem::Track(track) => (
                     to_bidi_string(&crate::utils::map_join(&track.artists, |a| &a.name, ", ")),


### PR DESCRIPTION
This PR adds `{track_number}` component so its usable in the `playback_format` config option

```
playback_format = """
{status} {track_number}. {track} • {artists} {liked}
{album} • {genres}
{metadata}"""
```

<img width="1332" height="488" alt="CleanShot 2025-10-04 at 12 04 27@2x" src="https://github.com/user-attachments/assets/a9efb37e-231b-4797-996e-d961abe92430" />
