### PR TITLE
feat(device): track integrated device via `is_integrated` flag

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,6 @@ spotify_player -o device.volume=80 -o theme=dracula
 | `enable_notify`                   | Enable notifications (requires `notify` feature).                                                    | `true`                                                                 |
 | `enable_cover_image_cache`        | Cache album cover images.                                                                            | `true`                                                                 |
 | `notify_streaming_only`           | Send notifications only when streaming is active (requires `streaming` and `notify` features).       | `false`                                                                |
-| `default_device`                  | Default device to connect to on startup.                                                             | `spotify-player`                                                       |
 | `play_icon`                       | Icon for playing state.                                                                              | `▶`                                                                    |
 | `pause_icon`                      | Icon for paused state.                                                                               | `▌▌`                                                                   |
 | `liked_icon`                      | Icon for liked songs.                                                                                | `♥`                                                                    |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -16,7 +16,6 @@ enable_streaming = "Always"
 enable_notify = true
 enable_cover_image_cache = true
 notify_streaming_only = false
-default_device = "spotify-player"
 play_icon = "▶"
 pause_icon = "▌▌"
 liked_icon = "♥"

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -479,24 +479,8 @@ impl AppClient {
                     .filter_map(Device::try_from_device)
                     .collect();
 
-                // Include the local streaming device when the streaming feature is enabled.
-                // This ensures the device list is never empty when using integrated playback,
-                // even if the user hasn't configured a custom client_id or if the Spotify API
-                // hasn't registered the device yet.
                 #[cfg(feature = "streaming")]
-                {
-                    let configs = config::get_config();
-                    let session = self.spotify.session().await;
-                    let local_device = Device {
-                        id: session.device_id().to_string(),
-                        name: configs.app_config.device.name.clone(),
-                    };
-
-                    // Only add if not already in the list (avoid duplicates)
-                    if !devices.iter().any(|d| d.id == local_device.id) {
-                        devices.push(local_device);
-                    }
-                }
+                self.ensure_integrated_device(&mut devices).await;
 
                 state.player.write().devices = devices;
             }
@@ -800,49 +784,62 @@ impl AppClient {
     /// Find an available device. If found, return the device's ID.
     async fn find_available_device(&self) -> Result<Option<String>> {
         let devices = self.available_devices().await?;
-        tracing::info!("Available devices: {devices:?}");
 
         // if there is an active device, return it
         if let Some(d) = devices.iter().find(|d| d.is_active) {
             return Ok(d.id.clone());
         }
 
-        // convert a vector of `Device` items into `(name, id)` pairs
+        #[allow(unused_mut)]
         let mut devices = devices
             .into_iter()
-            .filter_map(|d| d.id.map(|id| (d.name, id)))
+            .filter_map(Device::try_from_device)
             .collect::<Vec<_>>();
 
-        let configs = config::get_config();
-
-        // Manually append the integrated device to the device list if `streaming` feature is enabled.
-        // The integrated device may not show up in the device list returned by the Spotify API because
-        // 1. The device is just initialized and hasn't been registered in Spotify server.
-        //    Related issue/discussion: https://github.com/aome510/spotify-player/issues/79
-        // 2. The device list is empty. This might be because user doesn't specify their own client ID.
-        //    By default, the application uses Spotify web app's client ID, which doesn't have
-        //    access to user's active devices.
         #[cfg(feature = "streaming")]
-        {
-            let session = self.spotify.session().await;
-            let device_name = configs.app_config.device.name.clone();
-            let device_id = session.device_id().to_string();
-            log::info!("Adding integrated device {device_name} to the device list: {device_id}");
-            devices.push((device_name, device_id));
-        }
+        self.ensure_integrated_device(&mut devices).await;
+
+        tracing::info!("no active device found, available devices: {devices:?}");
 
         if devices.is_empty() {
             return Ok(None);
         }
 
-        // Prioritize the `default_device` specified in the application's configurations,
-        // otherwise, use the first available device.
+        // Prioritize the integrated device; otherwise, use the first available device.
         let id = devices
             .iter()
-            .position(|d| d.0 == configs.app_config.default_device)
+            .position(|d| d.is_integrated)
             .unwrap_or_default();
 
-        Ok(Some(devices.remove(id).1))
+        Ok(Some(devices.remove(id).id))
+    }
+
+    /// Ensures the integrated librespot device (of *this* running instance) is present in `devices`.
+    ///
+    /// The integrated device may not show up in the device list returned by the Spotify API because
+    /// 1. The device is just initialized and hasn't been registered in Spotify server.
+    ///    Related issue/discussion: <https://github.com/aome510/spotify-player/issues/79>
+    /// 2. The device list is empty. This might be because user doesn't specify their own client ID.
+    ///    By default, the application uses Spotify web app's client ID, which doesn't have
+    ///    access to user's active devices.
+    #[cfg(feature = "streaming")]
+    async fn ensure_integrated_device(&self, devices: &mut Vec<Device>) {
+        let session = self.spotify.session().await;
+        let session_device_id = session.device_id().to_string();
+
+        // Mark the integrated device if it's already in the list; otherwise, add it, so it's
+        // always present without duplicating an entry the API already returned.
+        match devices.iter_mut().find(|d| d.id == session_device_id) {
+            Some(device) => device.is_integrated = true,
+            None => devices.insert(
+                0,
+                Device {
+                    id: session_device_id,
+                    name: config::get_config().app_config.device.name.clone(),
+                    is_integrated: true,
+                },
+            ),
+        }
     }
 
     /// Get the saved (liked) tracks of the current user

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -119,8 +119,6 @@ pub struct AppConfig {
 
     pub enable_cover_image_cache: bool,
 
-    pub default_device: String,
-
     pub device: DeviceConfig,
 
     #[cfg(all(feature = "streaming", feature = "notify"))]
@@ -382,8 +380,6 @@ impl Default for AppConfig {
             enable_notify: true,
 
             enable_cover_image_cache: true,
-
-            default_device: "spotify-player".to_string(),
 
             device: DeviceConfig::default(),
 

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -129,6 +129,11 @@ pub struct PlaybackMetadata {
 pub struct Device {
     pub id: String,
     pub name: String,
+    /// Whether this device is the integrated librespot player of *this* running instance.
+    ///
+    /// Used to distinguish the current app's integrated device from other `spotify-player`
+    /// instances (which may share the same device name) running elsewhere.
+    pub is_integrated: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -322,6 +327,7 @@ impl Device {
         Some(Self {
             id: device.id?,
             name: device.name,
+            is_integrated: false,
         })
     }
 }

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -97,7 +97,16 @@ pub fn render_popup(
                 let items = player
                     .devices
                     .iter()
-                    .map(|d| (format!("{} | {}", d.name, d.id), current_device_id == d.id))
+                    .map(|d| {
+                        // Mark the integrated device of this running instance to distinguish it
+                        // from other `spotify-player` instances running elsewhere.
+                        let name = if d.is_integrated {
+                            format!("{} (integrated)", d.name)
+                        } else {
+                            d.name.clone()
+                        };
+                        (format!("{name} | {}", d.id), current_device_id == d.id)
+                    })
                     .collect();
 
                 let rect = render_list_popup(frame, rect, "Devices", items, 5, ui);


### PR DESCRIPTION
Add an `is_integrated` field to the `Device` model to distinguish this instance's integrated librespot player from other `spotify-player` instances that may share the same device name.

- Extract the integrated-device insertion/dedup logic into a shared `ensure_integrated_device` helper, used by both the `GetDevices` handler and `find_available_device`.
- Select the auto-connect device by the `is_integrated` flag instead of matching against a configured name.
- Mark the integrated device with an "(integrated)" label in the device list popup.
- Remove the now-redundant `default_device` config option in favour of `is_integrated`.