### PR TITLE
Rework auto-reconnect logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,13 @@ tracing::error!("...: {err:#}");
 tracing::debug!("{value:?}");
 ```
 
+### Comments and doc comments
+
+- Comment the _why_, not the _what_ — skip comments that restate the code.
+- Reserve comments for non-obvious intent: invariants, ordering constraints, workarounds, edge cases.
+- Keep comments concise and clear; avoid long paragraphs.
+- Try to keep comments up to date with code changes.
+
 ## Keeping docs up to date
 
 `README.md` and `docs/config.md` are the primary user-facing references. Update them on any user-visible change:
@@ -118,3 +125,11 @@ Keep `.github/copilot-instructions.md` and this `CLAUDE.md` in sync when project
 1. Add the variant to `Command` in `command.rs` and update `Command::desc()`.
 2. Add a default keybinding in `config/keymap.rs`.
 3. Update the command table in `README.md`.
+
+## Writing PR descriptions
+
+Base the description on the actual branch diff (`git diff master...<branch>`), not assumptions. Keep it clear and concise:
+
+- **Summary** — 2-4 sentences: what problem the change solves and the approach. State the _why_ (the prior behaviour / bug) before the _what_.
+- **Changes** — a bullet per logical change, each tagged with the affected module/file. Lead with the user-facing or architectural change, not mechanical edits.
+- Prefer plain prose over filler; omit empty sections. Add a short **Notes** section only for non-obvious trade-offs or follow-ups.

--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::config;
 use anyhow::{Context as _, Result};
 use base64::Engine as _;
-use librespot_core::{authentication::Credentials, cache::Cache, config::SessionConfig, Session};
+use librespot_core::{authentication::Credentials, cache::Cache, Session};
 use reqwest::Url;
 use rspotify::clients::{BaseClient as _, OAuthClient as _};
 use sha2::{Digest as _, Sha256};
@@ -48,7 +48,6 @@ pub const OAUTH_SCOPES: &[&str] = &[
 #[derive(Clone)]
 pub struct AuthConfig {
     pub cache: Cache,
-    pub session_config: SessionConfig,
     pub login_redirect_uri: String,
 }
 
@@ -56,7 +55,6 @@ impl Default for AuthConfig {
     fn default() -> Self {
         AuthConfig {
             cache: Cache::new(None::<String>, None, None, None).unwrap(),
-            session_config: SessionConfig::default(),
             login_redirect_uri: "http://127.0.0.1:8989/login".to_string(),
         }
     }
@@ -65,7 +63,8 @@ impl Default for AuthConfig {
 impl AuthConfig {
     /// Create a `librespot::Session` from authentication configs
     pub fn session(&self) -> Session {
-        Session::new(self.session_config.clone(), Some(self.cache.clone()))
+        let session_config = config::get_config().app_config.session_config();
+        Session::new(session_config, Some(self.cache.clone()))
     }
 
     pub fn new(configs: &config::Configs) -> Result<AuthConfig> {
@@ -84,7 +83,6 @@ impl AuthConfig {
 
         Ok(AuthConfig {
             cache,
-            session_config: configs.app_config.session_config(),
             login_redirect_uri: configs.app_config.login_redirect_uri.clone(),
         })
     }

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -131,10 +131,6 @@ async fn handle_socket_request(
     state: Option<&SharedState>,
     request: super::Request,
 ) -> Result<Vec<u8>> {
-    if let Some(state) = state {
-        client.check_valid_session(state).await?;
-    }
-
     match request {
         Request::Get(GetRequest::Key(key)) => handle_get_key_request(client, state, key).await,
         Request::Get(GetRequest::Item(item_type, id_or_name)) => {

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -41,21 +41,8 @@ pub async fn start_client_handler(
 }
 
 /// Interval between background session-validity checks.
-///
-/// Checking validity only reads a local flag (`Session::is_invalid`), so this
-/// can run frequently without making any API calls; it only triggers work when
-/// the session has actually been invalidated.
 const SESSION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Periodically checks whether the client's session is still valid and
-/// reconnects when it has become invalid (e.g. after a broken pipe, audio key
-/// timeout, or other network drop).
-///
-/// Without this, an invalid session is only detected the next time a
-/// [`ClientRequest`] happens to run [`super::AppClient::check_valid_session`],
-/// which may never occur while the application is idle (e.g. the default
-/// `playback_refresh_duration_in_ms = 0`, where no periodic playback refresh
-/// request is sent).
 pub async fn start_session_watcher(state: SharedState, client: super::AppClient) {
     let mut interval = tokio::time::interval(SESSION_CHECK_INTERVAL);
     // If a check ever runs long (e.g. a slow reconnect), skip missed ticks

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -25,11 +25,6 @@ pub async fn start_client_handler(
     client_sub: &flume::Receiver<ClientRequest>,
 ) {
     while let Ok(request) = client_sub.recv_async().await {
-        if let Err(err) = client.check_valid_session(state).await {
-            tracing::error!("{err:#}");
-            continue;
-        }
-
         let state = state.clone();
         let client = client.clone();
         let span = tracing::info_span!("client_request", request = ?request);
@@ -42,6 +37,36 @@ pub async fn start_client_handler(
             }
             .instrument(span),
         );
+    }
+}
+
+/// Interval between background session-validity checks.
+///
+/// Checking validity only reads a local flag (`Session::is_invalid`), so this
+/// can run frequently without making any API calls; it only triggers work when
+/// the session has actually been invalidated.
+const SESSION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Periodically checks whether the client's session is still valid and
+/// reconnects when it has become invalid (e.g. after a broken pipe, audio key
+/// timeout, or other network drop).
+///
+/// Without this, an invalid session is only detected the next time a
+/// [`ClientRequest`] happens to run [`super::AppClient::check_valid_session`],
+/// which may never occur while the application is idle (e.g. the default
+/// `playback_refresh_duration_in_ms = 0`, where no periodic playback refresh
+/// request is sent).
+pub async fn start_session_watcher(state: SharedState, client: super::AppClient) {
+    let mut interval = tokio::time::interval(SESSION_CHECK_INTERVAL);
+    // If a check ever runs long (e.g. a slow reconnect), skip missed ticks
+    // rather than firing them back-to-back.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        interval.tick().await;
+        if let Err(err) = client.check_valid_session(&state).await {
+            tracing::error!("Failed to check/reconnect the client's session: {err:#}");
+        }
     }
 }
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -223,7 +223,9 @@ impl AppClient {
 
         tracing::info!("Used a new session for Spotify client.");
 
-        self.refresh_token().await.context("refresh auth token")?;
+        if let Err(err) = self.refresh_token().await {
+            tracing::warn!("Failed to refresh auth token after creating a new session: {err:#}");
+        }
 
         if let Some(state) = state {
             // reset the application's caches

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -801,10 +801,10 @@ impl AppClient {
         #[cfg(feature = "streaming")]
         {
             let session = self.spotify.session().await;
-            devices.push((
-                configs.app_config.device.name.clone(),
-                session.device_id().to_string(),
-            ));
+            let device_name = configs.app_config.device.name.clone();
+            let device_id = session.device_id().to_string();
+            log::info!("Adding integrated device {device_name} to the device list: {device_id}");
+            devices.push((device_name, device_id));
         }
 
         if devices.is_empty() {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -142,8 +142,10 @@ impl AppClient {
             .clone())
     }
 
-    /// Initialize the application's playback upon creating a new session or during startup
-    pub fn initialize_playback(&self, state: &SharedState) {
+    /// Initialize the application's playback upon creating a new session or during startup.
+    ///
+    /// `resume` controls whether playback should be (re)started on the device we connect to.
+    pub fn initialize_playback(&self, state: &SharedState, resume: bool) {
         tokio::task::spawn({
             let client = self.clone();
             let state = state.clone();
@@ -178,11 +180,20 @@ impl AppClient {
                     };
 
                     if let Some(id) = id {
-                        tracing::info!("Trying to connect to device (id={id})");
+                        tracing::info!("Trying to connect to device (id={id}, resume={resume})");
                         if let Err(err) = client.transfer_playback(&id, Some(false)).await {
                             tracing::warn!("Connection failed (device_id={id}): {err:#}");
                         } else {
                             tracing::info!("Connection succeeded (device_id={id})!");
+                            if resume {
+                                if let Err(err) =
+                                    client.resume_playback(Some(id.as_ref()), None).await
+                                {
+                                    tracing::warn!(
+                                        "Failed to resume playback after reconnect: {err:#}"
+                                    );
+                                }
+                            }
                             // upon new connection, reset the buffered playback
                             state.player.write().buffered_playback = None;
                             client.update_playback(&state);
@@ -196,6 +207,19 @@ impl AppClient {
 
     /// Create a new client session
     pub async fn new_session(&self, state: Option<&SharedState>, reauth: bool) -> Result<()> {
+        // Capture whether playback was active *before* tearing down any existing streaming
+        // connection. Shutting down the old `librespot` spirc pauses playback Spotify-side
+        // (and a broken session leaves it paused too), so we use this to resume on the new
+        // device rather than reconnecting in a paused state.
+        let was_playing = state.is_some_and(|state| {
+            state
+                .player
+                .read()
+                .buffered_playback
+                .as_ref()
+                .is_some_and(|p| p.is_playing)
+        });
+
         let session = self.auth_config.session();
         let creds = auth::get_creds(&self.auth_config, reauth, true).context("get credentials")?;
         self.spotify.set_session(session.clone()).await;
@@ -230,7 +254,7 @@ impl AppClient {
         if let Some(state) = state {
             // reset the application's caches
             state.data.write().caches = MemoryCaches::new();
-            self.initialize_playback(state);
+            self.initialize_playback(state, was_playing);
         }
 
         Ok(())

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -24,26 +24,6 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::config::apply_config_override;
 
-fn init_spotify(
-    client_pub: &flume::Sender<client::ClientRequest>,
-    client: &client::AppClient,
-    state: &state::SharedState,
-) -> Result<()> {
-    client.initialize_playback(state);
-
-    // request user data
-    client_pub.send(client::ClientRequest::GetCurrentUser)?;
-    client_pub.send(client::ClientRequest::GetUserPlaylists)?;
-    client_pub.send(client::ClientRequest::GetUserFollowedArtists)?;
-    client_pub.send(client::ClientRequest::GetUserSavedAlbums)?;
-    client_pub.send(client::ClientRequest::GetContext(state::ContextId::Tracks(
-        state::USER_LIKED_TRACKS_ID.to_owned(),
-    )))?;
-    client_pub.send(client::ClientRequest::GetUserSavedShows)?;
-
-    Ok(())
-}
-
 fn init_logging(
     log_folder: &std::path::Path,
     log_buffer: Arc<Mutex<VecDeque<String>>>,
@@ -136,8 +116,15 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
         .await
         .context("initialize new Spotify session")?;
 
-    // initialize Spotify-related stuff
-    init_spotify(&client_pub, &client, state).context("Failed to initialize the Spotify data")?;
+    // request user data
+    client_pub.send(client::ClientRequest::GetCurrentUser)?;
+    client_pub.send(client::ClientRequest::GetUserPlaylists)?;
+    client_pub.send(client::ClientRequest::GetUserFollowedArtists)?;
+    client_pub.send(client::ClientRequest::GetUserSavedAlbums)?;
+    client_pub.send(client::ClientRequest::GetContext(state::ContextId::Tracks(
+        state::USER_LIKED_TRACKS_ID.to_owned(),
+    )))?;
+    client_pub.send(client::ClientRequest::GetUserSavedShows)?;
 
     // client socket task (for handling CLI commands)
     tokio::task::spawn({

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -151,8 +151,19 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
     // client event handler task
     tokio::task::spawn({
         let state = state.clone();
+        let client = client.clone();
         async move {
             client::start_client_handler(&state, &client, &client_sub).await;
+        }
+    });
+
+    // background task that detects an invalidated session and reconnects,
+    // independent of any incoming client request
+    tokio::task::spawn({
+        let state = state.clone();
+        let client = client.clone();
+        async move {
+            client::start_session_watcher(state, client).await;
         }
     });
 


### PR DESCRIPTION
### Summary

Reworks how the client detects and recovers from an invalidated `librespot` session (broken pipe, audio-key timeout, network drop). Previously a dead session was only noticed when an incoming `ClientRequest` happened to call `check_valid_session` — so while idle (the default, since `playback_refresh_duration_in_ms = 0` sends no periodic refresh) a broken session could go undetected indefinitely. This PR moves validity checking into a dedicated background task and resumes playback on reconnect.

### Changes

- **Dedicated session watcher** (`client/handlers.rs`): new `start_session_watcher` task polls validity every second and reconnects when the session drops. The check only reads a local flag (`Session::is_invalid`) — no API calls — so it's cheap to run frequently. Spawned as its own tokio task in `main.rs`.
- **Removed per-request checks**: dropped `check_valid_session` from the client handler loop and the CLI socket handler now that the watcher owns reconnection.
- **Auto-resume on reconnect** (`client/mod.rs`): `initialize_playback` takes a `resume` flag. `new_session` records whether playback was active *before* tearing down the old streaming connection (shutdown / a broken session pauses playback Spotify-side) and resumes on the new device, so reconnection no longer lands paused.
- **Fresh `device_id` per session** (`auth.rs`): `SessionConfig` is built fresh in `AuthConfig::session()` instead of stored and cloned, so each session gets a new device id rather than reusing a stale one, which causes an issue when reconnecting. 
- **Resilient token refresh** (`client/mod.rs`): a failed refresh during `new_session` now logs a warning instead of aborting the reconnect.
- **Cleanup** (`main.rs`): removed the redundant `init_spotify` wrapper; initial playback setup now happens in `new_session`.
