### PR TITLE
Fix Spotify API February 2026 migration issues (v0.23.0)

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -665,6 +665,85 @@ impl AppClient {
         Ok(self.device().await?)
     }
 
+    /// Get a show data
+    pub async fn get_a_show(&self, show_id: ShowId<'_>, market: Option<rspotify::model::Market>) -> Result<serde_json::Value> {
+        let url = format!("{SPOTIFY_API_ENDPOINT}/shows/{}", show_id.id());
+        let mut query = Query::new();
+        if let Some(market) = market {
+            query.insert("market", <&str>::from(market));
+        }
+        self.http_get::<serde_json::Value>(&url, &query).await
+    }
+
+    pub async fn artist(&self, artist_id: ArtistId<'_>) -> Result<Artist> {
+        let url = format!("{SPOTIFY_API_ENDPOINT}/artists/{}", artist_id.id());
+        let v = self.http_get::<serde_json::Value>(&url, &Query::new()).await?;
+        serde_json::from_value(v).context("parse artist")
+    }
+
+    pub async fn artist_related_artists(&self, artist_id: ArtistId<'_>) -> Result<Vec<Artist>> {
+        #[derive(Deserialize)]
+        struct RelatedArtistsResponse {
+            artists: Vec<serde_json::Value>,
+        }
+
+        let url = format!("{SPOTIFY_API_ENDPOINT}/artists/{}/related-artists", artist_id.id());
+        let response = match self.http_get::<RelatedArtistsResponse>(&url, &Query::new()).await {
+            Ok(r) => r,
+            Err(_) => return Ok(vec![]),
+        };
+
+        Ok(response
+            .artists
+            .into_iter()
+            .filter_map(|v| serde_json::from_value(v).ok())
+            .collect())
+    }
+
+    pub async fn artist_top_tracks(
+        &self,
+        artist_id: rspotify::model::ArtistId<'_>,
+        market: Option<rspotify::model::Market>,
+    ) -> Result<Vec<rspotify::model::FullTrack>> {
+        match self.deref().artist_top_tracks(artist_id, market).await {
+            Ok(t) => Ok(t),
+            Err(e) => {
+                tracing::warn!("Failed to get artist top tracks: {e:#}");
+                Ok(vec![])
+            }
+        }
+    }
+
+    /// Make a GET HTTP request to the Spotify server
+    async fn http_get<T>(&self, url: &str, payload: &Query<'_>) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let access_token = self.token().await.context("get token")?;
+        tracing::debug!("{access_token} {url}");
+
+        let response = self
+            .http
+            .get(url)
+            .query(payload)
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {access_token}"),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        let text = response.text().await?;
+        tracing::debug!("{text}");
+
+        if status != StatusCode::OK {
+            anyhow::bail!("failed to send a Spotify API request {url}: {text}");
+        }
+
+        Ok(serde_json::from_str(&text)?)
+    }
+
     pub fn update_playback(&self, state: &SharedState) {
         // After handling a request changing the player's playback,
         // update the playback state by making multiple get-playback requests.
@@ -786,7 +865,7 @@ impl AppClient {
     /// Get the saved (liked) tracks of the current user
     pub async fn current_user_saved_tracks(&self) -> Result<Vec<Track>> {
         let tracks = self
-            .all_paging_items::<rspotify::model::SavedTrack>(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/tracks"),
                 0, // we don't know the total number of saved tracks beforehand
             )
@@ -794,22 +873,44 @@ impl AppClient {
 
         Ok(tracks
             .into_iter()
-            .filter_map(|t| Track::try_from_full_track(t.track))
+            .filter_map(|v| {
+                let track_v = v.get("track")?.clone();
+                let mut track = Track::try_from_value(track_v)?;
+                if let Some(added_at) = v.get("added_at").and_then(|v| v.as_str()) {
+                    if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(added_at) {
+                        track.added_at = ts.timestamp() as u64;
+                    }
+                }
+                Some(track)
+            })
             .collect())
     }
 
     /// Get the recently played tracks of the current user
     pub async fn current_user_recently_played_tracks(&self) -> Result<Vec<Track>> {
-        let first_page = self.current_user_recently_played(Some(50), None).await?;
+        let url = format!("{SPOTIFY_API_ENDPOINT}/me/player/recently-played?limit=50");
+        let mut response_v = self.http_get::<serde_json::Value>(&url, &Query::new()).await?;
 
-        let play_histories = self.all_cursor_based_paging_items(first_page).await?;
+        let mut tracks = Vec::new();
+        let mut seen_names = HashSet::new();
 
-        // de-duplicate the tracks returned from the recently-played API
-        let mut tracks = Vec::<Track>::new();
-        for history in play_histories {
-            if !tracks.iter().any(|t| t.name == history.track.name) {
-                if let Some(track) = Track::try_from_full_track(history.track) {
-                    tracks.push(track);
+        loop {
+            if let Some(items) = response_v.get("items").and_then(|i| i.as_array()) {
+                for item in items {
+                    if let Some(track_v) = item.get("track") {
+                        if let Some(track) = Track::try_from_value(track_v.clone()) {
+                            if seen_names.insert(track.name.clone()) {
+                                tracks.push(track);
+                            }
+                        }
+                    }
+                }
+            }
+
+            match response_v.get("next").and_then(|n| n.as_str()) {
+                None => break,
+                Some(url) => {
+                    response_v = self.http_get::<serde_json::Value>(url, &Query::new()).await?;
                 }
             }
         }
@@ -818,23 +919,27 @@ impl AppClient {
 
     /// Get the top tracks of the current user
     pub async fn current_user_top_tracks(&self) -> Result<Vec<Track>> {
-        let tracks = self
-            .all_paging_items::<rspotify::model::FullTrack>(
+        let tracks = match self
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/top/tracks"),
                 0, // we don't know the total number of top tracks beforehand
             )
-            .await?;
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("Failed to get top tracks: {e:#}");
+                return Ok(vec![]);
+            }
+        };
 
-        Ok(tracks
-            .into_iter()
-            .filter_map(Track::try_from_full_track)
-            .collect())
+        Ok(tracks.into_iter().filter_map(Track::try_from_value).collect())
     }
 
     /// Get all playlists of the current user
     pub async fn current_user_playlists(&self) -> Result<Vec<Playlist>> {
         let playlists = self
-            .all_paging_items::<rspotify::model::SimplifiedPlaylist>(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/playlists"),
                 0, // we don't know the total number of playlists beforehand
             )
@@ -842,63 +947,86 @@ impl AppClient {
 
         Ok(playlists
             .into_iter()
-            .map(std::convert::Into::into)
+            .filter_map(|v| serde_json::from_value(v).ok())
             .collect())
     }
 
     /// Get all followed artists of the current user
     pub async fn current_user_followed_artists(&self) -> Result<Vec<Artist>> {
-        let first_page = self
-            .deref()
-            .current_user_followed_artists(None, None)
-            .await?;
+        let url = format!("{SPOTIFY_API_ENDPOINT}/me/following?type=artist");
+        let mut response_v = self.http_get::<serde_json::Value>(&url, &Query::new()).await?;
 
-        // followed artists pagination is handled different from
-        // other paginations. The endpoint uses cursor-based pagination.
-        let mut artists = first_page.items;
-        let mut maybe_next = first_page.next;
-        while let Some(url) = maybe_next {
-            let mut next_page = self
-                .http_get::<rspotify::model::CursorPageFullArtists>(&url, &Query::new())
-                .await?
-                .artists;
-            artists.append(&mut next_page.items);
-            maybe_next = next_page.next;
+        let mut artists = Vec::new();
+        loop {
+            let artists_obj = match response_v.get("artists") {
+                Some(a) => a,
+                None => break,
+            };
+
+            if let Some(items) = artists_obj.get("items").and_then(|i| i.as_array()) {
+                for item in items {
+                    if let Ok(artist) = serde_json::from_value(item.clone()) {
+                        artists.push(artist);
+                    }
+                }
+            }
+
+            match artists_obj.get("next").and_then(|n| n.as_str()) {
+                None => break,
+                Some(url) => {
+                    response_v = self.http_get::<serde_json::Value>(url, &Query::new()).await?;
+                }
+            }
         }
-
-        // converts `rspotify::model::FullArtist` into `state::Artist`
-        Ok(artists.into_iter().map(std::convert::Into::into).collect())
+        Ok(artists)
     }
 
     /// Get all saved albums of the current user
     pub async fn current_user_saved_albums(&self) -> Result<Vec<Album>> {
         let albums = self
-            .all_paging_items::<rspotify::model::SavedAlbum>(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/albums"),
                 0, // we don't know the total number of saved albums beforehand
             )
             .await?;
 
-        // Converts `rspotify::model::SavedAlbum` into `state::Album`
-        Ok(albums.into_iter().map(Album::from).collect())
+        Ok(albums
+            .into_iter()
+            .filter_map(|v| {
+                let album_v = v.get("album")?.clone();
+                let mut album = Album::try_from_simplified_album_value(album_v)?;
+                if let Some(added_at) = v.get("added_at").and_then(|v| v.as_str()) {
+                    if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(added_at) {
+                        album.added_at = ts.timestamp() as u64;
+                    }
+                }
+                Some(album)
+            })
+            .collect())
     }
 
     /// Get all saved shows of the current user
     pub async fn current_user_saved_shows(&self) -> Result<Vec<Show>> {
         let shows = self
-            .all_paging_items::<rspotify::model::Show>(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/shows"),
                 0, // we don't know the total number of saved shows beforehand
             )
             .await?;
 
-        Ok(shows.into_iter().map(|s| s.show.into()).collect())
+        Ok(shows
+            .into_iter()
+            .filter_map(|v| {
+                let show_v = v.get("show")?.clone();
+                serde_json::from_value(show_v).ok()
+            })
+            .collect())
     }
 
     /// Get all albums of an artist
     pub async fn artist_albums(&self, artist_id: ArtistId<'_>) -> Result<Vec<Album>> {
         let albums = self
-            .all_paging_items::<rspotify::model::SimplifiedAlbum>(
+            .all_paging_items::<serde_json::Value>(
                 &format!(
                     "{SPOTIFY_API_ENDPOINT}/artists/{}/albums?include_groups=album,single",
                     artist_id.id()
@@ -907,7 +1035,7 @@ impl AppClient {
             )
             .await?
             .into_iter()
-            .filter_map(Album::try_from_simplified_album)
+            .filter_map(Album::try_from_simplified_album_value)
             .collect();
 
         Ok(AppClient::process_artist_albums(albums))
@@ -1009,64 +1137,94 @@ impl AppClient {
 
     /// Search for items (tracks, artists, albums, playlists) matching a given query
     pub async fn search(&self, query: &str) -> Result<SearchResults> {
-        let (
-            track_result,
-            artist_result,
-            album_result,
-            playlist_result,
-            show_result,
-            episode_result,
-        ) = tokio::try_join!(
-            self.search_specific_type(query, rspotify::model::SearchType::Track),
-            self.search_specific_type(query, rspotify::model::SearchType::Artist),
-            self.search_specific_type(query, rspotify::model::SearchType::Album),
-            self.search_specific_type(query, rspotify::model::SearchType::Playlist),
-            self.search_specific_type(query, rspotify::model::SearchType::Show),
-            self.search_specific_type(query, rspotify::model::SearchType::Episode)
-        )?;
+        let mut tracks = vec![];
+        let mut artists = vec![];
+        let mut albums = vec![];
+        let mut playlists = vec![];
+        let mut shows = vec![];
+        let mut episodes = vec![];
 
-        let (tracks, artists, albums, playlists, shows, episodes) = (
-            match track_result {
-                rspotify::model::SearchResult::Tracks(p) => p
+        let url = format!("{SPOTIFY_API_ENDPOINT}/search");
+        let payload = Query::from([
+            ("q", query),
+            ("type", "track,artist,album,playlist,show,episode"),
+            ("limit", "10"),
+        ]);
+
+        let result = match self.http_get::<serde_json::Value>(&url, &payload).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Search failed: {e:#}");
+                return Ok(SearchResults::default());
+            }
+        };
+
+        if let Some(t) = result.get("tracks") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                tracks = p
                     .items
                     .into_iter()
-                    .filter_map(Track::try_from_full_track)
-                    .collect(),
-                _ => anyhow::bail!("expect a track search result"),
-            },
-            match artist_result {
-                rspotify::model::SearchResult::Artists(p) => {
-                    p.items.into_iter().map(std::convert::Into::into).collect()
-                }
-                _ => anyhow::bail!("expect an artist search result"),
-            },
-            match album_result {
-                rspotify::model::SearchResult::Albums(p) => p
+                    .filter_map(Track::try_from_value)
+                    .collect();
+            }
+        }
+        if let Some(t) = result.get("artists") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                artists = p
                     .items
                     .into_iter()
-                    .filter_map(Album::try_from_simplified_album)
-                    .collect(),
-                _ => anyhow::bail!("expect an album search result"),
-            },
-            match playlist_result {
-                rspotify::model::SearchResult::Playlists(p) => {
-                    p.items.into_iter().map(std::convert::Into::into).collect()
-                }
-                _ => anyhow::bail!("expect a playlist search result"),
-            },
-            match show_result {
-                rspotify::model::SearchResult::Shows(p) => {
-                    p.items.into_iter().map(std::convert::Into::into).collect()
-                }
-                _ => anyhow::bail!("expect a show search result"),
-            },
-            match episode_result {
-                rspotify::model::SearchResult::Episodes(p) => {
-                    p.items.into_iter().map(std::convert::Into::into).collect()
-                }
-                _ => anyhow::bail!("expect a episode search result"),
-            },
-        );
+                    .filter_map(|v| serde_json::from_value(v).ok())
+                    .collect();
+            }
+        }
+        if let Some(t) = result.get("albums") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                albums = p
+                    .items
+                    .into_iter()
+                    .filter_map(Album::try_from_simplified_album_value)
+                    .collect();
+            }
+        }
+        if let Some(t) = result.get("playlists") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                playlists = p
+                    .items
+                    .into_iter()
+                    .filter_map(|v| serde_json::from_value(v).ok())
+                    .collect();
+            }
+        }
+        if let Some(t) = result.get("shows") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                shows = p
+                    .items
+                    .into_iter()
+                    .filter_map(|v| serde_json::from_value(v).ok())
+                    .collect();
+            }
+        }
+        if let Some(t) = result.get("episodes") {
+            if let Ok(p) =
+                serde_json::from_value::<rspotify::model::Page<serde_json::Value>>(t.clone())
+            {
+                episodes = p
+                    .items
+                    .into_iter()
+                    .filter_map(|v| serde_json::from_value(v).ok())
+                    .collect();
+            }
+        }
 
         Ok(SearchResults {
             tracks,
@@ -1086,7 +1244,7 @@ impl AppClient {
     ) -> Result<rspotify::model::SearchResult> {
         Ok(self
             .deref()
-            .search(query, typ, None, None, None, None)
+            .search(query, typ, None, None, Some(10), None)
             .await?)
     }
 
@@ -1331,29 +1489,75 @@ impl AppClient {
         let playlist_uri = playlist_id.uri();
         tracing::info!("Get playlist context: {}", playlist_uri);
 
-        let playlist = self
-            .playlist(
-                playlist_id.clone(),
-                None,
-                Some(rspotify::model::Market::FromToken),
+        #[derive(Deserialize, Debug)]
+        struct ManualPlaylist {
+            pub id: PlaylistId<'static>,
+            pub collaborative: bool,
+            pub name: String,
+            pub owner: rspotify::model::PublicUser,
+            pub description: Option<String>,
+            pub snapshot_id: String,
+            #[serde(alias = "items")]
+            pub tracks: serde_json::Value,
+        }
+
+        let playlist_v = self
+            .http_get::<serde_json::Value>(
+                &format!("{SPOTIFY_API_ENDPOINT}/playlists/{}", playlist_id.id()),
+                &Query::from([("market", "from_token")]),
             )
             .await?;
+        let p: ManualPlaylist = serde_json::from_value(playlist_v.clone()).context("parse playlist")?;
+
+        let total_tracks = p.tracks.get("total").and_then(|t| t.as_u64()).unwrap_or(0) as usize;
+
+        #[derive(Deserialize, Debug)]
+        struct ManualPlaylistItem {
+            #[serde(alias = "item")]
+            pub track: Option<rspotify::model::PlayableItem>,
+            pub added_at: Option<chrono::DateTime<chrono::Utc>>,
+        }
 
         let tracks = self
-            .all_paging_items(
+            .all_paging_items::<ManualPlaylistItem>(
                 &format!(
-                    "{SPOTIFY_API_ENDPOINT}/playlists/{}/tracks",
+                    "{SPOTIFY_API_ENDPOINT}/playlists/{}/items",
                     playlist_id.id(),
                 ),
-                playlist.tracks.total as usize,
+                total_tracks,
             )
             .await?
             .into_iter()
-            .filter_map(Track::try_from_playlist_item)
+            .filter_map(|item| {
+                // convert ManualPlaylistItem to rspotify::model::PlaylistItem
+                let playlist_item = rspotify::model::PlaylistItem {
+                    added_at: item.added_at,
+                    added_by: None,
+                    is_local: false,
+                    track: item.track,
+                };
+                Track::try_from_playlist_item(playlist_item)
+            })
             .collect::<Vec<_>>();
 
+        // manual conversion to state::Playlist
+        let re = regex::Regex::new("(<.*?>|</.*?>)").expect("valid regex");
+        let desc = p.description.unwrap_or_default();
+        let desc = html_escape::decode_html_entities(&re.replace_all(&desc, "")).to_string();
+
         Ok(Context::Playlist {
-            playlist: playlist.into(),
+            playlist: Playlist {
+                id: p.id,
+                name: p.name,
+                collaborative: p.collaborative,
+                owner: (
+                    p.owner.display_name.unwrap_or_default(),
+                    p.owner.id,
+                ),
+                desc,
+                current_folder_id: 0,
+                snapshot_id: p.snapshot_id,
+            },
             tracks,
         })
     }
@@ -1363,31 +1567,29 @@ impl AppClient {
         let album_uri = album_id.uri();
         tracing::info!("Get album context: {}", album_uri);
 
-        let album = self
-            .album(album_id.clone(), Some(rspotify::model::Market::FromToken))
+        let album_v = self
+            .http_get::<serde_json::Value>(
+                &format!("{SPOTIFY_API_ENDPOINT}/albums/{}", album_id.id()),
+                &Query::from([("market", "from_token")]),
+            )
             .await?;
+        let album: Album = serde_json::from_value(album_v.clone()).context("parse album")?;
 
-        let total_tracks = album.tracks.total as usize;
-
-        // converts `rspotify::model::FullAlbum` into `state::Album`
-        let album: Album = album.into();
+        let total_tracks = album_v.get("tracks").or_else(|| album_v.get("items"))
+            .and_then(|t| t.get("total")).and_then(|t| t.as_u64()).unwrap_or(0) as usize;
 
         // get the album's tracks
         let tracks = self
-            .all_paging_items(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/albums/{}/tracks", album_id.id()),
                 total_tracks,
             )
             .await?
             .into_iter()
-            .filter_map(|t| {
-                // simplified track doesn't have album so
-                // we need to manually include one during
-                // converting into `state::Track`
-                Track::try_from_simplified_track(t).map(|mut t| {
-                    t.album = Some(album.clone());
-                    t
-                })
+            .filter_map(|v| {
+                let mut track = Track::try_from_simplified_track_value(v)?;
+                track.album = Some(album.clone());
+                Some(track)
             })
             .collect::<Vec<_>>();
 
@@ -1399,36 +1601,30 @@ impl AppClient {
         let artist_uri = artist_id.uri();
         tracing::info!("Get artist context: {}", artist_uri);
 
-        // get the artist's information, including top tracks, related artists, and albums
+        let artist = self.artist(artist_id.as_ref()).await?;
 
-        let artist = self
-            .artist(artist_id.as_ref())
+        let top_tracks = match self
+            .http_get::<serde_json::Value>(
+                &format!("{SPOTIFY_API_ENDPOINT}/artists/{}/top-tracks", artist_id.id()),
+                &Query::from([("market", "from_token")]),
+            )
             .await
-            .context("get artist")?
-            .into();
+        {
+            Ok(v) => v
+                .get("tracks")
+                .and_then(|t| t.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| Track::try_from_value(v.clone()))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(_) => vec![],
+        };
 
-        let top_tracks = self
-            .artist_top_tracks(artist_id.as_ref(), Some(rspotify::model::Market::FromToken))
-            .await
-            .context("get artist's top tracks")?
-            .into_iter()
-            .filter_map(Track::try_from_full_track)
-            .collect::<Vec<_>>();
+        let related_artists = self.artist_related_artists(artist_id.as_ref()).await.unwrap_or_default();
 
-        #[allow(deprecated)]
-        let related_artists = self
-            .artist_related_artists(artist_id.as_ref())
-            .await
-            .ok()
-            .unwrap_or_default()
-            .into_iter()
-            .map(std::convert::Into::into)
-            .collect::<Vec<_>>();
-
-        let albums = self
-            .artist_albums(artist_id.as_ref())
-            .await
-            .context("get artist's albums")?;
+        let albums = self.artist_albums(artist_id.as_ref()).await.unwrap_or_default();
 
         Ok(Context::Artist {
             artist,
@@ -1443,69 +1639,31 @@ impl AppClient {
         let show_uri = show_id.uri();
         tracing::info!("Get show context: {}", show_uri);
 
-        let show = self.get_a_show(show_id.clone(), None).await?;
+        let show_v = self.get_a_show(show_id.clone(), Some(rspotify::model::Market::FromToken)).await?;
+        let show: Show = serde_json::from_value(show_v.clone()).context("parse show")?;
+
+        let total_episodes = show_v.get("episodes").and_then(|e| e.get("total")).and_then(|t| t.as_u64()).unwrap_or(0) as usize;
 
         // get the show's episodes
         let episodes = self
-            .all_paging_items::<rspotify::model::SimplifiedEpisode>(
+            .all_paging_items::<serde_json::Value>(
                 &format!("{SPOTIFY_API_ENDPOINT}/shows/{}/episodes", show_id.id()),
-                show.episodes.total as usize,
+                total_episodes,
             )
             .await?
             .into_iter()
-            .map(std::convert::Into::into)
+            .filter_map(|v| serde_json::from_value(v).ok())
             .collect::<Vec<_>>();
 
-        // converts `rspotify::model::FullShow` into `state::Show`
-        let show: Show = show.into();
-
         Ok(Context::Show { show, episodes })
-    }
-
-    /// Make a GET HTTP request to the Spotify server
-    async fn http_get<T>(&self, url: &str, payload: &Query<'_>) -> Result<T>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        /// a helper function to process an API response from Spotify server
-        ///
-        /// This function is mainly used to patch upstream API bugs , resulting in
-        /// a type error when a third-party library like `rspotify` parses the response
-        fn process_spotify_api_response(text: &str) -> String {
-            text.to_string()
-        }
-
-        let access_token = self.token().await.context("get token")?;
-        tracing::debug!("{access_token} {url}");
-
-        let response = self
-            .http
-            .get(url)
-            .query(payload)
-            .header(
-                reqwest::header::AUTHORIZATION,
-                format!("Bearer {access_token}"),
-            )
-            .send()
-            .await?;
-
-        let status = response.status();
-        let text = process_spotify_api_response(&response.text().await?);
-        tracing::debug!("{text}");
-
-        if status != StatusCode::OK {
-            anyhow::bail!("failed to send a Spotify API request {url}: {text}");
-        }
-
-        Ok(serde_json::from_str(&text)?)
     }
 
     async fn all_paging_items<T>(&self, base_url: &str, mut count: usize) -> Result<Vec<T>>
     where
         T: serde::de::DeserializeOwned + std::fmt::Debug,
     {
-        const PAGE_LIMIT: usize = 50;
-        const MAX_PARALLEL: usize = 8;
+        const PAGE_LIMIT: usize = 20;
+        const MAX_PARALLEL: usize = 2;
 
         let mut all_items = Vec::new();
         let mut offset = 0;
@@ -1531,20 +1689,33 @@ impl AppClient {
                         ("limit", &limit_str),
                         ("offset", &offset_str),
                     ]);
-                    self.http_get::<rspotify::model::Page<T>>(base_url, &params)
-                        .await
+                    self.http_get::<serde_json::Value>(base_url, &params).await
                 });
             }
 
             let results = futures::future::try_join_all(futures).await?;
 
             let mut found_empty = false;
-            for mut page in results {
-                if page.items.is_empty() {
+            for json in results {
+                let items_v = json
+                    .get("items")
+                    .or_else(|| json.get("tracks"))
+                    .cloned()
+                    .unwrap_or(json);
+
+                let mut items = if items_v.is_array() {
+                    serde_json::from_value::<Vec<T>>(items_v)?
+                } else if let Some(items) = items_v.get("items").or_else(|| items_v.get("tracks")) {
+                    serde_json::from_value::<Vec<T>>(items.clone())?
+                } else {
+                    vec![]
+                };
+
+                if items.is_empty() {
                     found_empty = true;
                     break;
                 }
-                all_items.append(&mut page.items);
+                all_items.append(&mut items);
             }
 
             if found_empty {
@@ -1596,22 +1767,18 @@ impl AppClient {
 
             let prev_item = player.currently_playing();
 
-            let prev_name = match prev_item {
-                Some(rspotify::model::PlayableItem::Track(track)) => track.name.clone(),
-                Some(rspotify::model::PlayableItem::Episode(episode)) => episode.name.clone(),
-                Some(rspotify::model::PlayableItem::Unknown(_)) | None => String::new(),
-            };
+            let prev_name = prev_item
+                .map(crate::utils::get_playable_item_name)
+                .unwrap_or_default();
 
             player.playback = playback;
             player.playback_last_updated_time = Some(std::time::Instant::now());
 
             let curr_item = player.currently_playing();
 
-            let curr_name = match curr_item {
-                Some(rspotify::model::PlayableItem::Track(track)) => track.name.clone(),
-                Some(rspotify::model::PlayableItem::Episode(episode)) => episode.name.clone(),
-                Some(rspotify::model::PlayableItem::Unknown(_)) | None => String::new(),
-            };
+            let curr_name = curr_item
+                .map(crate::utils::get_playable_item_name)
+                .unwrap_or_default();
 
             let new_playback = prev_name != curr_name && !curr_name.is_empty();
             // check if we need to update the buffered playback
@@ -1693,16 +1860,9 @@ impl AppClient {
             }
         }
 
-        let url = match curr_item {
-            rspotify::model::PlayableItem::Track(ref track) => {
-                crate::utils::get_track_album_image_url(track)
-                    .ok_or(anyhow::anyhow!("missing image"))?
-            }
-            rspotify::model::PlayableItem::Episode(ref episode) => {
-                crate::utils::get_episode_show_image_url(episode)
-                    .ok_or(anyhow::anyhow!("missing image"))?
-            }
-            rspotify::model::PlayableItem::Unknown(_) => return Ok(()),
+        let url = match crate::utils::get_playable_item_image_url(&curr_item) {
+            Some(url) => url,
+            None => return Ok(()),
         };
 
         let filename = (match curr_item {
@@ -1724,18 +1884,26 @@ impl AppClient {
                     &episode.show.id.as_ref().id()[..6]
                 )
             }
-            rspotify::model::PlayableItem::Unknown(_) => return Ok(()),
+            rspotify::model::PlayableItem::Unknown(value) => {
+                format!(
+                    "unknown-cover-{}.jpg",
+                    &crate::utils::get_playable_item_uri(&rspotify::model::PlayableItem::Unknown(value.clone()))
+                        .split(':')
+                        .last()
+                        .unwrap_or("unknown")[..6]
+                )
+            }
         })
         .replace('/', ""); // remove invalid characters from the file's name
         let path = configs.cache_folder.join("image").join(filename);
 
         if configs.app_config.enable_cover_image_cache {
-            self.retrieve_image(url, &path, true).await?;
+            self.retrieve_image(&url, &path, true).await?;
         }
 
         #[cfg(feature = "image")]
-        if !state.data.read().caches.images.contains_key(url) {
-            let bytes = self.retrieve_image(url, &path, false).await?;
+        if !state.data.read().caches.images.contains_key(&url) {
+            let bytes = self.retrieve_image(&url, &path, false).await?;
 
             #[cfg(not(feature = "pixelate"))]
             let image =

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -134,64 +134,119 @@ pub struct Device {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify track
 pub struct Track {
+    #[serde(alias = "uri")]
     pub id: TrackId<'static>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub artists: Vec<Artist>,
     pub album: Option<Album>,
+    #[serde(rename = "duration_ms", deserialize_with = "deserialize_duration", default)]
     pub duration: std::time::Duration,
+    #[serde(default)]
     pub explicit: bool,
     #[serde(skip)]
     pub added_at: u64,
 }
 
+fn deserialize_duration<'de, D>(deserializer: D) -> Result<std::time::Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let ms = u64::deserialize(deserializer).unwrap_or_default();
+    Ok(std::time::Duration::from_millis(ms))
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify album
 pub struct Album {
+    #[serde(alias = "uri")]
     pub id: AlbumId<'static>,
+    #[serde(default)]
     pub release_date: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub artists: Vec<Artist>,
+    #[serde(rename = "album_type")]
     pub typ: Option<rspotify::model::AlbumType>,
+    #[serde(default)]
+    pub images: Vec<rspotify::model::Image>,
+    #[serde(default)]
     pub added_at: u64,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify artist
 pub struct Artist {
+    #[serde(alias = "uri")]
     pub id: ArtistId<'static>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
+    pub genres: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify playlist
 pub struct Playlist {
+    #[serde(alias = "uri")]
     pub id: PlaylistId<'static>,
+    #[serde(default)]
     pub collaborative: bool,
+    #[serde(default)]
     pub name: String,
+    #[serde(deserialize_with = "deserialize_playlist_owner")]
     pub owner: (String, UserId<'static>),
+    #[serde(default)]
     pub desc: String,
     /// which folder id the playlist refers to
     #[serde(default)]
     pub current_folder_id: usize,
+    #[serde(default)]
     pub snapshot_id: String,
+}
+
+fn deserialize_playlist_owner<'de, D>(deserializer: D) -> Result<(String, UserId<'static>), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Owner {
+        #[serde(default)]
+        display_name: Option<String>,
+        #[serde(alias = "uri")]
+        id: UserId<'static>,
+    }
+    let owner = Owner::deserialize(deserializer)?;
+    Ok((owner.display_name.unwrap_or_default(), owner.id))
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify show (podcast)
 pub struct Show {
+    #[serde(alias = "uri")]
     pub id: ShowId<'static>,
+    #[serde(default)]
     pub name: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A Spotify episode (podcast episode)
 pub struct Episode {
+    #[serde(alias = "uri")]
     pub id: EpisodeId<'static>,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
+    #[serde(rename = "duration_ms", deserialize_with = "deserialize_duration", default)]
     pub duration: std::time::Duration,
     pub show: Option<Show>,
+    #[serde(default)]
     pub release_date: String,
+    #[serde(default)]
+    pub images: Vec<rspotify::model::Image>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -405,11 +460,41 @@ impl Track {
 
     /// tries to convert from a `rspotify::model::PlaylistItem` into `Track`
     pub fn try_from_playlist_item(item: rspotify::model::PlaylistItem) -> Option<Self> {
-        let rspotify::model::PlayableItem::Track(track) = item.track? else {
-            return None;
-        };
+        match item.track? {
+            rspotify::model::PlayableItem::Track(track) => {
+                Track::try_from_full_track_with_date(track, item.added_at)
+            }
+            rspotify::model::PlayableItem::Unknown(value) => {
+                let mut track = Track::try_from_value(value)?;
+                if let Some(added_at) = item.added_at {
+                    track.added_at = added_at.timestamp() as u64;
+                }
+                Some(track)
+            }
+            _ => None,
+        }
+    }
 
-        Track::try_from_full_track_with_date(track, item.added_at)
+    /// tries to convert from a `serde_json::Value` into `Track`
+    pub fn try_from_value(value: serde_json::Value) -> Option<Self> {
+        serde_json::from_value(value).ok()
+    }
+
+    /// tries to convert from a simplified track `serde_json::Value` into `Track`
+    pub fn try_from_simplified_track_value(value: serde_json::Value) -> Option<Self> {
+        serde_json::from_value(value).ok()
+    }
+
+    /// tries to convert from a playlist item `serde_json::Value` into `Track`
+    pub fn try_from_playlist_item_value(value: serde_json::Value) -> Option<Self> {
+        let track_v = value.get("item").or_else(|| value.get("track"))?.clone();
+        let mut track = Track::try_from_value(track_v)?;
+        if let Some(added_at) = value.get("added_at").and_then(|v| v.as_str()) {
+            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(added_at) {
+                track.added_at = ts.timestamp() as u64;
+            }
+        }
+        Some(track)
     }
 }
 
@@ -444,6 +529,7 @@ impl Album {
                     "compilation" => Some(rspotify::model::AlbumType::Compilation),
                     _ => None,
                 }),
+            images: album.images,
             added_at: 0,
         })
     }
@@ -464,6 +550,11 @@ impl Album {
             _ => String::new(),
         }
     }
+
+    /// tries to convert from a `serde_json::Value` into `Album`
+    pub fn try_from_simplified_album_value(value: serde_json::Value) -> Option<Self> {
+        serde_json::from_value(value).ok()
+    }
 }
 
 impl From<rspotify::model::FullAlbum> for Album {
@@ -474,6 +565,7 @@ impl From<rspotify::model::FullAlbum> for Album {
             release_date: album.release_date,
             artists: from_simplified_artists_to_artists(album.artists),
             typ: Some(album.album_type),
+            images: album.images,
             added_at: 0,
         }
     }
@@ -507,6 +599,7 @@ impl Artist {
         Some(Self {
             id: artist.id?,
             name: artist.name,
+            genres: vec![],
         })
     }
 }
@@ -516,6 +609,7 @@ impl From<rspotify::model::FullArtist> for Artist {
         Self {
             name: artist.name,
             id: artist.id,
+            genres: artist.genres,
         }
     }
 }
@@ -621,6 +715,7 @@ impl From<rspotify::model::SimplifiedEpisode> for Episode {
             duration: episode.duration.to_std().expect("valid chrono duration"),
             show: None,
             release_date: episode.release_date,
+            images: episode.images,
         }
     }
 }
@@ -634,10 +729,17 @@ impl From<rspotify::model::FullEpisode> for Episode {
             duration: episode.duration.to_std().expect("valid chrono duration"),
             show: Some(episode.show.into()),
             release_date: episode.release_date,
+            images: episode.images,
         }
     }
 }
 
+impl Episode {
+    /// tries to convert from a `serde_json::Value` into `Episode`
+    pub fn try_from_value(value: serde_json::Value) -> Option<Self> {
+        serde_json::from_value(value).ok()
+    }
+}
 impl std::fmt::Display for Episode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(s) = &self.show {

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -6,7 +6,7 @@ use std::{
 use chrono_humanize::HumanTime;
 use ratatui::text::Line;
 
-use crate::{state::Episode, utils::format_duration};
+use crate::state::Episode;
 
 use super::{
     config, utils, utils::construct_and_render_block, Album, Alignment, Artist, ArtistFocusState,
@@ -722,33 +722,6 @@ pub fn render_queue_page(
     ui: &mut UIStateGuard,
     rect: Rect,
 ) {
-    use rspotify::model::{FullEpisode, FullTrack, PlayableItem};
-    fn get_playable_name(item: &PlayableItem) -> String {
-        match item {
-            PlayableItem::Track(FullTrack { ref name, .. })
-            | PlayableItem::Episode(FullEpisode { ref name, .. }) => name.clone(),
-            PlayableItem::Unknown(_) => String::new(),
-        }
-    }
-    fn get_playable_artists(item: &PlayableItem) -> String {
-        match item {
-            PlayableItem::Track(FullTrack { ref artists, .. }) => artists
-                .iter()
-                .map(|a| a.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", "),
-            PlayableItem::Episode(FullEpisode { ref show, .. }) => show.publisher.clone(),
-            PlayableItem::Unknown(_) => String::new(),
-        }
-    }
-    fn get_playable_duration(item: &PlayableItem) -> String {
-        match item {
-            PlayableItem::Track(FullTrack { ref duration, .. })
-            | PlayableItem::Episode(FullEpisode { ref duration, .. }) => format_duration(duration),
-            PlayableItem::Unknown(_) => String::new(),
-        }
-    }
-
     // 1. Get data
     let player = state.player.read();
     let queue = match player.queue {
@@ -779,9 +752,11 @@ pub fn render_queue_page(
             .map(|(i, x)| {
                 Row::new(vec![
                     Cell::from(format!("{}", i + 1)),
-                    Cell::from(get_playable_name(x)),
-                    Cell::from(get_playable_artists(x)),
-                    Cell::from(get_playable_duration(x)),
+                    Cell::from(crate::utils::get_playable_item_name(x)),
+                    Cell::from(crate::utils::get_playable_item_artists(x)),
+                    Cell::from(crate::utils::format_duration(
+                        &crate::utils::get_playable_item_duration(x).unwrap_or_default(),
+                    )),
                 ])
             })
             .collect::<Vec<_>>(),
@@ -949,12 +924,8 @@ fn render_track_table(
     let mut playing_track_uri = String::new();
     let mut playing_id = "";
     if let Some(ref playback) = state.player.read().playback {
-        if let Some(rspotify::model::PlayableItem::Track(ref track)) = playback.item {
-            playing_track_uri = track
-                .id
-                .as_ref()
-                .map(rspotify::prelude::Id::uri)
-                .unwrap_or_default();
+        if let Some(ref item) = playback.item {
+            playing_track_uri = crate::utils::get_playable_item_uri(item);
 
             playing_id = if playback.is_playing {
                 &configs.app_config.play_icon

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -6,7 +6,7 @@ use super::{
 #[cfg(feature = "image")]
 use crate::state::ImageRenderInfo;
 use crate::{
-    state::Track,
+    state::{Episode, Show, Track},
     ui::utils::{format_genres, to_bidi_string},
 };
 #[cfg(feature = "image")]
@@ -50,15 +50,7 @@ pub fn render_playback_window(
                             }
                         };
 
-                    let url = match item {
-                        rspotify::model::PlayableItem::Track(track) => {
-                            crate::utils::get_track_album_image_url(track).map(String::from)
-                        }
-                        rspotify::model::PlayableItem::Episode(episode) => {
-                            crate::utils::get_episode_show_image_url(episode).map(String::from)
-                        }
-                        rspotify::model::PlayableItem::Unknown(_) => None,
-                    };
+                    let url = crate::utils::get_playable_item_image_url(item);
                     if let Some(url) = url {
                         let needs_clear = if ui.last_cover_image_render_info.url != url
                             || ui.last_cover_image_render_info.render_area != cover_img_rect
@@ -122,14 +114,11 @@ pub fn render_playback_window(
                 frame.render_widget(playback_desc, metadata_rect);
             }
 
-            let duration = match item {
-                rspotify::model::PlayableItem::Track(track) => track.duration,
-                rspotify::model::PlayableItem::Episode(episode) => episode.duration,
-                rspotify::model::PlayableItem::Unknown(item) => {
+            let duration = crate::utils::get_playable_item_duration(item)
+                .unwrap_or_else(|| {
                     log::warn!("Unknown playback item: {item:?}");
-                    return other_rect;
-                }
-            };
+                    chrono::Duration::zero()
+                });
 
             let progress = std::cmp::min(
                 player.playback_progress().expect("non-empty playback"),
@@ -208,6 +197,29 @@ fn construct_playback_text(
     playable: &rspotify::model::PlayableItem,
     playback: &PlaybackMetadata,
 ) -> Text<'static> {
+    // try to parse Unknown items into Track or Episode
+    let (track, episode) = match playable {
+        rspotify::model::PlayableItem::Track(track) => {
+            (Track::try_from_full_track(track.clone()), None)
+        }
+        rspotify::model::PlayableItem::Episode(episode) => (
+            None,
+            Some(Episode {
+                id: episode.id.clone(),
+                name: episode.name.clone(),
+                description: episode.description.clone(),
+                duration: episode.duration.to_std().expect("valid duration"),
+                show: Some(Show::from(episode.show.clone())),
+                release_date: episode.release_date.clone(),
+                images: episode.images.clone(),
+            }),
+        ),
+        rspotify::model::PlayableItem::Unknown(value) => (
+            Track::try_from_value(value.clone()),
+            Episode::try_from_value(value.clone()),
+        ),
+    };
+
     // Construct a "styled" text (`playback_text`) from playback's data
     // based on a user-configurable format string (app_config.playback_format)
     let configs = config::get_config();
@@ -246,92 +258,80 @@ fn construct_playback_text(
                 .to_owned(),
                 ui.theme.playback_status(),
             ),
-            "{liked}" => match playable {
-                rspotify::model::PlayableItem::Track(track) => match &track.id {
-                    Some(id) => {
-                        if data.user_data.saved_tracks.contains_key(&id.uri()) {
-                            (configs.app_config.liked_icon.clone(), ui.theme.like())
-                        } else {
-                            continue;
-                        }
+            "{liked}" => {
+                if let Some(t) = &track {
+                    if data.user_data.saved_tracks.contains_key(&t.id.uri()) {
+                        (configs.app_config.liked_icon.clone(), ui.theme.like())
+                    } else {
+                        continue;
                     }
-                    None => continue,
-                },
-                rspotify::model::PlayableItem::Episode(_)
-                | rspotify::model::PlayableItem::Unknown(_) => continue,
-            },
-            "{track}" => match playable {
-                rspotify::model::PlayableItem::Track(track) => (
-                    {
-                        let track = Track::try_from_full_track(track.clone()).unwrap();
-                        to_bidi_string(&track.display_name())
-                    },
-                    ui.theme.playback_track(),
-                ),
-                rspotify::model::PlayableItem::Episode(episode) => (
-                    {
-                        let bidi_string = to_bidi_string(&episode.name);
-                        if episode.explicit {
-                            format!("{bidi_string} (E)")
-                        } else {
-                            bidi_string
-                        }
-                    },
-                    ui.theme.playback_track(),
-                ),
-                rspotify::model::PlayableItem::Unknown(_) => {
+                } else {
                     continue;
                 }
-            },
-            "{track_number}" => match playable {
-                rspotify::model::PlayableItem::Track(track) => (
-                    { to_bidi_string(&track.track_number.to_string()) },
-                    ui.theme.playback_track(),
-                ),
-                rspotify::model::PlayableItem::Episode(_)
-                | rspotify::model::PlayableItem::Unknown(_) => {
+            }
+            "{track}" => {
+                if let Some(t) = &track {
+                    (
+                        to_bidi_string(&t.display_name()),
+                        ui.theme.playback_track(),
+                    )
+                } else if let Some(e) = &episode {
+                    (to_bidi_string(&e.name), ui.theme.playback_track())
+                } else {
                     continue;
                 }
-            },
-            "{artists}" => match playable {
-                rspotify::model::PlayableItem::Track(track) => (
-                    to_bidi_string(&crate::utils::map_join(&track.artists, |a| &a.name, ", ")),
-                    ui.theme.playback_artists(),
-                ),
-                rspotify::model::PlayableItem::Episode(episode) => {
-                    (episode.show.publisher.clone(), ui.theme.playback_artists())
-                }
-                rspotify::model::PlayableItem::Unknown(_) => {
+            }
+            "{track_number}" => {
+                continue;
+            }
+            "{artists}" => {
+                if let Some(t) = &track {
+                    (
+                        to_bidi_string(&t.artists_info()),
+                        ui.theme.playback_artists(),
+                    )
+                } else if let Some(e) = &episode {
+                    (
+                        e
+                            .show
+                            .as_ref()
+                            .map(|s| s.name.clone())
+                            .unwrap_or_default(),
+                        ui.theme.playback_artists(),
+                    )
+                } else {
                     continue;
                 }
-            },
-            "{album}" => match playable {
-                rspotify::model::PlayableItem::Track(track) => {
-                    (to_bidi_string(&track.album.name), ui.theme.playback_album())
-                }
-                rspotify::model::PlayableItem::Episode(episode) => (
-                    to_bidi_string(&episode.show.name),
-                    ui.theme.playback_album(),
-                ),
-                rspotify::model::PlayableItem::Unknown(_) => {
+            }
+            "{album}" => {
+                if let Some(t) = &track {
+                    (to_bidi_string(&t.album_info()), ui.theme.playback_album())
+                } else if let Some(e) = &episode {
+                    (
+                        to_bidi_string(
+                            &e
+                                .show
+                                .as_ref()
+                                .map(|s| s.name.clone())
+                                .unwrap_or_default(),
+                        ),
+                        ui.theme.playback_album(),
+                    )
+                } else {
                     continue;
                 }
-            },
-            "{genres}" => match playable {
-                rspotify::model::PlayableItem::Track(full_track) => {
-                    let genre = match data.caches.genres.get(&full_track.artists[0].name) {
+            }
+            "{genres}" => {
+                if let Some(t) = &track {
+                    let genre = match data.caches.genres.get(&t.artists[0].name) {
                         Some(genres) => &format_genres(genres, configs.app_config.genre_num),
                         None => "no genre",
                     };
                     (to_bidi_string(genre), ui.theme.playback_genres())
-                }
-                rspotify::model::PlayableItem::Episode(_) => {
+                } else {
                     (to_bidi_string("no genre"), ui.theme.playback_genres())
                 }
-                rspotify::model::PlayableItem::Unknown(_) => {
-                    continue;
-                }
-            },
+            }
             "{metadata}" => {
                 let repeat_value = <&'static str>::from(playback.repeat_state).to_string();
 

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -37,6 +37,90 @@ pub fn get_episode_show_image_url(episode: &rspotify::model::FullEpisode) -> Opt
     }
 }
 
+#[cfg(feature = "image")]
+pub fn get_playable_item_image_url(item: &rspotify::model::PlayableItem) -> Option<String> {
+    match item {
+        rspotify::model::PlayableItem::Track(track) => {
+            get_track_album_image_url(track).map(String::from)
+        }
+        rspotify::model::PlayableItem::Episode(episode) => {
+            get_episode_show_image_url(episode).map(String::from)
+        }
+        rspotify::model::PlayableItem::Unknown(value) => {
+            crate::state::Track::try_from_value(value.clone())
+                .and_then(|t| t.album.and_then(|a| a.images.first().map(|i| i.url.clone())))
+                .or_else(|| {
+                    crate::state::Episode::try_from_value(value.clone())
+                        .and_then(|e| e.images.first().map(|i| i.url.clone()))
+                })
+        }
+    }
+}
+
+pub fn get_playable_item_duration(item: &rspotify::model::PlayableItem) -> Option<chrono::Duration> {
+    match item {
+        rspotify::model::PlayableItem::Track(track) => Some(track.duration),
+        rspotify::model::PlayableItem::Episode(episode) => Some(episode.duration),
+        rspotify::model::PlayableItem::Unknown(value) => {
+            crate::state::Track::try_from_value(value.clone())
+                .map(|t| chrono::Duration::from_std(t.duration).unwrap())
+                .or_else(|| {
+                    crate::state::Episode::try_from_value(value.clone())
+                        .map(|e| chrono::Duration::from_std(e.duration).unwrap())
+                })
+        }
+    }
+}
+
+pub fn get_playable_item_name(item: &rspotify::model::PlayableItem) -> String {
+    match item {
+        rspotify::model::PlayableItem::Track(track) => track.name.clone(),
+        rspotify::model::PlayableItem::Episode(episode) => episode.name.clone(),
+        rspotify::model::PlayableItem::Unknown(value) => {
+            crate::state::Track::try_from_value(value.clone())
+                .map(|t| t.name)
+                .or_else(|| crate::state::Episode::try_from_value(value.clone()).map(|e| e.name))
+                .unwrap_or_default()
+        }
+    }
+}
+
+pub fn get_playable_item_artists(item: &rspotify::model::PlayableItem) -> String {
+    match item {
+        rspotify::model::PlayableItem::Track(track) => {
+            map_join(&track.artists, |a| &a.name, ", ")
+        }
+        rspotify::model::PlayableItem::Episode(episode) => episode.show.publisher.clone(),
+        rspotify::model::PlayableItem::Unknown(value) => {
+            crate::state::Track::try_from_value(value.clone())
+                .map(|t| t.artists_info())
+                .or_else(|| {
+                    crate::state::Episode::try_from_value(value.clone())
+                        .and_then(|e| e.show.map(|s| s.name))
+                })
+                .unwrap_or_default()
+        }
+    }
+}
+
+pub fn get_playable_item_uri(item: &rspotify::model::PlayableItem) -> String {
+    use rspotify::prelude::Id;
+    match item {
+        rspotify::model::PlayableItem::Track(track) => track
+            .id
+            .as_ref()
+            .map(Id::uri)
+            .unwrap_or_default(),
+        rspotify::model::PlayableItem::Episode(episode) => episode.id.uri(),
+        rspotify::model::PlayableItem::Unknown(value) => {
+            crate::state::Track::try_from_value(value.clone())
+                .map(|t| t.id.uri())
+                .or_else(|| crate::state::Episode::try_from_value(value.clone()).map(|e| e.id.uri()))
+                .unwrap_or_default()
+        }
+    }
+}
+
 pub fn parse_uri(uri: &str) -> Cow<'_, str> {
     let parts = uri.split(':').collect::<Vec<_>>();
     // The below URI probably has a format of `spotify:user:{user_id}:{type}:{id}`,


### PR DESCRIPTION
Fixes critical UI and API breakages caused by the February 2026 Spotify Web API migration for Development Mode apps. Migrates to /items endpoint, adds model aliases/defaults for stripped fields, and improves search resilience.