### PR TITLE
Fix package URL format in Cargo.toml

### DIFF
--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -97,7 +97,7 @@ fzf = ["fuzzy-matcher"]
 default = ["rodio-backend", "media-control"]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }_{ target }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"
 
 [lints]
 workspace = true


### PR DESCRIPTION
cargo-binstall currently looks for {name}_{target}{archive-suffix}, but the GitHub release artifacts are published as {name}-{target}. This updates the pkg-url template so binstall can resolve prebuilt binaries instead of falling back to cargo install.