### PR TITLE
fix: restore terminal after thread failures

### DIFF
--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -53,12 +53,31 @@ impl Drop for UiThreadSupervisor {
     }
 }
 
+fn install_panic_hook(backtrace_file: Option<std::fs::File>) {
+    let backtrace_file = backtrace_file.map(std::sync::Mutex::new);
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        ui::handle_panic();
+
+        if let Some(backtrace_file) = backtrace_file.as_ref() {
+            if let Ok(mut file) = backtrace_file.lock() {
+                let backtrace = backtrace::Backtrace::new();
+                let _ = writeln!(&mut file, "Got a panic: {info:#?}\n");
+                let _ = writeln!(&mut file, "Stack backtrace:\n{backtrace:?}");
+            }
+        }
+
+        previous_hook(info);
+    }));
+}
+
 fn init_logging(
     log_folder: &std::path::Path,
     log_buffer: Arc<Mutex<VecDeque<String>>>,
 ) -> Result<()> {
     if std::env::var_os("RUST_LOG").is_some_and(|x| x == "off") {
         // Don't create log files if logging is disabled.
+        install_panic_hook(None);
         return Ok(());
     }
 
@@ -93,19 +112,7 @@ fn init_logging(
     // initialize the application's panic backtrace
     let backtrace_file = std::fs::File::create(log_folder.join(format!("{log_prefix}.backtrace")))
         .context("failed to create backtrace file")?;
-    let backtrace_file = std::sync::Mutex::new(backtrace_file);
-    let previous_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        ui::handle_panic();
-
-        if let Ok(mut file) = backtrace_file.lock() {
-            let backtrace = backtrace::Backtrace::new();
-            let _ = writeln!(&mut file, "Got a panic: {info:#?}\n");
-            let _ = writeln!(&mut file, "Stack backtrace:\n{backtrace:?}");
-        }
-
-        previous_hook(info);
-    }));
+    install_panic_hook(Some(backtrace_file));
 
     Ok(())
 }

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -24,6 +24,35 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::config::apply_config_override;
 
+struct UiThreadSupervisor {
+    state: state::SharedState,
+    thread: Option<std::thread::JoinHandle<Result<()>>>,
+}
+
+impl UiThreadSupervisor {
+    fn new(state: state::SharedState, thread: std::thread::JoinHandle<Result<()>>) -> Self {
+        Self {
+            state,
+            thread: Some(thread),
+        }
+    }
+
+    fn join(mut self) -> Result<()> {
+        join_ui_thread(self.thread.take().expect("UI thread is available"))
+    }
+}
+
+impl Drop for UiThreadSupervisor {
+    fn drop(&mut self) {
+        self.state.ui.lock().is_running = false;
+        if let Some(thread) = self.thread.take() {
+            if let Err(err) = join_ui_thread(thread) {
+                tracing::error!("Failed while shutting down the UI thread: {err:#}");
+            }
+        }
+    }
+}
+
 fn init_logging(
     log_folder: &std::path::Path,
     log_buffer: Arc<Mutex<VecDeque<String>>>,
@@ -65,11 +94,17 @@ fn init_logging(
     let backtrace_file = std::fs::File::create(log_folder.join(format!("{log_prefix}.backtrace")))
         .context("failed to create backtrace file")?;
     let backtrace_file = std::sync::Mutex::new(backtrace_file);
+    let previous_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let mut file = backtrace_file.lock().unwrap();
-        let backtrace = backtrace::Backtrace::new();
-        writeln!(&mut file, "Got a panic: {info:#?}\n").unwrap();
-        writeln!(&mut file, "Stack backtrace:\n{backtrace:?}").unwrap();
+        ui::handle_panic();
+
+        if let Ok(mut file) = backtrace_file.lock() {
+            let backtrace = backtrace::Backtrace::new();
+            let _ = writeln!(&mut file, "Got a panic: {info:#?}\n");
+            let _ = writeln!(&mut file, "Stack backtrace:\n{backtrace:?}");
+        }
+
+        previous_hook(info);
     }));
 
     Ok(())
@@ -165,7 +200,9 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
             }
         })?;
 
-    if !state.is_daemon {
+    let ui_thread = if state.is_daemon {
+        None
+    } else {
         #[cfg(feature = "image")]
         ui::init_image_picker(state).context("initialize image picker")?;
         let terminal = ui::init_terminal().context("initialize terminal")?;
@@ -182,11 +219,22 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
             })?;
 
         // application UI task
-        std::thread::Builder::new().name("ui".to_string()).spawn({
+        let ui_thread = std::thread::Builder::new().name("ui".to_string()).spawn({
             let state = state.clone();
-            move || ui::run(&state, terminal)
+            move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    ui::run(&state, terminal)
+                }));
+                state.ui.lock().is_running = false;
+
+                match result {
+                    Ok(result) => result,
+                    Err(payload) => std::panic::resume_unwind(payload),
+                }
+            }
         })?;
-    }
+        Some(UiThreadSupervisor::new(state.clone(), ui_thread))
+    };
 
     #[cfg(feature = "media-control")]
     if config::get_config().app_config.enable_media_control {
@@ -213,14 +261,44 @@ async fn start_app(state: &state::SharedState) -> Result<()> {
             // control events. The below code will create an invisible window on startup
             // to listen to such events.
             let event_loop = winit::event_loop::EventLoop::new()?;
+            let state = state.clone();
             #[allow(deprecated)]
-            event_loop.run(move |_, _| {})?;
+            event_loop.run(move |_, event_loop| {
+                event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(
+                    std::time::Instant::now() + std::time::Duration::from_millis(100),
+                ));
+                if !state.ui.lock().is_running {
+                    event_loop.exit();
+                }
+            })?;
         }
     }
 
-    // infinite loop to keep the main thread alive
+    if let Some(ui_thread) = ui_thread {
+        return ui_thread.join();
+    }
+
+    // Keep daemon mode alive while its background tasks are healthy.
     loop {
+        if ui::application_panicked() {
+            anyhow::bail!("an application thread panicked");
+        }
         std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload")
+}
+
+fn join_ui_thread(ui_thread: std::thread::JoinHandle<Result<()>>) -> Result<()> {
+    match ui_thread.join() {
+        Ok(result) => result.context("application UI failed"),
+        Err(payload) => anyhow::bail!("UI thread panicked: {}", panic_payload_message(&*payload)),
     }
 }
 
@@ -321,5 +399,21 @@ fn main() -> Result<()> {
             start_app(&state)
         }
         Some((cmd, args)) => cli::handle_cli_subcommand(cmd, args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_ui_thread;
+
+    #[test]
+    fn ui_thread_panic_is_reported_as_an_error() {
+        let ui_thread = std::thread::spawn(|| -> anyhow::Result<()> {
+            panic!("injected UI failure");
+        });
+
+        let err = join_ui_thread(ui_thread).unwrap_err();
+
+        assert!(err.to_string().contains("injected UI failure"));
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -18,11 +18,66 @@ use ratatui::{
     },
     Frame,
 };
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 #[cfg(feature = "image")]
 use crate::state::ImageRenderInfo;
 
-type Terminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>;
+type RatatuiTerminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>;
+
+const RAW_MODE_ACTIVE: u8 = 1 << 0;
+const ALTERNATE_SCREEN_ACTIVE: u8 = 1 << 1;
+const MOUSE_CAPTURE_ACTIVE: u8 = 1 << 2;
+
+static ACTIVE_TERMINAL_STATE: AtomicU8 = AtomicU8::new(0);
+static APPLICATION_PANICKED: AtomicBool = AtomicBool::new(false);
+
+struct RestoreOnDrop<F: FnOnce()>(Option<F>);
+
+impl<F: FnOnce()> RestoreOnDrop<F> {
+    fn new(restore: F) -> Self {
+        Self(Some(restore))
+    }
+
+    fn disarm(&mut self) {
+        self.0.take();
+    }
+}
+
+impl<F: FnOnce()> Drop for RestoreOnDrop<F> {
+    fn drop(&mut self) {
+        if let Some(restore) = self.0.take() {
+            restore();
+        }
+    }
+}
+
+pub(crate) struct TerminalSession {
+    terminal: RatatuiTerminal,
+    restore_guard: RestoreOnDrop<fn()>,
+}
+
+impl TerminalSession {
+    fn restore(mut self) -> Result<()> {
+        let result = restore_active_terminal();
+        self.restore_guard.disarm();
+        result
+    }
+}
+
+impl std::ops::Deref for TerminalSession {
+    type Target = RatatuiTerminal;
+
+    fn deref(&self) -> &Self::Target {
+        &self.terminal
+    }
+}
+
+impl std::ops::DerefMut for TerminalSession {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.terminal
+    }
+}
 
 #[cfg(feature = "image")]
 pub mod cover_image;
@@ -35,18 +90,21 @@ pub mod streaming;
 pub mod utils;
 
 /// Run the application UI
-pub fn run(state: &SharedState, mut terminal: Terminal) -> Result<()> {
+pub(crate) fn run(state: &SharedState, mut terminal: TerminalSession) -> Result<()> {
     let ui_refresh_duration = std::time::Duration::from_millis(
         config::get_config().app_config.app_refresh_duration_in_ms,
     );
     let mut last_terminal_size = None;
 
     loop {
+        if application_panicked() {
+            anyhow::bail!("another application thread panicked");
+        }
+
         {
             let mut ui = state.ui.lock();
             if !ui.is_running {
-                clean_up(terminal).context("clean up UI resources")?;
-                std::process::exit(0);
+                break;
             }
 
             let terminal_size = terminal.size()?;
@@ -73,26 +131,37 @@ pub fn run(state: &SharedState, mut terminal: Terminal) -> Result<()> {
 
         std::thread::sleep(ui_refresh_duration);
     }
+
+    terminal.restore().context("clean up UI resources")
 }
 
-pub fn init_terminal() -> Result<Terminal> {
+pub(crate) fn init_terminal() -> Result<TerminalSession> {
     let mut stdout = std::io::stdout();
     crossterm::terminal::enable_raw_mode()?;
-    crossterm::execute!(
-        stdout,
-        crossterm::terminal::EnterAlternateScreen,
-        crossterm::event::EnableMouseCapture
-    )?;
+    ACTIVE_TERMINAL_STATE.fetch_or(RAW_MODE_ACTIVE, Ordering::SeqCst);
+    let restore_guard = RestoreOnDrop::new(restore_active_terminal_best_effort as fn());
+
+    ACTIVE_TERMINAL_STATE.fetch_or(ALTERNATE_SCREEN_ACTIVE, Ordering::SeqCst);
+    crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen)?;
+
+    ACTIVE_TERMINAL_STATE.fetch_or(MOUSE_CAPTURE_ACTIVE, Ordering::SeqCst);
+    crossterm::execute!(stdout, crossterm::event::EnableMouseCapture)?;
+
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = ratatui::Terminal::new(backend)?;
     terminal.clear()?;
-    Ok(terminal)
+    Ok(TerminalSession {
+        terminal,
+        restore_guard,
+    })
 }
 
 #[cfg(feature = "image")]
 pub fn init_image_picker(state: &SharedState) -> Result<()> {
     let mut ui = state.ui.lock();
     crossterm::terminal::enable_raw_mode()?;
+    ACTIVE_TERMINAL_STATE.fetch_or(RAW_MODE_ACTIVE, Ordering::SeqCst);
+    let mut restore_guard = RestoreOnDrop::new(restore_active_terminal_best_effort as fn());
     ui.picker = match ratatui_image::picker::Picker::from_query_stdio() {
         Ok(p) => p,
         Err(err) => {
@@ -101,6 +170,8 @@ pub fn init_image_picker(state: &SharedState) -> Result<()> {
         }
     };
     crossterm::terminal::disable_raw_mode()?;
+    ACTIVE_TERMINAL_STATE.fetch_and(!RAW_MODE_ACTIVE, Ordering::SeqCst);
+    restore_guard.disarm();
 
     // ratatui_image might detect the wrong protocol for iTerm2, so override it to the native iTerm2 protocol if detected
     // https://github.com/ratatui/ratatui-image/issues/158
@@ -123,16 +194,85 @@ fn is_iterm2() -> bool {
         || std::env::var("LC_TERMINAL").is_ok_and(|v| v.eq_ignore_ascii_case("iTerm2"))
 }
 
-/// Clean up UI resources before quitting the application
-fn clean_up(mut terminal: Terminal) -> Result<()> {
-    crossterm::terminal::disable_raw_mode()?;
-    crossterm::execute!(
-        terminal.backend_mut(),
-        crossterm::terminal::LeaveAlternateScreen,
-        crossterm::event::DisableMouseCapture,
+fn record_first_error(first_error: &mut Option<std::io::Error>, result: std::io::Result<()>) {
+    if let Err(err) = result {
+        first_error.get_or_insert(err);
+    }
+}
+
+fn restore_terminal_state_with<W, DisableRawMode>(
+    state: u8,
+    output: &mut W,
+    disable_raw_mode: DisableRawMode,
+) -> std::io::Result<()>
+where
+    W: std::io::Write,
+    DisableRawMode: FnOnce() -> std::io::Result<()>,
+{
+    let mut first_error = None;
+
+    if state & RAW_MODE_ACTIVE != 0 {
+        record_first_error(&mut first_error, disable_raw_mode());
+    }
+    if state & ALTERNATE_SCREEN_ACTIVE != 0 {
+        record_first_error(
+            &mut first_error,
+            crossterm::execute!(output, crossterm::terminal::LeaveAlternateScreen),
+        );
+    }
+    if state & MOUSE_CAPTURE_ACTIVE != 0 {
+        record_first_error(
+            &mut first_error,
+            crossterm::execute!(output, crossterm::event::DisableMouseCapture),
+        );
+    }
+    if state != 0 {
+        record_first_error(
+            &mut first_error,
+            crossterm::execute!(output, crossterm::cursor::Show),
+        );
+    }
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+fn restore_terminal_state(state: u8) -> Result<()> {
+    restore_terminal_state_with(
+        state,
+        &mut std::io::stdout(),
+        crossterm::terminal::disable_raw_mode,
     )?;
-    terminal.show_cursor()?;
     Ok(())
+}
+
+fn restore_active_terminal() -> Result<()> {
+    let state = ACTIVE_TERMINAL_STATE.swap(0, Ordering::SeqCst);
+    restore_terminal_state(state)
+}
+
+fn restore_active_terminal_best_effort() {
+    if let Err(err) = restore_active_terminal() {
+        eprintln!("Failed to restore terminal state: {err:#}");
+    }
+}
+
+/// Restore terminal state immediately after a panic and signal the UI loop to stop.
+///
+/// The active-state flags remain set so the terminal session guard repeats the cleanup after the
+/// UI thread has stopped drawing.
+pub(crate) fn handle_panic() {
+    APPLICATION_PANICKED.store(true, Ordering::SeqCst);
+    let state = ACTIVE_TERMINAL_STATE.load(Ordering::SeqCst);
+    if let Err(err) = restore_terminal_state(state) {
+        eprintln!("Failed to restore terminal state after panic: {err:#}");
+    }
+}
+
+pub(crate) fn application_panicked() -> bool {
+    APPLICATION_PANICKED.load(Ordering::SeqCst)
 }
 
 /// Render the application
@@ -201,5 +341,60 @@ impl Orientation {
             Self::Vertical => Layout::vertical(constraints),
             Self::Horizontal => Layout::horizontal(constraints),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        restore_terminal_state_with, RestoreOnDrop, ALTERNATE_SCREEN_ACTIVE, MOUSE_CAPTURE_ACTIVE,
+        RAW_MODE_ACTIVE,
+    };
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    fn contains_bytes(output: &[u8], expected: &[u8]) -> bool {
+        output
+            .windows(expected.len())
+            .any(|window| window == expected)
+    }
+
+    #[test]
+    fn terminal_restore_resets_every_enabled_mode() {
+        let raw_mode_disabled = AtomicBool::new(false);
+        let mut output = Vec::new();
+
+        restore_terminal_state_with(
+            RAW_MODE_ACTIVE | ALTERNATE_SCREEN_ACTIVE | MOUSE_CAPTURE_ACTIVE,
+            &mut output,
+            || {
+                raw_mode_disabled.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(raw_mode_disabled.load(Ordering::SeqCst));
+        assert!(contains_bytes(&output, b"\x1b[?1049l"));
+        assert!(contains_bytes(&output, b"\x1b[?1000l"));
+        assert!(contains_bytes(&output, b"\x1b[?25h"));
+    }
+
+    #[test]
+    fn terminal_restore_guard_runs_during_unwind() {
+        let restored = Arc::new(AtomicBool::new(false));
+        let restored_by_guard = restored.clone();
+
+        let result = std::panic::catch_unwind(move || {
+            let _guard = RestoreOnDrop::new(move || {
+                restored_by_guard.store(true, Ordering::SeqCst);
+            });
+            panic!("injected terminal failure");
+        });
+
+        assert!(result.is_err());
+        assert!(restored.load(Ordering::SeqCst));
     }
 }

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -60,7 +60,9 @@ pub(crate) struct TerminalSession {
 impl TerminalSession {
     fn restore(mut self) -> Result<()> {
         let result = restore_active_terminal();
-        self.restore_guard.disarm();
+        if result.is_ok() {
+            self.restore_guard.disarm();
+        }
         result
     }
 }
@@ -200,37 +202,40 @@ fn record_first_error(first_error: &mut Option<std::io::Error>, result: std::io:
     }
 }
 
-fn restore_terminal_state_with<W, DisableRawMode>(
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalRestoreAction {
+    DisableRawMode,
+    LeaveAlternateScreen,
+    DisableMouseCapture,
+    ShowCursor,
+}
+
+fn restore_terminal_state_with(
     state: u8,
-    output: &mut W,
-    disable_raw_mode: DisableRawMode,
-) -> std::io::Result<()>
-where
-    W: std::io::Write,
-    DisableRawMode: FnOnce() -> std::io::Result<()>,
-{
+    mut restore: impl FnMut(TerminalRestoreAction) -> std::io::Result<()>,
+) -> std::io::Result<()> {
     let mut first_error = None;
 
     if state & RAW_MODE_ACTIVE != 0 {
-        record_first_error(&mut first_error, disable_raw_mode());
+        record_first_error(
+            &mut first_error,
+            restore(TerminalRestoreAction::DisableRawMode),
+        );
     }
     if state & ALTERNATE_SCREEN_ACTIVE != 0 {
         record_first_error(
             &mut first_error,
-            crossterm::execute!(output, crossterm::terminal::LeaveAlternateScreen),
+            restore(TerminalRestoreAction::LeaveAlternateScreen),
         );
     }
     if state & MOUSE_CAPTURE_ACTIVE != 0 {
         record_first_error(
             &mut first_error,
-            crossterm::execute!(output, crossterm::event::DisableMouseCapture),
+            restore(TerminalRestoreAction::DisableMouseCapture),
         );
     }
     if state != 0 {
-        record_first_error(
-            &mut first_error,
-            crossterm::execute!(output, crossterm::cursor::Show),
-        );
+        record_first_error(&mut first_error, restore(TerminalRestoreAction::ShowCursor));
     }
 
     match first_error {
@@ -240,17 +245,34 @@ where
 }
 
 fn restore_terminal_state(state: u8) -> Result<()> {
-    restore_terminal_state_with(
-        state,
-        &mut std::io::stdout(),
-        crossterm::terminal::disable_raw_mode,
-    )?;
+    let mut stdout = std::io::stdout();
+    restore_terminal_state_with(state, |action| match action {
+        TerminalRestoreAction::DisableRawMode => crossterm::terminal::disable_raw_mode(),
+        TerminalRestoreAction::LeaveAlternateScreen => {
+            crossterm::execute!(&mut stdout, crossterm::terminal::LeaveAlternateScreen)
+        }
+        TerminalRestoreAction::DisableMouseCapture => {
+            crossterm::execute!(&mut stdout, crossterm::event::DisableMouseCapture)
+        }
+        TerminalRestoreAction::ShowCursor => {
+            crossterm::execute!(&mut stdout, crossterm::cursor::Show)
+        }
+    })?;
+    Ok(())
+}
+
+fn restore_active_terminal_with(
+    active_state: &AtomicU8,
+    restore: impl FnOnce(u8) -> Result<()>,
+) -> Result<()> {
+    let state = active_state.load(Ordering::SeqCst);
+    restore(state)?;
+    active_state.fetch_and(!state, Ordering::SeqCst);
     Ok(())
 }
 
 fn restore_active_terminal() -> Result<()> {
-    let state = ACTIVE_TERMINAL_STATE.swap(0, Ordering::SeqCst);
-    restore_terminal_state(state)
+    restore_active_terminal_with(&ACTIVE_TERMINAL_STATE, restore_terminal_state)
 }
 
 fn restore_active_terminal_best_effort() {
@@ -347,39 +369,54 @@ impl Orientation {
 #[cfg(test)]
 mod tests {
     use super::{
-        restore_terminal_state_with, RestoreOnDrop, ALTERNATE_SCREEN_ACTIVE, MOUSE_CAPTURE_ACTIVE,
-        RAW_MODE_ACTIVE,
+        restore_active_terminal_with, restore_terminal_state_with, RestoreOnDrop,
+        TerminalRestoreAction, ALTERNATE_SCREEN_ACTIVE, MOUSE_CAPTURE_ACTIVE, RAW_MODE_ACTIVE,
     };
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU8, Ordering},
         Arc,
     };
 
-    fn contains_bytes(output: &[u8], expected: &[u8]) -> bool {
-        output
-            .windows(expected.len())
-            .any(|window| window == expected)
-    }
-
     #[test]
     fn terminal_restore_resets_every_enabled_mode() {
-        let raw_mode_disabled = AtomicBool::new(false);
-        let mut output = Vec::new();
+        let mut actions = Vec::new();
 
         restore_terminal_state_with(
             RAW_MODE_ACTIVE | ALTERNATE_SCREEN_ACTIVE | MOUSE_CAPTURE_ACTIVE,
-            &mut output,
-            || {
-                raw_mode_disabled.store(true, Ordering::SeqCst);
+            |action| {
+                actions.push(action);
                 Ok(())
             },
         )
         .unwrap();
 
-        assert!(raw_mode_disabled.load(Ordering::SeqCst));
-        assert!(contains_bytes(&output, b"\x1b[?1049l"));
-        assert!(contains_bytes(&output, b"\x1b[?1000l"));
-        assert!(contains_bytes(&output, b"\x1b[?25h"));
+        assert_eq!(
+            actions,
+            [
+                TerminalRestoreAction::DisableRawMode,
+                TerminalRestoreAction::LeaveAlternateScreen,
+                TerminalRestoreAction::DisableMouseCapture,
+                TerminalRestoreAction::ShowCursor,
+            ]
+        );
+    }
+
+    #[test]
+    fn failed_terminal_restore_remains_armed_for_retry() {
+        let active_state = AtomicU8::new(RAW_MODE_ACTIVE | MOUSE_CAPTURE_ACTIVE);
+
+        let result = restore_active_terminal_with(&active_state, |_| {
+            anyhow::bail!("injected restore failure")
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            active_state.load(Ordering::SeqCst),
+            RAW_MODE_ACTIVE | MOUSE_CAPTURE_ACTIVE
+        );
+
+        restore_active_terminal_with(&active_state, |_| Ok(())).unwrap();
+        assert_eq!(active_state.load(Ordering::SeqCst), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- own raw mode, alternate-screen mode, mouse capture, and cursor restoration through a terminal-session guard
- restore terminal state immediately from the panic hook while preserving backtrace files and default panic reporting
- supervise the UI thread and propagate UI failures through `main` instead of leaving the process asleep forever
- coordinate normal and panic shutdown with the existing UI running state, including the macOS and Windows event loop
- add tests for restoration commands, unwind cleanup, and UI panic propagation

## Why

The terminal was owned by a detached UI thread while the main thread slept forever. Cleanup only ran on the normal quit path, which called `process::exit` directly. A panic in the UI thread therefore skipped cleanup and left both the process and terminal in a broken state.

Terminal setup is now tracked as it succeeds, so partial initialization and later unwinding both restore every active terminal mode. The main application owns a UI-thread supervisor that signals shutdown, joins the UI thread on every return path, and converts UI panics into a nonzero application result. Panics in other application threads also signal the UI loop to stop after immediate terminal restoration.

## User impact

Normal quit still restores the terminal and exits successfully. Panics after terminal initialization now leave raw mode, mouse capture, the alternate screen, and cursor visibility in a usable state, then terminate the application with a failure status and useful panic output.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features rodio-backend,media-control,image,notify,fzf`
- `cargo clippy --no-default-features --features rodio-backend,media-control,image,notify,fzf -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `git diff --check`

Closes #1028
