### PR TITLE
Add logs page to see application's logs directly in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ List of supported commands:
 | `Queue`                         | go to the queue page                                                                               | `z`                |
 | `OpenCommandHelp`               | go to the command help page                                                                        | `?`, `C-h`         |
 | `PreviousPage`                  | go to the previous page                                                                            | `backspace`, `C-q` |
+| `OpenLogs`                      | go the the application logs page                                                                   | `g o`              |
 | `OpenSpotifyLinkFromClipboard`  | open a Spotify link from clipboard                                                                 | `O`                |
 | `SortTrackByTitle`              | sort the track table (if any) by track's title                                                     | `s t`              |
 | `SortTrackByArtists`            | sort the track table (if any) by track's artists                                                   | `s a`              |

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -89,6 +89,7 @@ pub enum Command {
     MovePlaylistItemDown,
 
     CreatePlaylist,
+    OpenLogs,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -372,6 +373,7 @@ impl Command {
             Self::MovePlaylistItemDown => "move playlist item down one position",
             Self::CreatePlaylist => "create a new playlist",
             Self::VolumeChange { offset: _ } => unreachable!(),
+            Self::OpenLogs => "go to the application logs page",
         }
         .to_string()
     }

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -328,6 +328,10 @@ impl Default for KeymapConfig {
                     key_sequence: "g c".into(),
                     command: Command::JumpToCurrentTrackInContext,
                 },
+                Keymap {
+                    key_sequence: "g o".into(),
+                    command: Command::OpenLogs,
+                },
             ],
         }
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -626,6 +626,9 @@ fn handle_global_command(
         Command::OpenCommandHelp => {
             ui.new_page(PageState::CommandHelp { scroll_offset: 0 });
         }
+        Command::OpenLogs => {
+            ui.new_page(PageState::Logs { scroll_offset: 0 });
+        }
         Command::RefreshPlayback => {
             client_pub.send(ClientRequest::GetCurrentPlayback)?;
         }

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -556,21 +556,12 @@ fn handle_command_for_command_help_page(command: Command, ui: &mut UIStateGuard)
 }
 
 fn handle_command_for_logs_page(command: Command, ui: &mut UIStateGuard) -> bool {
-    match command {
-        Command::SelectNextOrScrollDown => {
-            if let PageState::Logs { scroll_offset } = ui.current_page_mut() {
-                *scroll_offset += 1;
-            }
-            true
-        }
-        Command::SelectPreviousOrScrollUp => {
-            if let PageState::Logs { scroll_offset } = ui.current_page_mut() {
-                *scroll_offset = scroll_offset.saturating_sub(1);
-            }
-            true
-        }
-        _ => false,
-    }
+    let scroll_offset = match ui.current_page() {
+        PageState::Logs { scroll_offset } => *scroll_offset,
+        _ => return false,
+    };
+    let count = ui.count_prefix;
+    handle_navigation_command(command, ui.current_page_mut(), scroll_offset, 10000, count)
 }
 
 pub fn handle_navigation_command(

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -31,6 +31,7 @@ pub fn handle_key_sequence_for_page(
             PageType::Lyrics => Ok(false),
             PageType::Queue => Ok(handle_command_for_queue_page(command, ui)),
             PageType::CommandHelp => Ok(handle_command_for_command_help_page(command, ui)),
+            PageType::Logs => Ok(handle_command_for_logs_page(command, ui)),
         },
         Some(CommandOrAction::Action(action, ActionTarget::SelectedItem)) => match page_type {
             PageType::Search => anyhow::bail!("page search type should already be handled!"),
@@ -552,6 +553,24 @@ fn handle_command_for_command_help_page(command: Command, ui: &mut UIStateGuard)
     }
     let count = ui.count_prefix;
     handle_navigation_command(command, ui.current_page_mut(), scroll_offset, 10000, count)
+}
+
+fn handle_command_for_logs_page(command: Command, ui: &mut UIStateGuard) -> bool {
+    match command {
+        Command::SelectNextOrScrollDown => {
+            if let PageState::Logs { scroll_offset } = ui.current_page_mut() {
+                *scroll_offset += 1;
+            }
+            true
+        }
+        Command::SelectPreviousOrScrollUp => {
+            if let PageState::Logs { scroll_offset } = ui.current_page_mut() {
+                *scroll_offset = scroll_offset.saturating_sub(1);
+            }
+            true
+        }
+        _ => false,
+    }
 }
 
 pub fn handle_navigation_command(

--- a/spotify_player/src/log_layer.rs
+++ b/spotify_player/src/log_layer.rs
@@ -1,0 +1,56 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use parking_lot::Mutex;
+use tracing::Subscriber;
+use tracing_subscriber::Layer;
+
+pub struct BufferLayer {
+    buffer: Arc<Mutex<VecDeque<String>>>,
+    max_lines: usize,
+}
+
+impl BufferLayer {
+    pub fn new(buffer: Arc<Mutex<VecDeque<String>>>, max_lines: usize) -> Self {
+        Self { buffer, max_lines }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for BufferLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+
+        let level = event.metadata().level();
+        let target = event.metadata().target();
+        let line = format!(
+            "{} {:>5} {}: {}",
+            chrono::Local::now().format("%H:%M:%S"),
+            level,
+            target,
+            visitor.message
+        );
+
+        let mut buf = self.buffer.lock();
+        buf.push_back(line);
+        while buf.len() > self.max_lines {
+            buf.pop_front();
+        }
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{:?}", value);
+        }
+    }
+}

--- a/spotify_player/src/log_layer.rs
+++ b/spotify_player/src/log_layer.rs
@@ -50,7 +50,7 @@ struct MessageVisitor {
 impl tracing::field::Visit for MessageVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn core::fmt::Debug) {
         if field.name() == "message" {
-            self.message = format!("{:?}", value);
+            self.message = format!("{value:?}");
         }
     }
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -5,6 +5,7 @@ mod command;
 mod config;
 mod event;
 mod key;
+mod log_layer;
 #[cfg(feature = "media-control")]
 mod media_control;
 mod playlist_folders;
@@ -16,7 +17,10 @@ mod ui;
 mod utils;
 
 use anyhow::{Context, Result};
-use std::io::Write;
+use parking_lot::Mutex;
+use std::{collections::VecDeque, io::Write, sync::Arc};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 fn init_spotify(
     client_pub: &flume::Sender<client::ClientRequest>,
@@ -38,7 +42,10 @@ fn init_spotify(
     Ok(())
 }
 
-fn init_logging(log_folder: &std::path::Path) -> Result<()> {
+fn init_logging(
+    log_folder: &std::path::Path,
+    log_buffer: Arc<Mutex<VecDeque<String>>>,
+) -> Result<()> {
     if std::env::var_os("RUST_LOG").is_some_and(|x| x == "off") {
         // Don't create log files if logging is disabled.
         return Ok(());
@@ -59,10 +66,17 @@ fn init_logging(log_folder: &std::path::Path) -> Result<()> {
     }
     let log_file = std::fs::File::create(log_folder.join(format!("{log_prefix}.log")))
         .context("failed to create log file")?;
-    tracing_subscriber::fmt::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(false)
-        .with_writer(std::sync::Mutex::new(log_file))
+        .with_writer(std::sync::Mutex::new(log_file));
+
+    let buffer_layer = crate::log_layer::BufferLayer::new(log_buffer, 1000);
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(fmt_layer)
+        .with(buffer_layer)
         .init();
 
     // initialize the application's panic backtrace
@@ -272,7 +286,11 @@ fn main() -> Result<()> {
                 .as_deref()
                 .expect("log_folder is set");
 
-            init_logging(log_folder).context("failed to initialize application's logging")?;
+            let log_buffer: Arc<Mutex<VecDeque<String>>> =
+                Arc::new(Mutex::new(VecDeque::with_capacity(1000)));
+
+            init_logging(log_folder, log_buffer.clone())
+                .context("failed to initialize application's logging")?;
 
             // log the application's configurations
             tracing::info!("Configurations: {:?}", config::get_config());
@@ -301,7 +319,7 @@ fn main() -> Result<()> {
                 is_daemon = false;
             }
 
-            let state = std::sync::Arc::new(state::State::new(is_daemon));
+            let state = std::sync::Arc::new(state::State::new(is_daemon, log_buffer));
             start_app(&state)
         }
         Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args),

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -4,7 +4,7 @@ mod model;
 mod player;
 mod ui;
 
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 pub use constant::*;
 pub use data::*;
@@ -32,10 +32,12 @@ pub struct State {
     /// the mutex/state entirely when the feature is not in use.
     #[cfg(feature = "streaming")]
     pub vis_bands: Option<Arc<Mutex<crate::ui::streaming::VisBands>>>,
+
+    pub logs: Arc<Mutex<VecDeque<String>>>,
 }
 
 impl State {
-    pub fn new(is_daemon: bool) -> Self {
+    pub fn new(is_daemon: bool, log_buffer: Arc<Mutex<VecDeque<String>>>) -> Self {
         let mut ui = UIState::default();
         let configs = config::get_config();
 
@@ -59,6 +61,8 @@ impl State {
             } else {
                 None
             },
+
+            logs: log_buffer,
         }
     }
 

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -33,6 +33,9 @@ pub enum PageState {
     CommandHelp {
         scroll_offset: usize,
     },
+    Logs {
+        scroll_offset: usize,
+    },
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -44,6 +47,7 @@ pub enum PageType {
     Lyrics,
     Queue,
     CommandHelp,
+    Logs,
 }
 
 #[derive(Clone, Debug)]
@@ -147,6 +151,7 @@ impl PageState {
             PageState::Lyrics { .. } => PageType::Lyrics,
             PageState::Queue { .. } => PageType::Queue,
             PageState::CommandHelp { .. } => PageType::CommandHelp,
+            PageState::Logs { .. } => PageType::Logs,
         }
     }
 
@@ -232,9 +237,9 @@ impl PageState {
                 }
             },
             Self::Lyrics { .. } => None,
-            Self::CommandHelp { scroll_offset } | Self::Queue { scroll_offset } => {
-                Some(MutableWindowState::Scroll(scroll_offset))
-            }
+            Self::CommandHelp { scroll_offset }
+            | Self::Queue { scroll_offset }
+            | Self::Logs { scroll_offset } => Some(MutableWindowState::Scroll(scroll_offset)),
         }
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -135,6 +135,7 @@ fn render_main_layout(
         PageType::Lyrics => page::render_lyrics_page(is_active, frame, state, ui, rect),
         PageType::Queue => page::render_queue_page(frame, state, ui, rect),
         PageType::CommandHelp => page::render_commands_help_page(frame, ui, rect),
+        PageType::Logs => page::render_logs_page(frame, state, ui, rect),
     }
 }
 

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -1156,3 +1156,31 @@ fn render_episode_table(
         utils::render_table_window(frame, episode_table, rect, n_episodes, playable_table_state);
     }
 }
+
+pub fn render_logs_page(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGuard, rect: Rect) {
+    let rect = construct_and_render_block("Logs", &ui.theme, Borders::ALL, frame, rect);
+
+    let logs = state.logs.lock();
+    let scroll_offset = match ui.current_page_mut() {
+        PageState::Logs { scroll_offset } => *scroll_offset,
+        _ => return,
+    };
+
+    let lines: Vec<Line> = logs
+        .iter()
+        .skip(scroll_offset)
+        .map(|line| {
+            let style = if line.contains("ERROR") {
+                Style::default().fg(ratatui::style::Color::Red)
+            } else if line.contains("WARN") {
+                Style::default().fg(ratatui::style::Color::Yellow)
+            } else {
+                Style::default()
+            };
+            Line::styled(line, style)
+        })
+        .collect();
+
+    let paragraph = Paragraph::new(lines);
+    frame.render_widget(paragraph, rect);
+}

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -1162,7 +1162,12 @@ pub fn render_logs_page(frame: &mut Frame, state: &SharedState, ui: &mut UIState
 
     let logs = state.logs.lock();
     let scroll_offset = match ui.current_page_mut() {
-        PageState::Logs { scroll_offset } => *scroll_offset,
+        PageState::Logs { scroll_offset } => {
+            if !logs.is_empty() && *scroll_offset >= logs.len() {
+                *scroll_offset = logs.len() - 1;
+            }
+            *scroll_offset
+        }
         _ => return,
     };
 


### PR DESCRIPTION
Closes #954

Adds an in-app log viewer accessible via g o keybind.

Changes:

Added BufferLayer tracing layer that writes logs to a shared ring buffer (1000 lines max) alongside the existing file writer
Added PageState::Logs and Command::OpenLogs
Added render_logs_page with scroll support (j/k)
Default keybind: g o

Screenshot:
<img width="1668" height="1398" alt="image" src="https://github.com/user-attachments/assets/408e6f29-cb6c-425a-8469-514aa69cd43c" />