### PR TITLE
fix: include local streaming device in device list popup

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -416,6 +416,7 @@ impl AppClient {
                 self.retrieve_current_playback(state, true).await?;
             }
             ClientRequest::GetDevices => {
+                #[allow(unused_mut)]
                 let mut devices: Vec<Device> = self
                     .available_devices()
                     .await?


### PR DESCRIPTION
This PR fixes the issue where the local streaming device was not included in the device list popup.