### PR TITLE
fix: bind CLI socket before spawning handler thread

### DIFF
--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -163,8 +163,15 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Resul
             rt.block_on(client.new_session(None, false))
                 .context("new session")?;
 
+            // create a client socket for handling CLI commands
+            // NOTE: the socket must be bound *before* spawning the thread to avoid a
+            // race condition where the caller sends a request before the socket is ready.
+            let client_socket = rt.block_on(tokio::net::UdpSocket::bind(("127.0.0.1", port)))?;
+
             // spawn a thread to handle the CLI request
-            std::thread::spawn(move || rt.block_on(start_socket(&client, None)));
+            std::thread::spawn(move || {
+                rt.block_on(start_socket(&client, None, Some(client_socket)));
+            });
         } else {
             return Err(err.into());
         }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -137,7 +137,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
         let client = client.clone();
         let state = state.clone();
         async move {
-            cli::start_socket(&client, Some(&state)).await;
+            cli::start_socket(&client, Some(&state), None).await;
         }
     });
 


### PR DESCRIPTION
## Fix: CLI "Connection refused" in stateless mode

PR #921 moved the UDP socket binding inside the socket handler function. This introduced a race condition in the stateless CLI path (no running spotify_player instance): the handler thread is spawned but the socket isn't bound yet when the CLI tries to send its request, resulting in "Connection refused (os error 61)".

### Fix

The socket handler now accepts an optional pre-bound socket. In the stateless CLI path, the socket is bound **before** spawning the thread and passed in directly. The TUI/daemon path is unchanged.

Fixes #927
