### PR TITLE
feat: pause playback on app quit

### DIFF
--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -569,6 +569,7 @@ fn handle_global_command(
 ) -> Result<bool> {
     match command {
         Command::Quit => {
+            client_pub.send(ClientRequest::Player(PlayerRequest::Pause))?;
             ui.is_running = false;
         }
         Command::NextTrack => {


### PR DESCRIPTION
## Summary

Sends a Pause request when the user quits the TUI so playback stops instead of continuing in the background.

## Why this matters

If a song is playing and you close the app, it keeps playing through Spotify's servers. Reopening the app later doesn't resume where you left off. Pausing on quit fixes both problems.

## Changes

- `spotify_player/src/event/mod.rs`: Add `PlayerRequest::Pause` send in the `Command::Quit` handler, before setting `is_running = false`.

The `PlayerRequest::Pause` handler (in `client/mod.rs:296`) already checks `playback.is_playing`, so this is a no-op when nothing is playing. The flume channel `send()` queues the message synchronously, and the client consumer processes it during the UI loop's refresh sleep before `process::exit` runs.

## Testing

Verified the change compiles and follows the same pattern as other player commands (NextTrack, PreviousTrack, ResumePause) which all use `client_pub.send(ClientRequest::Player(...))`.

Fixes #944

This contribution was developed with AI assistance (Claude Code).