### PR TITLE
fix `0` key not working in popups

### DIFF
--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -485,20 +485,20 @@ fn handle_key_sequence_for_action_list_popup(
     state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
+    if let Some(Key::None(crossterm::event::KeyCode::Char(c))) = key_sequence.keys.first() {
+        if let Some(id) = c.to_digit(10) {
+            let id = id as usize;
+            if id < n_actions {
+                handle_item_action(id, client_pub, state, ui)?;
+                return Ok(true);
+            }
+        }
+    }
+
     let Some(command) = config::get_config()
         .keymap_config
         .find_command_from_key_sequence(key_sequence)
     else {
-        // handle selecting an action by pressing a key from '0' to '9'
-        if let Some(Key::None(crossterm::event::KeyCode::Char(c))) = key_sequence.keys.first() {
-            if let Some(id) = c.to_digit(10) {
-                let id = id as usize;
-                if id < n_actions {
-                    handle_item_action(id, client_pub, state, ui)?;
-                    return Ok(true);
-                }
-            }
-        }
         return Ok(false);
     };
 


### PR DESCRIPTION
after #888 pressing 0 would always start the song over even in a popup.
hopefully this doesnt somehow break anyones config? it feels natural to me that the popup menu should take priority over other keybinds since the key is on display