### PR TITLE
Fix clippy collapsible match warning

### DIFF
--- a/lyric_finder/src/lib.rs
+++ b/lyric_finder/src/lib.rs
@@ -249,10 +249,8 @@ mod parse {
         }
 
         match &node.data {
-            NodeData::Text { contents } => {
-                if should_parse {
-                    s.push_str(&contents.borrow().to_string());
-                }
+            NodeData::Text { contents } if should_parse => {
+                s.push_str(&contents.borrow().to_string());
             }
             NodeData::Element { ref name, .. } => {
                 if let expanded_name!(html "br") = name.expanded() {

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -121,12 +121,12 @@ fn handle_command_for_library_page(
         // Sort albums alphabetically
         data.user_data
             .saved_albums
-            .sort_by(|x, y| x.name.to_lowercase().cmp(&y.name.to_lowercase()));
+            .sort_by_key(|x| x.name.to_lowercase());
 
         // Sort artists alphabetically
         data.user_data
             .followed_artists
-            .sort_by(|x, y| x.name.to_lowercase().cmp(&y.name.to_lowercase()));
+            .sort_by_key(|x| x.name.to_lowercase());
     }
 
     if command == Command::SortLibraryByRecent {
@@ -155,7 +155,7 @@ fn handle_command_for_library_page(
         // Sort albums by recent addition
         data.user_data
             .saved_albums
-            .sort_by(|a, b| b.added_at.cmp(&a.added_at));
+            .sort_by_key(|a| std::cmp::Reverse(a.added_at));
     }
 
     match focus_state {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -27,6 +27,8 @@ pub fn handle_key_sequence_for_popup(
                 ui,
             );
         }
+        // can't use match guard: the match holds an immutable borrow of ui
+        #[allow(clippy::collapsible_match)]
         PopupState::UserPlaylistList(..) => {
             if handle_key_sequence_for_playlist_search_popup(key_sequence, ui) {
                 return Ok(true);

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -142,7 +142,7 @@ pub fn start_event_watcher(
     // The below refresh duration should be no less than 1s to avoid **overloading** linux dbus
     // handler provided by the souvlaki library, which only handles an event every 1s.
     // [1]: https://github.com/Sinono3/souvlaki/blob/b4d47bb2797ffdd625c17192df640510466762e1/src/platform/linux/mod.rs#L450
-    let refresh_duration = std::time::Duration::from_millis(1000);
+    let refresh_duration = std::time::Duration::from_secs(1);
     let mut info = String::new();
     loop {
         update_control_metadata(state, &mut controls, &mut info)?;

--- a/spotify_player/src/state/data.rs
+++ b/spotify_player/src/state/data.rs
@@ -24,7 +24,7 @@ pub enum FileCacheKey {
 
 /// default time-to-live cache duration
 pub static TTL_CACHE_DURATION: LazyLock<std::time::Duration> =
-    LazyLock::new(|| std::time::Duration::from_secs(60 * 60));
+    LazyLock::new(|| std::time::Duration::from_hours(1));
 
 /// the application's data
 pub struct AppData {


### PR DESCRIPTION
the CI workflow fails because of a clippy::collapsible-match warning.

This is clippy's suggested change.