### PR TITLE
fix: prevent stdin race between viuer and event handler (#1003)

### DIFF
--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -97,17 +97,6 @@ fn init_logging(
 
 #[tokio::main]
 async fn start_app(state: &state::SharedState) -> Result<()> {
-    if !state.is_daemon {
-        #[cfg(feature = "image")]
-        {
-            // initialize `viuer` supports for kitty, iterm2, and sixel
-            viuer::get_kitty_support();
-            viuer::is_iterm_supported();
-            #[cfg(feature = "sixel")]
-            viuer::is_sixel_supported();
-        }
-    }
-
     // client channels
     let (client_pub, client_sub) = flume::unbounded::<client::ClientRequest>();
 
@@ -179,21 +168,23 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
         })?;
 
     if !state.is_daemon {
-        // terminal event handler task
+        let terminal_ready = std::sync::Arc::new(std::sync::Barrier::new(2));
+
         std::thread::Builder::new()
             .name("terminal-event-handler".to_string())
             .spawn({
                 let client_pub = client_pub.clone();
                 let state = state.clone();
+                let terminal_ready = terminal_ready.clone();
                 move || {
+                    terminal_ready.wait();
                     event::start_event_handler(&state, &client_pub);
                 }
             })?;
 
-        // application UI task
         std::thread::Builder::new().name("ui".to_string()).spawn({
             let state = state.clone();
-            move || ui::run(&state)
+            move || ui::run(&state, terminal_ready)
         })?;
     }
 

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -184,7 +184,7 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
 
         std::thread::Builder::new().name("ui".to_string()).spawn({
             let state = state.clone();
-            move || ui::run(&state, terminal_ready)
+            move || ui::run(&state, &terminal_ready)
         })?;
     }
 

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -33,7 +33,7 @@ pub mod streaming;
 pub mod utils;
 
 /// Run the application UI
-pub fn run(state: &SharedState, terminal_ready: std::sync::Arc<std::sync::Barrier>) -> Result<()> {
+pub fn run(state: &SharedState, terminal_ready: &std::sync::Arc<std::sync::Barrier>) -> Result<()> {
     let mut terminal = init_ui().context("failed to initialize the application's UI")?;
     detect_image_protocol();
     terminal_ready.wait();

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -33,8 +33,10 @@ pub mod streaming;
 pub mod utils;
 
 /// Run the application UI
-pub fn run(state: &SharedState) -> Result<()> {
+pub fn run(state: &SharedState, terminal_ready: std::sync::Arc<std::sync::Barrier>) -> Result<()> {
     let mut terminal = init_ui().context("failed to initialize the application's UI")?;
+    detect_image_protocol();
+    terminal_ready.wait();
 
     let ui_refresh_duration = std::time::Duration::from_millis(
         config::get_config().app_config.app_refresh_duration_in_ms,
@@ -88,6 +90,16 @@ fn init_ui() -> Result<Terminal> {
     let mut terminal = ratatui::Terminal::new(backend)?;
     terminal.clear()?;
     Ok(terminal)
+}
+
+fn detect_image_protocol() {
+    #[cfg(feature = "image")]
+    {
+        viuer::get_kitty_support();
+        viuer::is_iterm_supported();
+        #[cfg(feature = "sixel")]
+        viuer::is_sixel_supported();
+    }
 }
 
 /// Clean up UI resources before quitting the application


### PR DESCRIPTION
Fixes #1003 — TUI intermittently fails to load on startup when the image feature is enabled on Kitty (and potentially other terminals that support the Kitty graphics protocol).
  
  Root Cause :
  
  On startup, viuer::get_kitty_support() sends escape sequences to the terminal and reads
  responses from stdin to detect graphics protocol support. Previously, this ran in start_app()
   while the terminal event handler thread was spawned independently shortly after.
  
  The event handler calls crossterm::event::read() in a loop, which also reads from stdin. If
  the terminal was slow to respond to viuer's protocol query, the response bytes would arrive
  after the event handler started — causing crossterm to consume them. This left viuer (and
  subsequently the UI) in a broken state.
  
  Because the timing depends on terminal response speed, the bug is intermittent — sometimes it
  works on the first try, sometimes it takes 5-6 restarts.
  
  Fix:
  
  Two changes:
  
  1. Moved detect_image_protocol() into the UI thread — it now runs inside ui::run(), after
  init_ui() has already enabled raw mode. This ensures the terminal query happens in a
  controlled, single-reader context.
  2. Added a std::sync::Barrier — the event handler thread waits on the barrier before starting
  crossterm::event::read(). The UI thread releases the barrier only after
  detect_image_protocol() completes. This guarantees no concurrent stdin readers during the
  protocol detection.
  
  Execution order (before → after)
  
  Before (racy):
  
  main thread:  viuer::get_kitty_support() → spawn threads
  event thread: crossterm::event::read()  ← could steal viuer's response
  ui thread:    init_ui() → render loop
  
  After (synchronized):
  
  ui thread:    init_ui() → detect_image_protocol() → barrier.wait()
  event thread: barrier.wait() → crossterm::event::read()
  
  Related
  
  - This is the same class of issue as #899, where the workaround was downgrading viuer to
  v0.9.2. This fix addresses the underlying race condition rather than relying on
  version-specific behavior.
  - The Cargo.toml comment about needing to resolve the freezing issue before upgrading viuer
  should now be unblocked by this fix.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────
  
  │ Note: I'm not a seasoned Rust developer, so I'm not entirely sure this is the most
  performant or idiomatic way to achieve this synchronization. If there's a lighter-weight
  primitive or a better pattern for this use case, I'm happy to adjust. The fix works reliably
  in my testing on Ubuntu + Kitty.