### PR TITLE
feat: add 'open' CLI command for playing Spotify URIs/URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ To enable [fuzzy search](https://en.wikipedia.org/wiki/Approximate_string_matchi
 - `get`: Get Spotify data (playlist/album/artist data, user's data, etc)
 - `playback`: Interact with the playback (start a playback, play-pause, next, etc)
 - `search`: Search spotify
+- `open`: Open and play a Spotify item by URI or URL
 - `connect`: Connect to a Spotify device
 - `like`: Like currently playing track
 - `authenticate`: Authenticate the application

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -391,7 +391,7 @@ async fn handle_open_request(
             .context("invalid Spotify URL")?
             .collect();
         if segments.len() != 2 {
-            anyhow::bail!("Unknown Spotify URL: {}", uri);
+            anyhow::bail!("Unknown Spotify URL: {uri}");
         }
         format!("spotify:{}:{}", segments[0], segments[1])
     } else {
@@ -416,7 +416,7 @@ async fn handle_open_request(
             None,
         )
     } else {
-        anyhow::bail!("Unknown or unsupported URI/URL: {}", uri);
+        anyhow::bail!("Unknown or unsupported URI/URL: {uri}");
     };
 
     let playback = if let Some(state) = state {

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -238,3 +238,11 @@ pub fn init_playlist_subcommand() -> Command {
 pub fn init_print_features_command() -> Command {
     Command::new("features").about("Print compiled in features")
 }
+
+pub fn init_open_command() -> Command {
+    Command::new("open").about("Open a Spotify link/uri").arg(
+        Arg::new("uri_or_url")
+            .help("Spotify URI or URL")
+            .required(true),
+    )
+}

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -217,6 +217,13 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
                 .expect("query is required")
                 .to_owned(),
         },
+        "open" => {
+            let uri = args
+                .get_one::<String>("uri_or_url")
+                .expect("uri_or_url arg is required")
+                .to_owned();
+            Request::Open { uri }
+        }
         _ => unreachable!(),
     };
 

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -131,6 +131,7 @@ pub enum Request {
     Like { unlike: bool },
     Playlist(PlaylistCommand),
     Search { query: String },
+    Open { uri: String },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -176,6 +177,7 @@ pub fn init_cli() -> anyhow::Result<clap::Command> {
         .subcommand(commands::init_playlist_subcommand())
         .subcommand(commands::init_generate_command())
         .subcommand(commands::init_search_command())
+        .subcommand(commands::init_open_command())
         .subcommand(commands::init_print_features_command())
         .arg(
             clap::Arg::new("theme")


### PR DESCRIPTION
Resolves #887

### What

Adds a new `spotify_player open <URI_OR_URL>` CLI command that starts playback of a Spotify item directly from the command line.

Both Spotify URIs and web URLs are accepted:

```sh
# By URI
spotify_player open spotify:track:6rqhFgbbKwnb9MLmUQDhG6

# By URL
spotify_player open https://open.spotify.com/track/6rqhFgbbKwnb9MLmUQDhG6
```

Supported item types: **tracks**, **albums**, **artists**, **playlists**.

### How it works

- URLs are converted to URIs by parsing the path segments (`/track/ID` → `spotify:track:ID`).
- The URI is matched against `TrackId`, `AlbumId`, `ArtistId`, and `PlaylistId` parsers to build the appropriate `PlayerRequest::StartPlayback`.
- Execution follows the same dual-mode pattern as the existing `playback` command - async when a TUI instance is running, synchronous otherwise.

### Refactoring

The async/sync player request logic that was previously inlined in `handle_playback_request` has been extracted into a shared `execute_player_request()` helper. Both `playback` and `open` commands now delegate to it, removing duplication.