### PR TITLE
Ghostty graphical progress bar option

### DIFF
--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -153,6 +153,7 @@ config_parser_impl!(BorderType);
 pub enum ProgressBarType {
     Line,
     Rectangle,
+    Terminal,
 }
 config_parser_impl!(ProgressBarType);
 

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -4,7 +4,7 @@ use crate::{
         self, construct_artist_actions, Action, ActionContext, ActionTarget, Command,
         CommandOrAction,
     },
-    config,
+    config::{self, ProgressBarType},
     key::{Key, KeySequence},
     state::{
         ActionListItem, Album, AlbumId, Artist, ArtistFocusState, ArtistId, ArtistPopupAction,
@@ -90,8 +90,15 @@ fn handle_mouse_event(
         }
         // a left click event
         crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
-            let rect = state.ui.lock().playback_progress_bar_rect;
-            if event.row == rect.y {
+            let (progress_row, progress_width) = if let ProgressBarType::Terminal =
+                config::get_config().app_config.progress_bar_type
+            {
+                (0, crossterm::terminal::window_size()?.columns)
+            } else {
+                let rect = state.ui.lock().playback_progress_bar_rect;
+                (rect.y, rect.width)
+            };
+            if event.row == progress_row {
                 // calculate the seek position (in ms) based on the mouse click position,
                 // the progress bar's width and the track's duration (in ms)
                 let player = state.player.read();
@@ -102,7 +109,7 @@ fn handle_mouse_event(
                 };
                 if let Some(duration) = duration {
                     let position_ms = (duration.num_milliseconds()) * i64::from(event.column)
-                        / i64::from(rect.width);
+                        / i64::from(progress_width);
                     client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
                         chrono::Duration::try_milliseconds(position_ms).unwrap(),
                     )))?;

--- a/spotify_player/src/key.rs
+++ b/spotify_player/src/key.rs
@@ -169,7 +169,7 @@ impl KeySequence {
         if self.keys.len() > other.keys.len() {
             return false;
         }
-        (0..self.keys.len()).fold(true, |acc, i| acc & (self.keys[i] == other.keys[i]))
+        (0..self.keys.len()).all(|i| self.keys[i] == other.keys[i])
     }
 }
 

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -90,6 +90,9 @@ fn init_ui() -> Result<Terminal> {
 
 /// Clean up UI resources before quitting the application
 fn clean_up(mut terminal: Terminal) -> Result<()> {
+    // disable ConEmu progress bar
+    print!("\x1b]9;4;0\x07");
+
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(
         terminal.backend_mut(),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -412,6 +412,22 @@ fn render_playback_progress_bar(
                 )),
             rect,
         ),
+        config::ProgressBarType::Terminal => {
+            // Ghostty terminal progress bar integration
+            let ratio_percentage = (ratio * 100.0).round() as u8;
+            print!("\x1b]9;4;1;{ratio_percentage}\x07");
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    format!(
+                        "{}/{}",
+                        crate::utils::format_duration(&progress),
+                        crate::utils::format_duration(&duration),
+                    ),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )),
+                rect,
+            );
+        }
     }
 
     // update the progress bar's position stored inside the UI state


### PR DESCRIPTION
using ConEmu escape sequences, draw a graphical progress bar as described in
https://ghostty.org/docs/install/release-notes/1-2-0#graphical-progress-bars

This can be enabled by setting `progress_bar_type = "Terminal"` in the config.

The left click handler for seeking has also been updated such that it responds when clicking the topmost row, just below the terminal progress bar.

# Preview

<img width="1253" height="853" alt="image" src="https://github.com/user-attachments/assets/90d71e59-41f5-473e-9d71-65d43640dce4" />

# Seeking


https://github.com/user-attachments/assets/b5c1b206-c653-402c-85c1-345a9f6cc336

