### PR TITLE
fix: Mouse seeking respects progress bar position

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -91,7 +91,10 @@ fn handle_mouse_event(
         // a left click event
         crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
             let rect = state.ui.lock().playback_progress_bar_rect;
-            if event.row == rect.y {
+            if event.row == rect.y
+                && event.column >= rect.x
+                && event.column < rect.x + rect.width
+            {
                 // calculate the seek position (in ms) based on the mouse click position,
                 // the progress bar's width and the track's duration (in ms)
                 let player = state.player.read();
@@ -101,7 +104,8 @@ fn handle_mouse_event(
                     Some(rspotify::model::PlayableItem::Unknown(_)) | None => None,
                 };
                 if let Some(duration) = duration {
-                    let position_ms = (duration.num_milliseconds()) * i64::from(event.column)
+                    let position_ms = (duration.num_milliseconds())
+                        * i64::from(event.column - rect.x)
                         / i64::from(rect.width);
                     client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
                         chrono::Duration::try_milliseconds(position_ms).unwrap(),

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -91,10 +91,7 @@ fn handle_mouse_event(
         // a left click event
         crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
             let rect = state.ui.lock().playback_progress_bar_rect;
-            if event.row == rect.y
-                && event.column >= rect.x
-                && event.column < rect.x + rect.width
-            {
+            if event.row == rect.y && event.column >= rect.x && event.column < rect.x + rect.width {
                 // calculate the seek position (in ms) based on the mouse click position,
                 // the progress bar's width and the track's duration (in ms)
                 let player = state.player.read();


### PR DESCRIPTION
Fixes #845

When `progress_bar_position = "Right"` is set, mouse seeking did not consider album art image width, leading to the progress bar jumping more to the right than intended. This PR fixes that issue.