### PR TITLE
Filter out keymaps with None command in shortcut help popup

### DIFF
--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -244,7 +244,9 @@ pub fn render_shortcut_help_popup(frame: &mut Frame, ui: &mut UIStateGuard, rect
                     keymap.key_sequence.keys.drain(0..input.keys.len());
                     keymap
                 })
-                .filter(|keymap| !keymap.key_sequence.keys.is_empty() && keymap.command != Command::None)
+                .filter(|keymap| {
+                    !keymap.key_sequence.keys.is_empty() && keymap.command != Command::None
+                })
                 .collect::<Vec<_>>()
         }
     };


### PR DESCRIPTION
This PR fixes an issue where the shortcut help popup displayed keymaps with Command::None.