### PR TITLE
feat: modal text input

### DIFF
--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -123,6 +123,8 @@ pub struct AppConfig {
     pub seek_duration_secs: u16,
 
     pub sort_artist_albums_by_type: bool,
+
+    pub modal_search: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -357,6 +359,8 @@ impl Default for AppConfig {
             seek_duration_secs: 5,
 
             sort_artist_albums_by_type: false,
+
+            modal_search: false,
         }
     }
 }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     state::{
         ActionListItem, Album, AlbumId, Artist, ArtistFocusState, ArtistId, ArtistPopupAction,
         BrowsePageUIState, Context, ContextId, ContextPageType, ContextPageUIState, DataReadGuard,
-        Focusable, Id, Item, ItemId, LibraryFocusState, LibraryPageUIState, PageState, PageType,
-        PlayableId, Playback, PlaylistCreateCurrentField, PlaylistFolderItem, PlaylistId,
+        Focusable, Id, InputMode, Item, ItemId, LibraryFocusState, LibraryPageUIState, PageState,
+        PageType, PlayableId, Playback, PlaylistCreateCurrentField, PlaylistFolderItem, PlaylistId,
         PlaylistPopupAction, PopupState, SearchFocusState, SearchPageUIState, SharedState, ShowId,
         Track, TrackId, TrackOrder, UIStateGuard, USER_LIKED_TRACKS_ID,
         USER_RECENTLY_PLAYED_TRACKS_ID, USER_TOP_TRACKS_ID,
@@ -705,6 +705,11 @@ fn handle_global_command(
                 line_input: LineInput::default(),
                 current_query: String::new(),
                 state: SearchPageUIState::new(),
+                mode: if config::get_config().app_config.modal_search {
+                    Some(InputMode::default())
+                } else {
+                    None
+                },
             });
         }
         Command::BrowsePage => {
@@ -855,6 +860,18 @@ fn handle_global_command(
             }
         }
         Command::ClosePopup => {
+            if let Some(PopupState::Search { ref mut mode, .. }) = ui.popup {
+                if let Some(InputMode::Insert) = mode {
+                    *mode = Some(InputMode::Normal);
+                    return Ok(true);
+                }
+            } else if config::get_config().app_config.modal_search
+                && ui.popup.is_none()
+                && ui.history.len() > 1
+            {
+                ui.history.pop();
+            }
+
             ui.popup = None;
         }
         _ => return Ok(false),

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -59,6 +59,11 @@ impl UIState {
         self.current_page_mut().select(0);
         self.popup = Some(PopupState::Search {
             query: String::new(),
+            mode: if config::get_config().app_config.modal_search {
+                Some(InputMode::Insert)
+            } else {
+                None
+            },
         });
     }
 
@@ -91,7 +96,7 @@ impl UIState {
     /// Get a list of items possibly filtered by a search query if exists a search popup
     pub fn search_filtered_items<'a, T: std::fmt::Display>(&self, items: &'a [T]) -> Vec<&'a T> {
         match self.popup {
-            Some(PopupState::Search { ref query }) => filtered_items_from_query(query, items),
+            Some(PopupState::Search { ref query, .. }) => filtered_items_from_query(query, items),
             _ => items.iter().collect::<Vec<_>>(),
         }
     }

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -1,5 +1,5 @@
 use crate::{
-    state::model::{Category, ContextId},
+    state::{InputMode, model::{Category, ContextId}},
     ui::single_line_input::LineInput,
 };
 use ratatui::widgets::{ListState, TableState};
@@ -18,6 +18,7 @@ pub enum PageState {
         line_input: LineInput,
         current_query: String,
         state: SearchPageUIState,
+        mode: Option<InputMode>,
     },
     Lyrics {
         track_uri: String,

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -11,10 +11,27 @@ pub enum PlaylistCreateCurrentField {
     Desc,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    #[default]
+    Insert,
+    Normal,
+}
+
+impl InputMode {
+    pub fn toggle(&mut self) {
+        *self = match self {
+            InputMode::Insert => InputMode::Normal,
+            InputMode::Normal => InputMode::Insert,
+        };
+    }
+}
+
 #[derive(Debug)]
 pub enum PopupState {
     Search {
         query: String,
+        mode: Option<InputMode>,
     },
     UserPlaylistList(PlaylistPopupAction, ListState),
     UserFollowedArtistList(ListState),

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -53,6 +53,7 @@ pub fn render_search_page(
             state,
             current_query,
             line_input,
+            ..
         } => (state.focus, current_query, line_input),
         _ => return,
     };

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -5,6 +5,7 @@ use super::{
     Paragraph, PlaylistCreateCurrentField, PlaylistPopupAction, PopupState, Rect, Row, SharedState,
     Table, UIStateGuard,
 };
+use crate::state::InputMode;
 
 const SHORTCUT_TABLE_N_COLUMNS: usize = 3;
 const SHORTCUT_TABLE_CONSTRAINS: [Constraint; SHORTCUT_TABLE_N_COLUMNS] =
@@ -62,14 +63,21 @@ pub fn render_popup(
                 );
                 (chunks[0], true)
             }
-            PopupState::Search { query } => {
+            PopupState::Search { query, mode } => {
                 let chunks =
                     Layout::vertical([Constraint::Fill(0), Constraint::Length(3)]).split(rect);
 
                 let rect =
                     construct_and_render_block("Search", &ui.theme, Borders::ALL, frame, chunks[1]);
 
-                frame.render_widget(Paragraph::new(format!("/{query}")), rect);
+                match mode {
+                    Some(InputMode::Insert) | None => {
+                        frame.render_widget(Paragraph::new(format!("/{query}")), rect);
+                    }
+                    Some(InputMode::Normal) => {
+                        frame.render_widget(Paragraph::new(query.to_string()), rect);
+                    }
+                }
                 (chunks[0], true)
             }
             PopupState::ActionList(item, _) => {

--- a/spotify_player/src/ui/single_line_input.rs
+++ b/spotify_player/src/ui/single_line_input.rs
@@ -98,11 +98,23 @@ impl LineInput {
 
         let text_style = Style::default();
         let cursor_style = Style::default().add_modifier(Modifier::REVERSED);
-        let formatted_line = Line::from(vec![
+        let mut text_parts = vec![
             Span::styled(before_cursor, text_style),
             Span::styled(cursor, cursor_style),
             Span::styled(after_cursor, text_style),
-        ]);
+        ];
+
+        if is_active && crate::config::get_config().app_config.modal_search {
+            text_parts.splice(
+                0..0,
+                [Span::styled(
+                    "/",
+                    Style::default().fg(ratatui::style::Color::DarkGray),
+                )],
+            );
+        }
+
+        let formatted_line = Line::from(text_parts);
 
         Paragraph::new(formatted_line)
     }


### PR DESCRIPTION
This PR adds the concept of a mode for search inputs (i'm not sure if this is the right abstraction)
This allows you to toggle between text input and and the results pane, this way all commands/action keymaps still work when you're focused on the results.

fixes #641

If this is something you'd like to include I can add some documentation