### PR TITLE
fix: keep main thread alive on Linux and when media-control is disabled - Issue 924

### DIFF
--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -207,31 +207,12 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
             #[allow(deprecated)]
             event_loop.run(move |_, _| {})?;
         }
-
-        // On Linux, we need to keep the main thread alive while the UI is running
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            loop {
-                if !state.ui.lock().is_running {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        }
     }
 
-    // If media-control is disabled, we still need to keep the main thread alive
-    #[cfg(not(feature = "media-control"))]
-    if !state.is_daemon {
-        loop {
-            if !state.ui.lock().is_running {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
+    // infinite loop to keep the main thread alive
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
     }
-
-    Ok(())
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Fix [Issue 924](https://github.com/aome510/spotify-player/issues/924)

The main thread was exiting prematurely, killing all spawned threads (UI, event handler, player watcher, etc.).

- On Linux with media-control enabled, add a polling loop since there is no winit event loop to block the main thread (unlike macOS/Windows).
- Without the media-control feature, add a polling loop for non-daemon mode to prevent the process from terminating while the UI is running.