### PR TITLE
fix: preserve client request ordering

### DIFF
--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context;
 use rspotify::model::Id;
@@ -18,26 +21,81 @@ struct PlayerEventHandlerState {
     last_playback_refresh_timer: Instant,
 }
 
+async fn dispatch_requests<T, Handler, HandlerFuture, RequiresOrderedExecution>(
+    request_sub: flume::Receiver<T>,
+    requires_ordered_execution: RequiresOrderedExecution,
+    handler: Handler,
+) where
+    T: Send + 'static,
+    Handler: Fn(T) -> HandlerFuture + Clone + Send + 'static,
+    HandlerFuture: Future<Output = ()> + Send + 'static,
+    RequiresOrderedExecution: Fn(&T) -> bool,
+{
+    let (ordered_pub, ordered_sub) = flume::unbounded();
+    let ordered_handler = handler.clone();
+    let ordered_task = tokio::task::spawn(async move {
+        while let Ok(request) = ordered_sub.recv_async().await {
+            if let Err(err) = tokio::task::spawn(ordered_handler(request)).await {
+                tracing::error!("Ordered client request task failed: {err:#}");
+            }
+        }
+    });
+    let mut concurrent_tasks = tokio::task::JoinSet::new();
+
+    while let Ok(request) = request_sub.recv_async().await {
+        if requires_ordered_execution(&request) {
+            if ordered_pub.send(request).is_err() {
+                break;
+            }
+        } else {
+            let handler = handler.clone();
+            concurrent_tasks.spawn(async move {
+                handler(request).await;
+            });
+        }
+
+        while let Some(result) = concurrent_tasks.try_join_next() {
+            if let Err(err) = result {
+                tracing::error!("Concurrent client request task failed: {err:#}");
+            }
+        }
+    }
+
+    drop(ordered_pub);
+    if let Err(err) = ordered_task.await {
+        tracing::error!("Ordered client request task failed: {err:#}");
+    }
+    while let Some(result) = concurrent_tasks.join_next().await {
+        if let Err(err) = result {
+            tracing::error!("Concurrent client request task failed: {err:#}");
+        }
+    }
+}
+
 /// starts the client's request handler
 pub async fn start_client_handler(
     state: &SharedState,
     client: &super::AppClient,
     client_sub: &flume::Receiver<ClientRequest>,
 ) {
-    while let Ok(request) = client_sub.recv_async().await {
-        let state = state.clone();
-        let client = client.clone();
-        let span = tracing::info_span!("client_request", request = ?request);
-
-        tokio::task::spawn(
+    let state = state.clone();
+    let client = client.clone();
+    dispatch_requests(
+        client_sub.clone(),
+        ClientRequest::requires_ordered_execution,
+        move |request| {
+            let state = state.clone();
+            let client = client.clone();
+            let span = tracing::info_span!("client_request", request = ?request);
             async move {
                 if let Err(err) = client.handle_request(&state, request).await {
                     tracing::error!("Failed to handle client request: {err:#}");
                 }
             }
-            .instrument(span),
-        );
-    }
+            .instrument(span)
+        },
+    )
+    .await;
 }
 
 /// Interval between background session-validity checks.
@@ -224,5 +282,106 @@ pub fn start_player_event_watcher(state: &SharedState, client_pub: &flume::Sende
         }
 
         std::thread::sleep(refresh_duration);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dispatch_requests;
+    use std::time::Duration;
+
+    struct TestRequest {
+        id: u8,
+        ordered: bool,
+        wait_for: Option<flume::Receiver<()>>,
+    }
+
+    fn test_dispatcher() -> (
+        flume::Sender<TestRequest>,
+        flume::Receiver<u8>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (request_pub, request_sub) = flume::unbounded();
+        let (completed_pub, completed_sub) = flume::unbounded();
+
+        let task = tokio::task::spawn(dispatch_requests(
+            request_sub,
+            |request: &TestRequest| request.ordered,
+            move |request: TestRequest| {
+                let completed_pub = completed_pub.clone();
+                async move {
+                    if let Some(wait_for) = request.wait_for {
+                        wait_for.recv_async().await.unwrap();
+                    }
+                    completed_pub.send_async(request.id).await.unwrap();
+                }
+            },
+        ));
+
+        (request_pub, completed_sub, task)
+    }
+
+    #[tokio::test]
+    async fn ordered_requests_finish_in_receive_order() {
+        let (gate_pub, gate_sub) = flume::bounded(1);
+        let (request_pub, completed_sub, task) = test_dispatcher();
+        request_pub
+            .send(TestRequest {
+                id: 1,
+                ordered: true,
+                wait_for: Some(gate_sub),
+            })
+            .unwrap();
+        request_pub
+            .send(TestRequest {
+                id: 2,
+                ordered: true,
+                wait_for: None,
+            })
+            .unwrap();
+        drop(request_pub);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), completed_sub.recv_async())
+                .await
+                .is_err()
+        );
+        gate_pub.send(()).unwrap();
+        task.await.unwrap();
+
+        assert_eq!(completed_sub.try_iter().collect::<Vec<_>>(), vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn concurrent_requests_are_not_blocked_by_ordered_requests() {
+        let (gate_pub, gate_sub) = flume::bounded(1);
+        let (request_pub, completed_sub, task) = test_dispatcher();
+        request_pub
+            .send(TestRequest {
+                id: 1,
+                ordered: true,
+                wait_for: Some(gate_sub),
+            })
+            .unwrap();
+        request_pub
+            .send(TestRequest {
+                id: 2,
+                ordered: false,
+                wait_for: None,
+            })
+            .unwrap();
+        drop(request_pub);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), completed_sub.recv_async())
+                .await
+                .unwrap()
+                .unwrap(),
+            2
+        );
+        gate_pub.send(()).unwrap();
+        task.await.unwrap();
+
+        assert_eq!(completed_sub.try_iter().collect::<Vec<_>>(), vec![1]);
     }
 }

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -21,14 +21,15 @@ struct PlayerEventHandlerState {
     last_playback_refresh_timer: Instant,
 }
 
-async fn dispatch_requests<T, Handler, HandlerFuture, RequiresOrderedExecution>(
+async fn dispatch_requests<T, Handler, HandlerFuture, HandlerOutput, RequiresOrderedExecution>(
     request_sub: flume::Receiver<T>,
     requires_ordered_execution: RequiresOrderedExecution,
     handler: Handler,
 ) where
     T: Send + 'static,
     Handler: Fn(T) -> HandlerFuture + Clone + Send + 'static,
-    HandlerFuture: Future<Output = ()> + Send + 'static,
+    HandlerFuture: Future<Output = HandlerOutput> + Send + 'static,
+    HandlerOutput: Send + 'static,
     RequiresOrderedExecution: Fn(&T) -> bool,
 {
     let (ordered_pub, ordered_sub) = flume::unbounded();
@@ -42,21 +43,33 @@ async fn dispatch_requests<T, Handler, HandlerFuture, RequiresOrderedExecution>(
     });
     let mut concurrent_tasks = tokio::task::JoinSet::new();
 
-    while let Ok(request) = request_sub.recv_async().await {
-        if requires_ordered_execution(&request) {
-            if ordered_pub.send(request).is_err() {
-                break;
-            }
-        } else {
-            let handler = handler.clone();
-            concurrent_tasks.spawn(async move {
-                handler(request).await;
-            });
-        }
-
+    loop {
         while let Some(result) = concurrent_tasks.try_join_next() {
             if let Err(err) = result {
                 tracing::error!("Concurrent client request task failed: {err:#}");
+            }
+        }
+
+        tokio::select! {
+            request = request_sub.recv_async() => {
+                let Ok(request) = request else {
+                    break;
+                };
+                if requires_ordered_execution(&request) {
+                    if ordered_pub.send(request).is_err() {
+                        break;
+                    }
+                } else {
+                    let handler = handler.clone();
+                    concurrent_tasks.spawn(async move {
+                        handler(request).await
+                    });
+                }
+            }
+            result = concurrent_tasks.join_next(), if !concurrent_tasks.is_empty() => {
+                if let Some(Err(err)) = result {
+                    tracing::error!("Concurrent client request task failed: {err:#}");
+                }
             }
         }
     }
@@ -290,6 +303,14 @@ mod tests {
     use super::dispatch_requests;
     use std::time::Duration;
 
+    struct DropSignal(flume::Sender<()>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
     struct TestRequest {
         id: u8,
         ordered: bool,
@@ -383,5 +404,40 @@ mod tests {
         task.await.unwrap();
 
         assert_eq!(completed_sub.try_iter().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn completed_concurrent_tasks_are_reaped_while_request_stream_is_idle() {
+        let (request_pub, request_sub) = flume::unbounded();
+        let (gate_pub, gate_sub) = flume::bounded(1);
+        let (started_pub, started_sub) = flume::bounded(1);
+        let (reaped_pub, reaped_sub) = flume::bounded(1);
+        let task = tokio::task::spawn(dispatch_requests(
+            request_sub,
+            |_: &()| false,
+            move |()| {
+                let gate_sub = gate_sub.clone();
+                let started_pub = started_pub.clone();
+                let reaped_pub = reaped_pub.clone();
+                async move {
+                    started_pub.send_async(()).await.unwrap();
+                    gate_sub.recv_async().await.unwrap();
+                    DropSignal(reaped_pub)
+                }
+            },
+        ));
+
+        request_pub.send(()).unwrap();
+        started_sub.recv_async().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        gate_pub.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), reaped_sub.recv_async())
+            .await
+            .unwrap()
+            .unwrap();
+
+        drop(request_pub);
+        task.await.unwrap();
     }
 }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -195,7 +195,10 @@ impl AppClient {
                                 }
                             }
                             // upon new connection, reset the buffered playback
-                            state.player.write().buffered_playback = None;
+                            let mut player = state.player.write();
+                            player.invalidate_playback_refreshes();
+                            player.buffered_playback = None;
+                            drop(player);
                             client.update_playback(&state);
                             break;
                         }
@@ -462,9 +465,16 @@ impl AppClient {
                 state.data.write().user_data.user = Some(user);
             }
             ClientRequest::Player(request) => {
-                let playback = state.player.read().buffered_playback.clone();
-                let playback = self.handle_player_request(request, playback).await?;
-                state.player.write().buffered_playback = playback;
+                let playback = {
+                    let mut player = state.player.write();
+                    player.invalidate_playback_refreshes();
+                    player.buffered_playback.clone()
+                };
+                let playback_result = self.handle_player_request(request, playback).await;
+                let mut player = state.player.write();
+                player.invalidate_playback_refreshes();
+                player.buffered_playback = playback_result?;
+                drop(player);
                 self.update_playback(state);
             }
             ClientRequest::GetCurrentPlayback => {
@@ -1659,10 +1669,17 @@ impl AppClient {
         state: &SharedState,
         reset_buffered_playback: bool,
     ) -> Result<()> {
+        let refresh_generation = state.player.write().begin_playback_refresh();
+        let playback = self.current_playback2().await?;
         let new_playback = {
-            // update the playback state
-            let playback = self.current_playback2().await?;
             let mut player = state.player.write();
+            if !player.is_current_playback_refresh(refresh_generation) {
+                tracing::debug!(
+                    refresh_generation,
+                    "Discarded a stale playback refresh response"
+                );
+                return Ok(());
+            }
 
             let prev_item = player.currently_playing();
 

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -60,3 +60,64 @@ pub enum ClientRequest {
         desc: String,
     },
 }
+
+impl ClientRequest {
+    /// Whether this request must run in the order it was received.
+    ///
+    /// Requests in this group either change Spotify state or refresh player state that can
+    /// conflict with those changes. Other data-fetching requests remain concurrent so slow
+    /// catalog or library loads do not delay this lane.
+    pub(crate) fn requires_ordered_execution(&self) -> bool {
+        match self {
+            Self::GetCurrentUser
+            | Self::GetDevices
+            | Self::GetBrowseCategories
+            | Self::GetBrowseCategoryPlaylists(_)
+            | Self::GetUserPlaylists
+            | Self::GetUserSavedAlbums
+            | Self::GetUserSavedShows
+            | Self::GetUserFollowedArtists
+            | Self::GetContext(_)
+            | Self::Search(_)
+            | Self::GetLyrics { .. } => false,
+            Self::GetCurrentPlayback
+            | Self::AddPlayableToQueue(_)
+            | Self::AddAlbumToQueue(_)
+            | Self::AddPlayableToPlaylist(_, _)
+            | Self::DeleteTrackFromPlaylist(_, _)
+            | Self::ReorderPlaylistItems { .. }
+            | Self::AddToLibrary(_)
+            | Self::DeleteFromLibrary(_)
+            | Self::Player(_)
+            | Self::GetCurrentUserQueue
+            | Self::CreatePlaylist { .. } => true,
+            #[cfg(feature = "streaming")]
+            Self::RestartIntegratedClient => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientRequest, PlayerRequest};
+
+    #[test]
+    fn stateful_requests_require_ordered_execution() {
+        assert!(ClientRequest::Player(PlayerRequest::Pause).requires_ordered_execution());
+        assert!(ClientRequest::GetCurrentPlayback.requires_ordered_execution());
+        assert!(ClientRequest::CreatePlaylist {
+            playlist_name: "playlist".to_owned(),
+            public: false,
+            collab: false,
+            desc: String::new(),
+        }
+        .requires_ordered_execution());
+    }
+
+    #[test]
+    fn independent_reads_allow_concurrent_execution() {
+        assert!(!ClientRequest::GetBrowseCategories.requires_ordered_execution());
+        assert!(!ClientRequest::GetUserSavedAlbums.requires_ordered_execution());
+        assert!(!ClientRequest::Search("query".to_owned()).requires_ordered_execution());
+    }
+}

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -14,6 +14,10 @@ pub struct PlayerState {
     // Related issue: https://github.com/aome510/spotify-player/issues/109
     pub buffered_playback: Option<PlaybackMetadata>,
 
+    /// Identifies the most recently started playback refresh. A refresh only applies its result
+    /// while its generation remains current.
+    playback_refresh_generation: u64,
+
     pub queue: Option<rspotify::model::CurrentUserQueue>,
 
     /// The currently playing Tracks context (for contexts not tracked by Spotify's playback, e.g. liked/top tracks)
@@ -26,6 +30,19 @@ pub struct PlayerState {
 }
 
 impl PlayerState {
+    pub(crate) fn begin_playback_refresh(&mut self) -> u64 {
+        self.invalidate_playback_refreshes();
+        self.playback_refresh_generation
+    }
+
+    pub(crate) fn invalidate_playback_refreshes(&mut self) {
+        self.playback_refresh_generation = self.playback_refresh_generation.wrapping_add(1);
+    }
+
+    pub(crate) fn is_current_playback_refresh(&self, generation: u64) -> bool {
+        self.playback_refresh_generation == generation
+    }
+
     /// Get the current playback
     ///
     /// # Note
@@ -112,5 +129,30 @@ impl PlayerState {
             },
             None => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PlayerState;
+
+    #[test]
+    fn newer_playback_refresh_supersedes_older_refresh() {
+        let mut player = PlayerState::default();
+        let older = player.begin_playback_refresh();
+        let newer = player.begin_playback_refresh();
+
+        assert!(!player.is_current_playback_refresh(older));
+        assert!(player.is_current_playback_refresh(newer));
+    }
+
+    #[test]
+    fn player_change_invalidates_pending_playback_refresh() {
+        let mut player = PlayerState::default();
+        let pending = player.begin_playback_refresh();
+
+        player.invalidate_playback_refreshes();
+
+        assert!(!player.is_current_playback_refresh(pending));
     }
 }


### PR DESCRIPTION
## Summary

- route state-changing client requests through a serialized execution lane
- keep independent data-fetching requests concurrent
- discard playback refresh responses superseded by a newer refresh or player command
- add deterministic delayed-handler tests for ordered and concurrent execution

## Why

The client handler previously spawned every received request as an independent task. Although the channel preserved receive order, completion order was uncontrolled. Rapid player commands could read the same buffered playback snapshot, and playlist or library mutations could reach Spotify out of order. Delayed playback refreshes could also overwrite newer local state.

The ordered lane now preserves receive order for conflicting requests without making slow catalog and library fetches block one another. Playback refresh generations ensure that only the newest in-flight response can update player state.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features rodio-backend,media-control,image,notify,fzf`
- `cargo clippy --no-default-features --features rodio-backend,media-control,image,notify,fzf -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `git diff --check`

Closes #1027
