### PR TITLE
feat: option to ignore "the" at the start of names when sorting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -52,6 +52,7 @@ spotify_player -o device.volume=80 -o theme=dracula
 | `enable_streaming`                | Enable streaming (`Always`, `Never`, or `DaemonOnly`).                                         | `Always`                                                               |
 | `enable_audio_visualization`      | Show a real-time frequency bar chart in the playback window (requires `streaming` feature).    | `false`                                                                |
 | `enable_notify`                   | Enable notifications (requires `notify` feature).                                              | `true`                                                                 |
+| `sort_ignore_the`                 | Ignore "the" at the start of names when sorting in library.                                    | `true`                                                                 |
 | `enable_cover_image_cache`        | Cache album cover images.                                                                      | `true`                                                                 |
 | `notify_streaming_only`           | Send notifications only when streaming is active (requires `streaming` and `notify` features). | `false`                                                                |
 | `default_device`                  | Default device to connect to on startup.                                                       | `spotify-player`                                                       |

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -119,6 +119,8 @@ pub struct AppConfig {
     #[cfg(feature = "notify")]
     pub enable_notify: bool,
 
+    pub sort_ignore_the: bool,
+
     pub enable_cover_image_cache: bool,
 
     pub default_device: String,
@@ -374,6 +376,8 @@ impl Default for AppConfig {
 
             #[cfg(feature = "notify")]
             enable_notify: true,
+
+            sort_ignore_the: true,
 
             enable_cover_image_cache: true,
 

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -104,6 +104,16 @@ fn handle_command_for_library_page(
     if command == Command::SortLibraryAlphabetically {
         let mut data = state.data.write();
 
+        // Always compare using lowercase, strip "the " prefix if set in config
+        let filter = if config::get_config().app_config.sort_ignore_the {
+            |name: &str| {
+                let lowered = name.to_lowercase();
+                lowered.strip_prefix("the ").unwrap_or(&lowered).to_string()
+            }
+        } else {
+            |name: &str| name.to_lowercase()
+        };
+
         // Sort playlists alphabetically, keeping folders on top
         data.user_data.playlists.sort_by(|a, b| match (a, b) {
             (PlaylistFolderItem::Folder(_), PlaylistFolderItem::Playlist(_)) => {
@@ -112,21 +122,18 @@ fn handle_command_for_library_page(
             (PlaylistFolderItem::Playlist(_), PlaylistFolderItem::Folder(_)) => {
                 std::cmp::Ordering::Greater
             }
-            _ => a
-                .to_string()
-                .to_lowercase()
-                .cmp(&b.to_string().to_lowercase()),
+            _ => filter(&a.to_string()).cmp(&filter(&b.to_string())),
         });
 
         // Sort albums alphabetically
         data.user_data
             .saved_albums
-            .sort_by(|x, y| x.name.to_lowercase().cmp(&y.name.to_lowercase()));
+            .sort_by(|x, y| filter(&x.name).cmp(&filter(&y.name)));
 
         // Sort artists alphabetically
         data.user_data
             .followed_artists
-            .sort_by(|x, y| x.name.to_lowercase().cmp(&y.name.to_lowercase()));
+            .sort_by(|x, y| filter(&x.name).cmp(&filter(&y.name)));
     }
 
     if command == Command::SortLibraryByRecent {


### PR DESCRIPTION
### Description
Adds an option to the config which means that the prefix "the " at the start of names is ignored when sorting entries the user's library. This is consistent with how sorting works in the official Spotify client.