### PR TITLE
Handle nil tracks during playback

### DIFF
--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -310,8 +310,10 @@ fn construct_playback_text(
                 rspotify::model::PlayableItem::Track(track) => (
                     {
                         let display = Track::try_from_full_track(track.clone())
-                            .map(|t| to_bidi_string(&t.display_name()))
-                            .unwrap_or_else(|| "Unknown Track".to_string());
+                            .map_or_else(
+                                || "Unknown Track".to_string(),
+                                |t| to_bidi_string(&t.display_name()),
+                            );
                         display
                     },
                     ui.theme.playback_track(),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -309,11 +309,10 @@ fn construct_playback_text(
             "{track}" => match playable {
                 rspotify::model::PlayableItem::Track(track) => (
                     {
-                        let display = Track::try_from_full_track(track.clone())
-                            .map_or_else(
-                                || "Unknown Track".to_string(),
-                                |t| to_bidi_string(&t.display_name()),
-                            );
+                        let display = Track::try_from_full_track(track.clone()).map_or_else(
+                            || "Unknown Track".to_string(),
+                            |t| to_bidi_string(&t.display_name()),
+                        );
                         display
                     },
                     ui.theme.playback_track(),

--- a/spotify_player/src/ui/playback.rs
+++ b/spotify_player/src/ui/playback.rs
@@ -309,8 +309,10 @@ fn construct_playback_text(
             "{track}" => match playable {
                 rspotify::model::PlayableItem::Track(track) => (
                     {
-                        let track = Track::try_from_full_track(track.clone()).unwrap();
-                        to_bidi_string(&track.display_name())
+                        let display = Track::try_from_full_track(track.clone())
+                            .map(|t| to_bidi_string(&t.display_name()))
+                            .unwrap_or_else(|| "Unknown Track".to_string());
+                        display
                     },
                     ui.theme.playback_track(),
                 ),


### PR DESCRIPTION
Fixes #949 by swapping `unwrap` for `unwrap_or_else`.