### PR TITLE
add `lyrics` CLI command

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -195,6 +195,7 @@ async fn handle_socket_request(
             let resp = handle_search_request(client, query).await?;
             Ok(resp)
         }
+        Request::Lyrics => handle_lyrics_request(client, state).await,
     }
 }
 
@@ -862,4 +863,42 @@ async fn playlist_import(
     ))?;
 
     Ok(result)
+}
+
+async fn handle_lyrics_request(client: &AppClient, state: Option<&SharedState>) -> Result<Vec<u8>> {
+    let playback = current_playback(client, state).await?;
+
+    let track = match playback {
+        Some(ref p) => match p.item {
+            Some(rspotify::model::PlayableItem::Track(ref t)) => t,
+            _ => anyhow::bail!("No track currently playing"),
+        },
+        None => anyhow::bail!("No active playback"),
+    };
+
+    let track_id = track.id.as_ref().context("Track has no ID")?;
+    let lyrics = client.lyrics(track_id.clone_static()).await?;
+
+    let mut output = format!(
+        "{} - {}\n\n",
+        track.name,
+        track
+            .artists
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    match lyrics {
+        Some(lyrics) => {
+            for (_, line) in &lyrics.lines {
+                output.push_str(line);
+                output.push('\n');
+            }
+        }
+        None => output.push_str("Lyrics not found"),
+    }
+
+    Ok(output.into_bytes())
 }

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -870,25 +870,21 @@ async fn handle_lyrics_request(
     state: Option<&SharedState>,
     id_or_name: Option<IdOrName>,
 ) -> Result<Vec<u8>> {
-    let track_id = match id_or_name {
-        Some(id_or_name) => {
-            let ItemId::Track(id) = get_spotify_id(client, ItemType::Track, id_or_name).await?
-            else {
-                anyhow::bail!("Unable to get track id")
-            };
-            id
-        }
-        None => {
-            let playback = current_playback(client, state).await?;
-            match playback {
-                Some(ref p) => match p.item {
-                    Some(rspotify::model::PlayableItem::Track(ref t)) => {
-                        t.id.as_ref().context("Track has no ID")?.clone_static()
-                    }
-                    _ => anyhow::bail!("No track currently playing"),
-                },
-                None => anyhow::bail!("No active playback"),
-            }
+    let track_id = if let Some(id_or_name) = id_or_name {
+        let ItemId::Track(id) = get_spotify_id(client, ItemType::Track, id_or_name).await? else {
+            anyhow::bail!("Unable to get track ID")
+        };
+        id
+    } else {
+        let playback = current_playback(client, state).await?;
+        match playback {
+            Some(ref p) => match p.item {
+                Some(rspotify::model::PlayableItem::Track(ref t)) => {
+                    t.id.as_ref().context("Track has no ID")?.clone_static()
+                }
+                _ => anyhow::bail!("No track currently playing"),
+            },
+            None => anyhow::bail!("No active playback"),
         }
     };
 

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -195,7 +195,7 @@ async fn handle_socket_request(
             let resp = handle_search_request(client, query).await?;
             Ok(resp)
         }
-        Request::Lyrics => handle_lyrics_request(client, state).await,
+        Request::Lyrics { id_or_name } => handle_lyrics_request(client, state, id_or_name).await,
     }
 }
 
@@ -865,19 +865,35 @@ async fn playlist_import(
     Ok(result)
 }
 
-async fn handle_lyrics_request(client: &AppClient, state: Option<&SharedState>) -> Result<Vec<u8>> {
-    let playback = current_playback(client, state).await?;
-
-    let track = match playback {
-        Some(ref p) => match p.item {
-            Some(rspotify::model::PlayableItem::Track(ref t)) => t,
-            _ => anyhow::bail!("No track currently playing"),
-        },
-        None => anyhow::bail!("No active playback"),
+async fn handle_lyrics_request(
+    client: &AppClient,
+    state: Option<&SharedState>,
+    id_or_name: Option<IdOrName>,
+) -> Result<Vec<u8>> {
+    let track_id = match id_or_name {
+        Some(id_or_name) => {
+            let ItemId::Track(id) = get_spotify_id(client, ItemType::Track, id_or_name).await?
+            else {
+                anyhow::bail!("Unable to get track id")
+            };
+            id
+        }
+        None => {
+            let playback = current_playback(client, state).await?;
+            match playback {
+                Some(ref p) => match p.item {
+                    Some(rspotify::model::PlayableItem::Track(ref t)) => {
+                        t.id.as_ref().context("Track has no ID")?.clone_static()
+                    }
+                    _ => anyhow::bail!("No track currently playing"),
+                },
+                None => anyhow::bail!("No active playback"),
+            }
+        }
     };
 
-    let track_id = track.id.as_ref().context("Track has no ID")?;
-    let lyrics = client.lyrics(track_id.clone_static()).await?;
+    let track = client.track(track_id.clone()).await?;
+    let lyrics = client.lyrics(track_id).await?;
 
     let mut output = format!(
         "{} - {}\n\n",

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -240,5 +240,10 @@ pub fn init_print_features_command() -> Command {
 }
 
 pub fn init_lyrics_command() -> Command {
-    Command::new("lyrics").about("Print current track's lyrics to stdout")
+    Command::new("lyrics")
+        .about(
+            "Print provided track`s name lyrics or current playing track, if no argument specified",
+        )
+        .arg(Arg::new("id").long("id").short('i').help("Track ID"))
+        .arg(Arg::new("name").long("name").short('n').help("Track Name"))
 }

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -81,12 +81,16 @@ fn init_playback_start_subcommand() -> Command {
 }
 
 fn add_id_or_name_group(cmd: Command) -> Command {
+    add_id_or_name_group_optional(cmd, true)
+}
+
+fn add_id_or_name_group_optional(cmd: Command, required: bool) -> Command {
     cmd.arg(Arg::new("id").long("id").short('i'))
         .arg(Arg::new("name").long("name").short('n'))
         .group(
             ArgGroup::new("id_or_name")
                 .args(["id", "name"])
-                .required(true),
+                .required(required),
         )
 }
 
@@ -240,10 +244,10 @@ pub fn init_print_features_command() -> Command {
 }
 
 pub fn init_lyrics_command() -> Command {
-    Command::new("lyrics")
-        .about(
-            "Print provided track`s name lyrics or current playing track, if no argument specified",
-        )
-        .arg(Arg::new("id").long("id").short('i').help("Track ID"))
-        .arg(Arg::new("name").long("name").short('n').help("Track Name"))
+    add_id_or_name_group_optional(
+        Command::new("lyrics").about(
+            "Print provided track's lyrics or current playing track, if no argument specified",
+        ),
+        false,
+    )
 }

--- a/spotify_player/src/cli/commands.rs
+++ b/spotify_player/src/cli/commands.rs
@@ -238,3 +238,7 @@ pub fn init_playlist_subcommand() -> Command {
 pub fn init_print_features_command() -> Command {
     Command::new("features").about("Print compiled in features")
 }
+
+pub fn init_lyrics_command() -> Command {
+    Command::new("lyrics").about("Print current track's lyrics to stdout")
+}

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -224,7 +224,17 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
                 .expect("query is required")
                 .to_owned(),
         },
-        "lyrics" => Request::Lyrics,
+        "lyrics" => {
+            let id_or_name = if let Some(id) = args.get_one::<String>("id") {
+                Some(IdOrName::Id(id.to_owned()))
+            } else if let Some(name) = args.get_one::<String>("name") {
+                Some(IdOrName::Name(name.to_owned()))
+            } else {
+                None
+            };
+
+            Request::Lyrics { id_or_name }
+        }
         _ => unreachable!(),
     };
 

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -225,13 +225,13 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
                 .to_owned(),
         },
         "lyrics" => {
-            let id_or_name = if let Some(id) = args.get_one::<String>("id") {
-                Some(IdOrName::Id(id.to_owned()))
-            } else if let Some(name) = args.get_one::<String>("name") {
-                Some(IdOrName::Name(name.to_owned()))
-            } else {
-                None
-            };
+            let id_or_name = args
+                .get_one::<String>("id")
+                .map(|id| IdOrName::Id(id.to_owned()))
+                .or_else(|| {
+                    args.get_one::<String>("name")
+                        .map(|name| IdOrName::Name(name.to_owned()))
+                });
 
             Request::Lyrics { id_or_name }
         }

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -28,21 +28,21 @@ fn receive_response(socket: &UdpSocket) -> Result<Response> {
 }
 
 fn get_id_or_name(args: &ArgMatches) -> IdOrName {
-    match args
-        .get_one::<Id>("id_or_name")
-        .expect("id_or_name group is required")
-        .as_str()
-    {
-        "name" => IdOrName::Name(
+    try_get_id_or_name(args).expect("id_or_name group is required")
+}
+
+fn try_get_id_or_name(args: &ArgMatches) -> Option<IdOrName> {
+    match args.get_one::<Id>("id_or_name")?.as_str() {
+        "name" => Some(IdOrName::Name(
             args.get_one::<String>("name")
                 .expect("name should be specified")
                 .to_owned(),
-        ),
-        "id" => IdOrName::Id(
+        )),
+        "id" => Some(IdOrName::Id(
             args.get_one::<String>("id")
                 .expect("id should be specified")
                 .to_owned(),
-        ),
+        )),
         id => panic!("unknown id: {id}"),
     }
 }
@@ -224,17 +224,9 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
                 .expect("query is required")
                 .to_owned(),
         },
-        "lyrics" => {
-            let id_or_name = args
-                .get_one::<String>("id")
-                .map(|id| IdOrName::Id(id.to_owned()))
-                .or_else(|| {
-                    args.get_one::<String>("name")
-                        .map(|name| IdOrName::Name(name.to_owned()))
-                });
-
-            Request::Lyrics { id_or_name }
-        }
+        "lyrics" => Request::Lyrics {
+            id_or_name: try_get_id_or_name(args),
+        },
         _ => unreachable!(),
     };
 

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -224,6 +224,7 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
                 .expect("query is required")
                 .to_owned(),
         },
+        "lyrics" => Request::Lyrics,
         _ => unreachable!(),
     };
 

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -131,7 +131,7 @@ pub enum Request {
     Like { unlike: bool },
     Playlist(PlaylistCommand),
     Search { query: String },
-    Lyrics,
+    Lyrics { id_or_name: Option<IdOrName> },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -131,6 +131,7 @@ pub enum Request {
     Like { unlike: bool },
     Playlist(PlaylistCommand),
     Search { query: String },
+    Lyrics,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -177,6 +178,7 @@ pub fn init_cli() -> anyhow::Result<clap::Command> {
         .subcommand(commands::init_generate_command())
         .subcommand(commands::init_search_command())
         .subcommand(commands::init_print_features_command())
+        .subcommand(commands::init_lyrics_command())
         .arg(
             clap::Arg::new("theme")
                 .short('t')


### PR DESCRIPTION
Closes #883

Added new CLI flag -- lyrics to print current track lyrics to stdout.

Usage:
```bash
spotify_player -- lyrics
```

Screenshot:
<img width="3439" height="1439" alt="image" src="https://github.com/user-attachments/assets/5f838799-f317-48b6-89df-f2f2bb90a46a" />