### PR TITLE
feat: expose asynchronous request states

### DIFF
--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -6,7 +6,10 @@ use tracing::Instrument;
 
 use crate::{
     config,
-    state::{ContextId, ContextPageType, ContextPageUIState, PageState, PlayableId, SharedState},
+    state::{
+        ContextId, ContextPageType, ContextPageUIState, PageState, PlayableId, PopupState,
+        SharedState,
+    },
 };
 
 use crate::utils::map_join;
@@ -18,6 +21,17 @@ struct PlayerEventHandlerState {
     last_playback_refresh_timer: Instant,
 }
 
+fn short_error_message(err: &anyhow::Error) -> String {
+    const MAX_CHARS: usize = 140;
+
+    let mut message = err.to_string();
+    if let Some((truncate_at, _)) = message.char_indices().nth(MAX_CHARS) {
+        message.truncate(truncate_at);
+        message.push_str("...");
+    }
+    message
+}
+
 /// starts the client's request handler
 pub async fn start_client_handler(
     state: &SharedState,
@@ -25,14 +39,38 @@ pub async fn start_client_handler(
     client_sub: &flume::Receiver<ClientRequest>,
 ) {
     while let Ok(request) = client_sub.recv_async().await {
+        let token = state.requests.write().begin(request.metadata());
         let state = state.clone();
         let client = client.clone();
         let span = tracing::info_span!("client_request", request = ?request);
 
         tokio::task::spawn(
             async move {
-                if let Err(err) = client.handle_request(&state, request).await {
-                    tracing::error!("Failed to handle client request: {err:#}");
+                let close_playlist_popup = matches!(&request, ClientRequest::CreatePlaylist { .. });
+
+                match client.handle_request(&state, request).await {
+                    Ok(()) => {
+                        state.requests.write().succeed(&token);
+                        if close_playlist_popup {
+                            let mut ui = state.ui.lock();
+                            if matches!(ui.popup, Some(PopupState::PlaylistCreate { .. })) {
+                                ui.popup = None;
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        let short_error = short_error_message(&err);
+                        state.requests.write().fail(&token, &short_error);
+                        if close_playlist_popup {
+                            let mut ui = state.ui.lock();
+                            if let Some(PopupState::PlaylistCreate { submitting, .. }) =
+                                ui.popup.as_mut()
+                            {
+                                *submitting = false;
+                            }
+                        }
+                        tracing::error!("Failed to handle client request: {err:#}");
+                    }
                 }
             }
             .instrument(span),

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -664,7 +664,9 @@ impl AppClient {
                     .user
                     .as_ref()
                     .map(|u| u.id.clone())
-                    .unwrap();
+                    .context(
+                        "Current user data is unavailable. Wait for account data to finish loading, then retry playlist creation",
+                    )?;
                 self.create_new_playlist(
                     state,
                     user_id,

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -1,5 +1,6 @@
 use crate::state::{
-    AlbumId, Category, ContextId, Item, ItemId, PlayableId, Playback, PlaylistId, TrackId,
+    AlbumId, Category, ContextId, Id, Item, ItemId, PlayableId, Playback, PlaylistId, RequestKey,
+    RequestMetadata, RequestOperation, TrackId,
 };
 
 #[derive(Clone, Debug)]
@@ -59,4 +60,209 @@ pub enum ClientRequest {
         collab: bool,
         desc: String,
     },
+}
+
+impl ClientRequest {
+    pub(crate) fn metadata(&self) -> RequestMetadata {
+        match self {
+            Self::GetCurrentUser => RequestMetadata::tracked(RequestKey::CurrentUser),
+            Self::GetDevices => RequestMetadata::tracked(RequestKey::Devices),
+            Self::GetBrowseCategories => RequestMetadata::tracked(RequestKey::BrowseCategories),
+            Self::GetBrowseCategoryPlaylists(category) => {
+                RequestMetadata::tracked(RequestKey::BrowseCategory(category.id.clone()))
+            }
+            Self::GetUserPlaylists => RequestMetadata::tracked(RequestKey::UserPlaylists),
+            Self::GetUserSavedAlbums => RequestMetadata::tracked(RequestKey::UserSavedAlbums),
+            Self::GetUserSavedShows => RequestMetadata::tracked(RequestKey::UserSavedShows),
+            Self::GetUserFollowedArtists => {
+                RequestMetadata::tracked(RequestKey::UserFollowedArtists)
+            }
+            Self::GetContext(context) => {
+                RequestMetadata::tracked(RequestKey::Context(context.uri()))
+            }
+            Self::GetCurrentPlayback => RequestMetadata::default(),
+            Self::Search(query) => RequestMetadata::tracked(RequestKey::Search(query.clone())),
+            Self::AddPlayableToQueue(_) => RequestMetadata::operation(RequestOperation::new(
+                "Adding item to queue...",
+                "Item added to queue",
+                "Could not add item to queue",
+            )),
+            Self::AddAlbumToQueue(_) => RequestMetadata::operation(RequestOperation::new(
+                "Adding album to queue...",
+                "Album added to queue",
+                "Could not add album to queue",
+            )),
+            Self::AddPlayableToPlaylist(_, _) => RequestMetadata::operation(RequestOperation::new(
+                "Adding item to playlist...",
+                "Item added to playlist",
+                "Could not add item to playlist",
+            )),
+            Self::DeleteTrackFromPlaylist(_, _) => {
+                RequestMetadata::operation(RequestOperation::new(
+                    "Removing track from playlist...",
+                    "Track removed from playlist",
+                    "Could not remove track from playlist",
+                ))
+            }
+            Self::ReorderPlaylistItems { .. } => RequestMetadata::operation(RequestOperation::new(
+                "Reordering playlist...",
+                "Playlist reordered",
+                "Could not reorder playlist",
+            )),
+            Self::AddToLibrary(item) => {
+                let kind = item_kind(item);
+                RequestMetadata::operation(RequestOperation::new(
+                    format!("Adding {kind} to library..."),
+                    format!("{kind} added to library"),
+                    format!("Could not add {kind} to library"),
+                ))
+            }
+            Self::DeleteFromLibrary(item_id) => {
+                let kind = item_id_kind(item_id);
+                RequestMetadata::operation(RequestOperation::new(
+                    format!("Removing {kind} from library..."),
+                    format!("{kind} removed from library"),
+                    format!("Could not remove {kind} from library"),
+                ))
+            }
+            Self::Player(request) => RequestMetadata::operation(request.operation()),
+            Self::GetCurrentUserQueue => RequestMetadata::tracked(RequestKey::Queue),
+            Self::GetLyrics { track_id } => {
+                RequestMetadata::tracked(RequestKey::Lyrics(track_id.uri()))
+            }
+            #[cfg(feature = "streaming")]
+            Self::RestartIntegratedClient => RequestMetadata::operation(RequestOperation::new(
+                "Restarting integrated client...",
+                "Integrated client restarted",
+                "Could not restart integrated client",
+            )),
+            Self::CreatePlaylist { .. } => RequestMetadata::tracked_operation(
+                RequestKey::CreatePlaylist,
+                RequestOperation::new(
+                    "Creating playlist...",
+                    "Playlist created",
+                    "Could not create playlist",
+                ),
+            ),
+        }
+    }
+}
+
+impl PlayerRequest {
+    fn operation(&self) -> RequestOperation {
+        let (pending, success, failure) = match self {
+            Self::NextTrack => (
+                "Skipping to next track...",
+                "Playing next track",
+                "Could not skip to next track",
+            ),
+            Self::PreviousTrack => (
+                "Returning to previous track...",
+                "Playing previous track",
+                "Could not return to previous track",
+            ),
+            Self::Resume => (
+                "Resuming playback...",
+                "Playback resumed",
+                "Could not resume playback",
+            ),
+            Self::Pause => (
+                "Pausing playback...",
+                "Playback paused",
+                "Could not pause playback",
+            ),
+            Self::ResumePause => (
+                "Toggling playback...",
+                "Playback updated",
+                "Could not toggle playback",
+            ),
+            Self::SeekTrack(_) => (
+                "Seeking track...",
+                "Track position updated",
+                "Could not seek track",
+            ),
+            Self::Repeat => (
+                "Updating repeat mode...",
+                "Repeat mode updated",
+                "Could not update repeat mode",
+            ),
+            Self::Shuffle => (
+                "Updating shuffle mode...",
+                "Shuffle mode updated",
+                "Could not update shuffle mode",
+            ),
+            Self::Volume(_) => (
+                "Updating volume...",
+                "Volume updated",
+                "Could not update volume",
+            ),
+            Self::ToggleMute => ("Toggling mute...", "Mute updated", "Could not toggle mute"),
+            Self::TransferPlayback(_, _) => (
+                "Switching playback device...",
+                "Playback device switched",
+                "Could not switch playback device",
+            ),
+            Self::StartPlayback(_, _) => (
+                "Starting playback...",
+                "Playback started",
+                "Could not start playback",
+            ),
+        };
+        RequestOperation::new(pending, success, failure)
+    }
+}
+
+fn item_kind(item: &Item) -> &'static str {
+    match item {
+        Item::Track(_) => "Track",
+        Item::Album(_) => "Album",
+        Item::Artist(_) => "Artist",
+        Item::Playlist(_) => "Playlist",
+        Item::Show(_) => "Show",
+    }
+}
+
+fn item_id_kind(item_id: &ItemId) -> &'static str {
+    match item_id {
+        ItemId::Track(_) => "Track",
+        ItemId::Album(_) => "Album",
+        ItemId::Artist(_) => "Artist",
+        ItemId::Playlist(_) => "Playlist",
+        ItemId::Show(_) => "Show",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientRequest, PlayerRequest};
+    use crate::state::RequestKey;
+
+    #[test]
+    fn page_requests_have_stable_tracking_keys() {
+        assert_eq!(
+            ClientRequest::Search("query".to_owned()).metadata().key,
+            Some(RequestKey::Search("query".to_owned()))
+        );
+        assert_eq!(
+            ClientRequest::GetCurrentUserQueue.metadata().key,
+            Some(RequestKey::Queue)
+        );
+    }
+
+    #[test]
+    fn mutations_expose_operation_feedback() {
+        assert!(ClientRequest::Player(PlayerRequest::Pause)
+            .metadata()
+            .operation
+            .is_some());
+        assert!(ClientRequest::CreatePlaylist {
+            playlist_name: "playlist".to_owned(),
+            public: false,
+            collab: false,
+            desc: String::new(),
+        }
+        .metadata()
+        .operation
+        .is_some());
+    }
 }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -11,9 +11,10 @@ use crate::{
         BrowsePageUIState, ConfirmableAction, Context, ContextId, ContextPageType,
         ContextPageUIState, DataReadGuard, Focusable, Id, Item, ItemId, LibraryFocusState,
         LibraryPageUIState, PageState, PageType, PlayableId, Playback, PlaylistCreateCurrentField,
-        PlaylistFolderItem, PlaylistId, PlaylistPopupAction, PopupState, SearchFocusState,
-        SearchPageUIState, SharedState, ShowId, Track, TrackId, TrackOrder, TracksId, UIStateGuard,
-        USER_LIKED_TRACKS_ID, USER_RECENTLY_PLAYED_TRACKS_ID, USER_TOP_TRACKS_ID,
+        PlaylistFolderItem, PlaylistId, PlaylistPopupAction, PopupState, RequestKey,
+        SearchFocusState, SearchPageUIState, SharedState, ShowId, Track, TrackId, TrackOrder,
+        TracksId, UIStateGuard, USER_LIKED_TRACKS_ID, USER_RECENTLY_PLAYED_TRACKS_ID,
+        USER_TOP_TRACKS_ID,
     },
     ui::{single_line_input::LineInput, Orientation},
     utils::parse_uri,
@@ -855,10 +856,15 @@ fn handle_global_command(
             client_pub.send(ClientRequest::GetCurrentUserQueue)?;
         }
         Command::CreatePlaylist => {
+            state
+                .requests
+                .write()
+                .clear_status(&RequestKey::CreatePlaylist);
             ui.popup = Some(PopupState::PlaylistCreate {
                 name: LineInput::default(),
                 desc: LineInput::default(),
                 current_field: PlaylistCreateCurrentField::Name,
+                submitting: false,
             });
         }
         Command::JumpToCurrentTrackInContext => {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::{
-    command::construct_artist_actions, state::ConfirmableAction, utils::filtered_items_from_query,
+    command::construct_artist_actions,
+    state::{ConfirmableAction, RequestKey},
+    utils::filtered_items_from_query,
 };
 use anyhow::Context;
 
@@ -16,7 +18,12 @@ pub fn handle_key_sequence_for_popup(
             return handle_key_sequence_for_search_popup(key_sequence, client_pub, state, ui);
         }
         PopupState::PlaylistCreate { .. } => {
-            return handle_key_sequence_for_create_playlist_popup(key_sequence, client_pub, ui);
+            return handle_key_sequence_for_create_playlist_popup(
+                key_sequence,
+                client_pub,
+                state,
+                ui,
+            );
         }
         PopupState::ActionList(item, ..) => {
             return handle_key_sequence_for_action_list_popup(
@@ -320,12 +327,22 @@ pub fn handle_key_sequence_for_popup(
 fn handle_key_sequence_for_create_playlist_popup(
     key_sequence: &KeySequence,
     client_pub: &flume::Sender<ClientRequest>,
+    state: &SharedState,
     ui: &mut UIStateGuard,
 ) -> Result<bool> {
+    if state
+        .requests
+        .read()
+        .is_loading(&RequestKey::CreatePlaylist)
+    {
+        return Ok(true);
+    }
+
     let Some(PopupState::PlaylistCreate {
         name,
         desc,
         current_field,
+        submitting,
     }) = &mut ui.popup
     else {
         return Ok(false);
@@ -333,13 +350,16 @@ fn handle_key_sequence_for_create_playlist_popup(
     if key_sequence.keys.len() == 1 {
         match &key_sequence.keys[0] {
             Key::None(crossterm::event::KeyCode::Enter) => {
+                if *submitting {
+                    return Ok(true);
+                }
                 client_pub.send(ClientRequest::CreatePlaylist {
                     playlist_name: name.get_text(),
                     public: false,
                     collab: false,
                     desc: desc.get_text(),
                 })?;
-                ui.popup = None;
+                *submitting = true;
                 return Ok(true);
             }
             Key::None(crossterm::event::KeyCode::Tab | crossterm::event::KeyCode::BackTab) => {

--- a/spotify_player/src/state/mod.rs
+++ b/spotify_player/src/state/mod.rs
@@ -3,6 +3,7 @@ mod data;
 mod model;
 mod player;
 mod queue;
+mod request;
 mod ui;
 
 use std::{collections::VecDeque, sync::Arc};
@@ -13,6 +14,7 @@ pub use model::*;
 pub use player::*;
 #[allow(unused_imports)]
 pub use queue::*;
+pub use request::*;
 pub use ui::*;
 
 use crate::config;
@@ -27,6 +29,7 @@ pub struct State {
     pub ui: Mutex<UIState>,
     pub player: RwLock<PlayerState>,
     pub data: RwLock<AppData>,
+    pub requests: RwLock<RequestTracker>,
 
     pub is_daemon: bool,
 
@@ -55,6 +58,7 @@ impl State {
             ui: Mutex::new(ui),
             player: RwLock::new(PlayerState::default()),
             data: RwLock::new(app_data),
+            requests: RwLock::new(RequestTracker::default()),
             is_daemon,
             #[cfg(feature = "streaming")]
             vis_bands: if configs.app_config.enable_audio_visualization {

--- a/spotify_player/src/state/request.rs
+++ b/spotify_player/src/state/request.rs
@@ -1,0 +1,271 @@
+use std::{collections::HashMap, time::Duration};
+
+const SUCCESS_FEEDBACK_DURATION: Duration = Duration::from_secs(4);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RequestKey {
+    BrowseCategories,
+    BrowseCategory(String),
+    Context(String),
+    CreatePlaylist,
+    CurrentUser,
+    Devices,
+    Lyrics(String),
+    Queue,
+    Search(String),
+    UserFollowedArtists,
+    UserPlaylists,
+    UserSavedAlbums,
+    UserSavedShows,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RequestStatus {
+    Loading,
+    Succeeded,
+    Failed(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestFeedbackKind {
+    Pending,
+    Success,
+    Error,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestFeedback {
+    pub kind: RequestFeedbackKind,
+    pub message: String,
+    updated_at: std::time::Instant,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestOperation {
+    pending: String,
+    success: String,
+    failure: String,
+}
+
+impl RequestOperation {
+    pub fn new(
+        pending: impl Into<String>,
+        success: impl Into<String>,
+        failure: impl Into<String>,
+    ) -> Self {
+        Self {
+            pending: pending.into(),
+            success: success.into(),
+            failure: failure.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RequestMetadata {
+    pub key: Option<RequestKey>,
+    pub operation: Option<RequestOperation>,
+}
+
+impl RequestMetadata {
+    pub fn tracked(key: RequestKey) -> Self {
+        Self {
+            key: Some(key),
+            operation: None,
+        }
+    }
+
+    pub fn operation(operation: RequestOperation) -> Self {
+        Self {
+            key: None,
+            operation: Some(operation),
+        }
+    }
+
+    pub fn tracked_operation(key: RequestKey, operation: RequestOperation) -> Self {
+        Self {
+            key: Some(key),
+            operation: Some(operation),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestToken {
+    id: u64,
+    key: Option<RequestKey>,
+    operation: Option<RequestOperation>,
+}
+
+#[derive(Clone, Debug)]
+struct TrackedStatus {
+    request_id: u64,
+    status: RequestStatus,
+}
+
+#[derive(Clone, Debug)]
+struct TrackedFeedback {
+    request_id: u64,
+    feedback: RequestFeedback,
+}
+
+#[derive(Debug, Default)]
+pub struct RequestTracker {
+    next_id: u64,
+    statuses: HashMap<RequestKey, TrackedStatus>,
+    feedback: Option<TrackedFeedback>,
+}
+
+impl RequestTracker {
+    pub fn begin(&mut self, metadata: RequestMetadata) -> RequestToken {
+        self.next_id = self.next_id.wrapping_add(1);
+        let token = RequestToken {
+            id: self.next_id,
+            key: metadata.key,
+            operation: metadata.operation,
+        };
+
+        if let Some(key) = token.key.clone() {
+            self.statuses.insert(
+                key,
+                TrackedStatus {
+                    request_id: token.id,
+                    status: RequestStatus::Loading,
+                },
+            );
+        }
+        if let Some(operation) = token.operation.as_ref() {
+            self.feedback = Some(TrackedFeedback {
+                request_id: token.id,
+                feedback: RequestFeedback {
+                    kind: RequestFeedbackKind::Pending,
+                    message: operation.pending.clone(),
+                    updated_at: std::time::Instant::now(),
+                },
+            });
+        }
+
+        token
+    }
+
+    pub fn succeed(&mut self, token: &RequestToken) {
+        self.update_status(token, RequestStatus::Succeeded);
+        if let Some(operation) = token.operation.as_ref() {
+            self.update_feedback(
+                token,
+                RequestFeedbackKind::Success,
+                operation.success.clone(),
+            );
+        }
+    }
+
+    pub fn fail(&mut self, token: &RequestToken, error: &str) {
+        self.update_status(token, RequestStatus::Failed(error.to_owned()));
+        if let Some(operation) = token.operation.as_ref() {
+            self.update_feedback(
+                token,
+                RequestFeedbackKind::Error,
+                format!("{}: {error}. See Logs for details.", operation.failure),
+            );
+        }
+    }
+
+    pub fn status(&self, key: &RequestKey) -> Option<&RequestStatus> {
+        self.statuses.get(key).map(|status| &status.status)
+    }
+
+    pub fn is_loading(&self, key: &RequestKey) -> bool {
+        self.status(key) == Some(&RequestStatus::Loading)
+    }
+
+    pub fn clear_status(&mut self, key: &RequestKey) {
+        self.statuses.remove(key);
+    }
+
+    pub fn visible_feedback(&self) -> Option<RequestFeedback> {
+        let tracked = self.feedback.as_ref()?;
+        if tracked.feedback.kind == RequestFeedbackKind::Success
+            && tracked.feedback.updated_at.elapsed() > SUCCESS_FEEDBACK_DURATION
+        {
+            return None;
+        }
+        Some(tracked.feedback.clone())
+    }
+
+    fn update_status(&mut self, token: &RequestToken, status: RequestStatus) {
+        if let Some(key) = token.key.as_ref() {
+            let Some(tracked) = self.statuses.get_mut(key) else {
+                return;
+            };
+            if tracked.request_id == token.id {
+                tracked.status = status;
+            }
+        }
+    }
+
+    fn update_feedback(
+        &mut self,
+        token: &RequestToken,
+        kind: RequestFeedbackKind,
+        message: String,
+    ) {
+        let Some(tracked) = self.feedback.as_mut() else {
+            return;
+        };
+        if tracked.request_id == token.id {
+            tracked.feedback = RequestFeedback {
+                kind,
+                message,
+                updated_at: std::time::Instant::now(),
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RequestFeedbackKind, RequestKey, RequestMetadata, RequestOperation, RequestStatus,
+        RequestTracker,
+    };
+
+    #[test]
+    fn older_completion_cannot_replace_newer_status() {
+        let mut tracker = RequestTracker::default();
+        let older = tracker.begin(RequestMetadata::tracked(RequestKey::Queue));
+        let newer = tracker.begin(RequestMetadata::tracked(RequestKey::Queue));
+
+        tracker.fail(&older, "old failure");
+        assert_eq!(
+            tracker.status(&RequestKey::Queue),
+            Some(&RequestStatus::Loading)
+        );
+
+        tracker.succeed(&newer);
+        assert_eq!(
+            tracker.status(&RequestKey::Queue),
+            Some(&RequestStatus::Succeeded)
+        );
+    }
+
+    #[test]
+    fn operation_feedback_transitions_from_pending_to_error() {
+        let mut tracker = RequestTracker::default();
+        let token = tracker.begin(RequestMetadata::operation(RequestOperation::new(
+            "Saving playlist",
+            "Playlist saved",
+            "Could not save playlist",
+        )));
+
+        assert_eq!(
+            tracker.visible_feedback().unwrap().kind,
+            RequestFeedbackKind::Pending
+        );
+
+        tracker.fail(&token, "network unavailable");
+        let feedback = tracker.visible_feedback().unwrap();
+        assert_eq!(feedback.kind, RequestFeedbackKind::Error);
+        assert!(feedback.message.contains("network unavailable"));
+        assert!(feedback.message.contains("See Logs"));
+    }
+}

--- a/spotify_player/src/state/request.rs
+++ b/spotify_player/src/state/request.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 const SUCCESS_FEEDBACK_DURATION: Duration = Duration::from_secs(4);
+const MAX_TRACKED_STATUSES: usize = 128;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RequestKey {
@@ -133,6 +134,7 @@ impl RequestTracker {
                     status: RequestStatus::Loading,
                 },
             );
+            self.evict_oldest_status();
         }
         if let Some(operation) = token.operation.as_ref() {
             self.feedback = Some(TrackedFeedback {
@@ -203,6 +205,21 @@ impl RequestTracker {
         }
     }
 
+    fn evict_oldest_status(&mut self) {
+        if self.statuses.len() <= MAX_TRACKED_STATUSES {
+            return;
+        }
+
+        let oldest_key = self
+            .statuses
+            .iter()
+            .min_by_key(|(_, tracked)| tracked.request_id)
+            .map(|(key, _)| key.clone());
+        if let Some(key) = oldest_key {
+            self.statuses.remove(&key);
+        }
+    }
+
     fn update_feedback(
         &mut self,
         token: &RequestToken,
@@ -226,7 +243,7 @@ impl RequestTracker {
 mod tests {
     use super::{
         RequestFeedbackKind, RequestKey, RequestMetadata, RequestOperation, RequestStatus,
-        RequestTracker,
+        RequestTracker, MAX_TRACKED_STATUSES,
     };
 
     #[test]
@@ -267,5 +284,47 @@ mod tests {
         assert_eq!(feedback.kind, RequestFeedbackKind::Error);
         assert!(feedback.message.contains("network unavailable"));
         assert!(feedback.message.contains("See Logs"));
+    }
+
+    #[test]
+    fn tracked_statuses_are_bounded_to_the_most_recent_requests() {
+        let mut tracker = RequestTracker::default();
+
+        for index in 0..=MAX_TRACKED_STATUSES {
+            tracker.begin(RequestMetadata::tracked(RequestKey::Search(format!(
+                "query-{index}"
+            ))));
+        }
+
+        assert_eq!(tracker.statuses.len(), MAX_TRACKED_STATUSES);
+        assert_eq!(
+            tracker.status(&RequestKey::Search("query-0".to_owned())),
+            None
+        );
+        assert_eq!(
+            tracker.status(&RequestKey::Search(format!("query-{MAX_TRACKED_STATUSES}"))),
+            Some(&RequestStatus::Loading)
+        );
+    }
+
+    #[test]
+    fn completion_for_an_evicted_generation_cannot_replace_a_new_request() {
+        let mut tracker = RequestTracker::default();
+        let key = RequestKey::Search("reused-query".to_owned());
+        let evicted = tracker.begin(RequestMetadata::tracked(key.clone()));
+
+        for index in 0..MAX_TRACKED_STATUSES {
+            tracker.begin(RequestMetadata::tracked(RequestKey::Search(format!(
+                "other-query-{index}"
+            ))));
+        }
+        assert_eq!(tracker.status(&key), None);
+
+        let current = tracker.begin(RequestMetadata::tracked(key.clone()));
+        tracker.fail(&evicted, "stale failure");
+        assert_eq!(tracker.status(&key), Some(&RequestStatus::Loading));
+
+        tracker.succeed(&current);
+        assert_eq!(tracker.status(&key), Some(&RequestStatus::Succeeded));
     }
 }

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -31,6 +31,7 @@ pub enum PopupState {
         name: LineInput,
         desc: LineInput,
         current_field: PlaylistCreateCurrentField,
+        submitting: bool,
     },
     ConfirmAction {
         message: String,

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -4,13 +4,14 @@ use crate::{
         Album, Artist, ArtistFocusState, BrowsePageUIState, Context, ContextPageUIState,
         DataReadGuard, Id, LibraryFocusState, MutableWindowState, PageState, PageType,
         PlaybackMetadata, PlaylistCreateCurrentField, PlaylistFolderItem, PlaylistPopupAction,
-        PopupState, SearchFocusState, SharedState, Track, UIStateGuard,
+        PopupState, RequestFeedbackKind, RequestKey, RequestStatus, SearchFocusState, SharedState,
+        Track, UIStateGuard,
     },
 };
 use anyhow::{Context as AnyhowContext, Result};
 use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{
         Block, BorderType, Borders, Cell, Gauge, LineGauge, List, ListItem, ListState, Paragraph,
@@ -144,11 +145,35 @@ fn render_application(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGu
     // See: https://github.com/aome510/spotify-player/issues/498
     let rect = playback::render_playback_window(frame, state, ui, rect);
 
+    let rect = render_request_feedback(frame, state, rect);
+
     let rect = popup::render_shortcut_help_popup(frame, ui, rect);
 
     let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
 
     render_main_layout(is_active, frame, state, ui, rect);
+}
+
+fn render_request_feedback(frame: &mut Frame, state: &SharedState, rect: Rect) -> Rect {
+    let Some(feedback) = state.requests.read().visible_feedback() else {
+        return rect;
+    };
+
+    let chunks = Layout::vertical([Constraint::Fill(0), Constraint::Length(1)]).split(rect);
+    let (label, color) = match feedback.kind {
+        RequestFeedbackKind::Pending => ("[Pending]", Color::Yellow),
+        RequestFeedbackKind::Success => ("[Success]", Color::Green),
+        RequestFeedbackKind::Error => ("[Error]", Color::Red),
+    };
+    let message = Line::from(vec![
+        Span::styled(
+            format!("{label} "),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(feedback.message),
+    ]);
+    frame.render_widget(Paragraph::new(message), chunks[1]);
+    chunks[0]
 }
 
 /// Render the application's main layout

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -12,8 +12,8 @@ use super::{
     config, utils, utils::construct_and_render_block, Album, Alignment, Artist, ArtistFocusState,
     Borders, BrowsePageUIState, Cell, Constraint, Context, ContextPageUIState, DataReadGuard,
     Frame, Id, Layout, LibraryFocusState, MutableWindowState, Orientation, PageState, Paragraph,
-    PlaylistFolderItem, Rect, Row, SearchFocusState, SharedState, Style, Table, Text, Track,
-    UIStateGuard,
+    PlaylistFolderItem, Rect, RequestKey, RequestStatus, Row, SearchFocusState, SharedState, Style,
+    Table, Text, Track, UIStateGuard,
 };
 use crate::state::BidiDisplay;
 use crate::ui::utils::to_bidi_string;
@@ -23,6 +23,24 @@ const COMMAND_TABLE_CONSTRAINTS: [Constraint; 3] = [
     Constraint::Percentage(25),
     Constraint::Percentage(50),
 ];
+
+fn request_state_message(
+    state: &SharedState,
+    key: &RequestKey,
+    has_content: bool,
+    loading_message: &str,
+    empty_message: &str,
+    failure_message: &str,
+) -> Option<String> {
+    match state.requests.read().status(key).cloned() {
+        Some(RequestStatus::Failed(error)) => Some(format!(
+            "{failure_message}: {error}. Open Logs for details."
+        )),
+        Some(RequestStatus::Loading) | None if !has_content => Some(loading_message.to_owned()),
+        Some(RequestStatus::Succeeded) if !has_content => Some(empty_message.to_owned()),
+        _ => None,
+    }
+}
 
 // UI codes to render a page.
 // A `render_*_page` function should follow (not strictly) the below steps
@@ -66,6 +84,42 @@ pub fn render_search_page(
     let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
     let search_input_rect = chunks[0];
     let rect = chunks[1];
+
+    let PageState::Search { line_input, .. } = ui.current_page() else {
+        return;
+    };
+    frame.render_widget(
+        line_input.widget(is_active && focus_state == SearchFocusState::Input),
+        search_input_rect,
+    );
+
+    if current_query.is_empty() {
+        frame.render_widget(
+            Paragraph::new("Enter a query and press Enter to search."),
+            rect,
+        );
+        return;
+    }
+
+    let has_results = search_results.is_some_and(|results| {
+        !results.tracks.is_empty()
+            || !results.albums.is_empty()
+            || !results.artists.is_empty()
+            || !results.playlists.is_empty()
+            || !results.shows.is_empty()
+            || !results.episodes.is_empty()
+    });
+    if let Some(message) = request_state_message(
+        state,
+        &RequestKey::Search(current_query.clone()),
+        has_results,
+        "Searching...",
+        "No results found.",
+        "Search failed",
+    ) {
+        frame.render_widget(Paragraph::new(message), rect);
+        return;
+    }
 
     // track/album/artist/playlist/show/episode search results layout
     let chunks = match ui.orientation {
@@ -226,19 +280,12 @@ pub fn render_search_page(
     // 4. Render the page's widgets
     // Need mutable access to the list/table states stored inside the page state for rendering.
     let PageState::Search {
-        state: page_state,
-        line_input,
-        ..
+        state: page_state, ..
     } = ui.current_page_mut()
     else {
         return;
     };
 
-    // Render the query input box
-    frame.render_widget(
-        line_input.widget(is_active && focus_state == SearchFocusState::Input),
-        search_input_rect,
-    );
     utils::render_list_window(
         frame,
         track_list,
@@ -319,98 +366,126 @@ pub fn render_context_page(
     };
 
     let data = state.data.read();
-    match data.caches.context.get(&id.uri()) {
-        Some(context) => {
-            // render context description
-            let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
+    let Some(context) = data.caches.context.get(&id.uri()) else {
+        let message = request_state_message(
+            state,
+            &RequestKey::Context(id.uri()),
+            false,
+            "Loading context...",
+            "No context data available.",
+            "Could not load context",
+        )
+        .unwrap_or_else(|| "Loading context...".to_owned());
+        frame.render_widget(Paragraph::new(message), rect);
+        return;
+    };
 
-            let description = if let Context::Playlist { playlist, .. } = context {
-                format!(
-                    "{} | {}",
-                    context.description(),
-                    if data.user_data.is_followed_playlist(playlist) {
-                        "Followed"
-                    } else {
-                        "Not Followed"
-                    }
-                )
+    // render context description
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
+
+    let description = if let Context::Playlist { playlist, .. } = context {
+        format!(
+            "{} | {}",
+            context.description(),
+            if data.user_data.is_followed_playlist(playlist) {
+                "Followed"
             } else {
-                context.description()
+                "Not Followed"
+            }
+        )
+    } else {
+        context.description()
+    };
+
+    frame.render_widget(
+        Paragraph::new(description).style(ui.theme.page_desc()),
+        chunks[0],
+    );
+    let rect = chunks[1];
+
+    match context {
+        Context::Artist {
+            artist,
+            top_tracks,
+            albums,
+            related_artists,
+        } => {
+            if top_tracks.is_empty()
+                && albums.is_empty()
+                && related_artists.is_empty()
+                && data.user_data.liked_tracks_by_artist(artist).is_empty()
+            {
+                frame.render_widget(Paragraph::new("No artist content available."), rect);
+                return;
+            }
+            render_artist_context_page_windows(
+                is_active,
+                frame,
+                state,
+                ui,
+                &data,
+                rect,
+                (artist, top_tracks, albums, related_artists),
+            );
+        }
+        Context::Playlist { tracks, playlist } => {
+            let rect = if playlist.desc.is_empty() {
+                rect
+            } else {
+                let chunks =
+                    Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
+                frame.render_widget(
+                    Paragraph::new(playlist.desc.clone()).style(ui.theme.playlist_desc()),
+                    chunks[0],
+                );
+                chunks[1]
             };
 
-            frame.render_widget(
-                Paragraph::new(description).style(ui.theme.page_desc()),
-                chunks[0],
-            );
-            let rect = chunks[1];
-
-            match context {
-                Context::Artist {
-                    artist,
-                    top_tracks,
-                    albums,
-                    related_artists,
-                } => {
-                    render_artist_context_page_windows(
-                        is_active,
-                        frame,
-                        state,
-                        ui,
-                        &data,
-                        rect,
-                        (artist, top_tracks, albums, related_artists),
-                    );
-                }
-                Context::Playlist { tracks, playlist } => {
-                    let rect = if playlist.desc.is_empty() {
-                        rect
-                    } else {
-                        let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)])
-                            .split(rect);
-                        frame.render_widget(
-                            Paragraph::new(playlist.desc.clone()).style(ui.theme.playlist_desc()),
-                            chunks[0],
-                        );
-                        chunks[1]
-                    };
-
-                    render_track_table(
-                        frame,
-                        rect,
-                        is_active,
-                        state,
-                        ui.search_filtered_items(tracks),
-                        ui,
-                        &data,
-                        false,
-                    );
-                }
-                Context::Tracks { tracks, .. } | Context::Album { tracks, .. } => {
-                    render_track_table(
-                        frame,
-                        rect,
-                        is_active,
-                        state,
-                        ui.search_filtered_items(tracks),
-                        ui,
-                        &data,
-                        false,
-                    );
-                }
-                Context::Show { episodes, .. } => {
-                    render_episode_table(
-                        frame,
-                        rect,
-                        is_active,
-                        state,
-                        ui.search_filtered_items(episodes),
-                        ui,
-                    );
-                }
+            if tracks.is_empty() {
+                frame.render_widget(Paragraph::new("This playlist is empty."), rect);
+                return;
             }
+
+            render_track_table(
+                frame,
+                rect,
+                is_active,
+                state,
+                ui.search_filtered_items(tracks),
+                ui,
+                &data,
+                false,
+            );
         }
-        None => {
-            frame.render_widget(Paragraph::new("Loading..."), rect);
+        Context::Tracks { tracks, .. } | Context::Album { tracks, .. } => {
+            if tracks.is_empty() {
+                frame.render_widget(Paragraph::new("No tracks available."), rect);
+                return;
+            }
+            render_track_table(
+                frame,
+                rect,
+                is_active,
+                state,
+                ui.search_filtered_items(tracks),
+                ui,
+                &data,
+                false,
+            );
+        }
+        Context::Show { episodes, .. } => {
+            if episodes.is_empty() {
+                frame.render_widget(Paragraph::new("No episodes available."), rect);
+                return;
+            }
+            render_episode_table(
+                frame,
+                rect,
+                is_active,
+                state,
+                ui.search_filtered_items(episodes),
+                ui,
+            );
         }
     }
 }
@@ -475,8 +550,10 @@ pub fn render_library_page(
 
     // 3. Construct the page's widgets
     // Construct the playlist window
+    let folder_playlist_items = data.user_data.folder_playlists_items(playlist_folder_id);
+    let has_playlists = !folder_playlist_items.is_empty();
     let items = ui
-        .search_filtered_items(&data.user_data.folder_playlists_items(playlist_folder_id))
+        .search_filtered_items(&folder_playlist_items)
         .into_iter()
         .map(|item| match item {
             PlaylistFolderItem::Playlist(p) => {
@@ -503,6 +580,7 @@ pub fn render_library_page(
     } else {
         None
     };
+    let has_saved_albums = !data.user_data.saved_albums.is_empty();
     let (album_list, n_albums) = utils::construct_list_widget(
         &ui.theme,
         ui.search_filtered_items(&data.user_data.saved_albums)
@@ -519,6 +597,7 @@ pub fn render_library_page(
     } else {
         None
     };
+    let has_followed_artists = !data.user_data.followed_artists.is_empty();
     let (artist_list, n_artists) = utils::construct_list_widget(
         &ui.theme,
         ui.search_filtered_items(&data.user_data.followed_artists)
@@ -536,27 +615,66 @@ pub fn render_library_page(
         return;
     };
 
-    utils::render_list_window(
-        frame,
-        playlist_list,
-        playlist_rect,
-        n_playlists,
-        &mut page_state.playlist_list,
-    );
-    utils::render_list_window(
-        frame,
-        album_list,
-        album_rect,
-        n_albums,
-        &mut page_state.saved_album_list,
-    );
-    utils::render_list_window(
-        frame,
-        artist_list,
-        artist_rect,
-        n_artists,
-        &mut page_state.followed_artist_list,
-    );
+    if let Some(message) = request_state_message(
+        state,
+        &RequestKey::UserPlaylists,
+        has_playlists,
+        "Loading playlists...",
+        "No playlists found.",
+        "Could not load playlists",
+    ) {
+        frame.render_widget(Paragraph::new(message), playlist_rect);
+    } else if n_playlists == 0 {
+        frame.render_widget(Paragraph::new("No matching playlists."), playlist_rect);
+    } else {
+        utils::render_list_window(
+            frame,
+            playlist_list,
+            playlist_rect,
+            n_playlists,
+            &mut page_state.playlist_list,
+        );
+    }
+    if let Some(message) = request_state_message(
+        state,
+        &RequestKey::UserSavedAlbums,
+        has_saved_albums,
+        "Loading saved albums...",
+        "No saved albums found.",
+        "Could not load saved albums",
+    ) {
+        frame.render_widget(Paragraph::new(message), album_rect);
+    } else if n_albums == 0 {
+        frame.render_widget(Paragraph::new("No matching saved albums."), album_rect);
+    } else {
+        utils::render_list_window(
+            frame,
+            album_list,
+            album_rect,
+            n_albums,
+            &mut page_state.saved_album_list,
+        );
+    }
+    if let Some(message) = request_state_message(
+        state,
+        &RequestKey::UserFollowedArtists,
+        has_followed_artists,
+        "Loading followed artists...",
+        "No followed artists found.",
+        "Could not load followed artists",
+    ) {
+        frame.render_widget(Paragraph::new(message), artist_rect);
+    } else if n_artists == 0 {
+        frame.render_widget(Paragraph::new("No matching followed artists."), artist_rect);
+    } else {
+        utils::render_list_window(
+            frame,
+            artist_list,
+            artist_rect,
+            n_artists,
+            &mut page_state.followed_artist_list,
+        );
+    }
 }
 
 pub fn render_browse_page(
@@ -581,6 +699,18 @@ pub fn render_browse_page(
                 rect =
                     construct_and_render_block("Categories", &ui.theme, Borders::ALL, frame, rect);
 
+                if let Some(message) = request_state_message(
+                    state,
+                    &RequestKey::BrowseCategories,
+                    !data.browse.categories.is_empty(),
+                    "Loading categories...",
+                    "No browse categories available.",
+                    "Could not load browse categories",
+                ) {
+                    frame.render_widget(Paragraph::new(message), rect);
+                    return;
+                }
+
                 utils::construct_list_widget(
                     &ui.theme,
                     ui.search_filtered_items(&data.browse.categories)
@@ -595,8 +725,19 @@ pub fn render_browse_page(
                 let title = format!("{} Playlists", category.name);
                 rect = construct_and_render_block(&title, &ui.theme, Borders::ALL, frame, rect);
 
-                let Some(playlists) = data.browse.category_playlists.get(&category.id) else {
-                    frame.render_widget(Paragraph::new("Loading..."), rect);
+                let playlists = data.browse.category_playlists.get(&category.id);
+                if let Some(message) = request_state_message(
+                    state,
+                    &RequestKey::BrowseCategory(category.id.clone()),
+                    playlists.is_some_and(|playlists| !playlists.is_empty()),
+                    "Loading playlists...",
+                    "No playlists available in this category.",
+                    "Could not load category playlists",
+                ) {
+                    frame.render_widget(Paragraph::new(message), rect);
+                    return;
+                }
+                let Some(playlists) = playlists else {
                     return;
                 };
 
@@ -653,11 +794,20 @@ pub fn render_lyrics_page(
 
     let lyrics = match data.caches.lyrics.get(track_uri) {
         None => {
-            frame.render_widget(Paragraph::new("Loading..."), rect);
+            let message = request_state_message(
+                state,
+                &RequestKey::Lyrics(track_uri.clone()),
+                false,
+                "Loading lyrics...",
+                "Lyrics not found.",
+                "Could not load lyrics",
+            )
+            .unwrap_or_else(|| "Loading lyrics...".to_owned());
+            frame.render_widget(Paragraph::new(message), rect);
             return;
         }
         Some(None) => {
-            frame.render_widget(Paragraph::new("Lyrics not found"), rect);
+            frame.render_widget(Paragraph::new("Lyrics not found."), rect);
             return;
         }
         Some(Some(lyrics)) => lyrics,
@@ -807,10 +957,22 @@ pub fn render_queue_page(
     }
 
     // 1. Get data
+    let rect = construct_and_render_block("Queue", &ui.theme, Borders::ALL, frame, rect);
     let player = state.player.read();
-    let queue = match player.queue {
-        Some(ref q) => &q.queue,
-        None => return,
+    let queue = player.queue.as_ref().map(|queue| &queue.queue);
+    if let Some(message) = request_state_message(
+        state,
+        &RequestKey::Queue,
+        queue.is_some_and(|queue| !queue.is_empty()),
+        "Loading queue...",
+        "The queue is empty.",
+        "Could not load queue",
+    ) {
+        frame.render_widget(Paragraph::new(message), rect);
+        return;
+    }
+    let Some(queue) = queue else {
+        return;
     };
     let scroll_offset = match ui.current_page_mut() {
         PageState::Queue {
@@ -824,10 +986,7 @@ pub fn render_queue_page(
         _ => return,
     };
 
-    // 2. Construct the page's layout
-    let rect = construct_and_render_block("Queue", &ui.theme, Borders::ALL, frame, rect);
-
-    // 3. Construct the page's widget
+    // 2. Construct the page's widget
     let queue_table = Table::new(
         queue
             .iter()

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -2,13 +2,31 @@ use crate::{command::Command, utils::filtered_items_from_query};
 
 use super::{
     config, utils, utils::construct_and_render_block, Borders, Cell, Constraint, Frame, Layout,
-    Paragraph, PlaylistCreateCurrentField, PlaylistPopupAction, PopupState, Rect, Row, SharedState,
-    Table, UIStateGuard,
+    Paragraph, PlaylistCreateCurrentField, PlaylistPopupAction, PopupState, Rect, RequestKey,
+    RequestStatus, Row, SharedState, Table, UIStateGuard,
 };
 
 const SHORTCUT_TABLE_N_COLUMNS: usize = 3;
 const SHORTCUT_TABLE_CONSTRAINS: [Constraint; SHORTCUT_TABLE_N_COLUMNS] =
     [Constraint::Ratio(1, 3); 3];
+
+fn request_status_message(
+    state: &SharedState,
+    key: &RequestKey,
+    has_content: bool,
+    loading_message: &str,
+    empty_message: &str,
+    failure_message: &str,
+) -> Option<String> {
+    match state.requests.read().status(key).cloned() {
+        Some(RequestStatus::Failed(error)) => Some(format!(
+            "{failure_message}: {error}. Open Logs for details."
+        )),
+        Some(RequestStatus::Loading) | None if !has_content => Some(loading_message.to_owned()),
+        Some(RequestStatus::Succeeded) if !has_content => Some(empty_message.to_owned()),
+        _ => None,
+    }
+}
 
 /// Render a popup (if any) to handle a command or show additional information
 /// depending on the current popup state.
@@ -28,13 +46,34 @@ pub fn render_popup(
                 name,
                 desc,
                 current_field,
+                ..
             } => {
+                let request_status = state
+                    .requests
+                    .read()
+                    .status(&RequestKey::CreatePlaylist)
+                    .cloned();
+                let status_message = match request_status {
+                    Some(RequestStatus::Loading) => Some("Creating playlist...".to_owned()),
+                    Some(RequestStatus::Failed(error)) => {
+                        Some(format!("Error: {error}. Press Enter to retry."))
+                    }
+                    Some(RequestStatus::Succeeded) => Some("Playlist created.".to_owned()),
+                    None => None,
+                };
+                let popup_height = if status_message.is_some() { 4 } else { 3 };
                 let chunks =
-                    Layout::vertical([Constraint::Min(0), Constraint::Length(3)]).split(rect);
+                    Layout::vertical([Constraint::Min(0), Constraint::Length(popup_height)])
+                        .split(rect);
+                let form_chunks = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Length(popup_height.saturating_sub(3)),
+                ])
+                .split(chunks[1]);
 
                 let popup_chunks =
                     Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                        .split(chunks[1]);
+                        .split(form_chunks[0]);
 
                 let name_input = construct_and_render_block(
                     "Enter Name for New Playlist:",
@@ -60,6 +99,9 @@ pub fn render_popup(
                     desc.widget(PlaylistCreateCurrentField::Desc == *current_field),
                     desc_input,
                 );
+                if let Some(message) = status_message {
+                    frame.render_widget(Paragraph::new(message), form_chunks[1]);
+                }
                 (chunks[0], true)
             }
             PopupState::Search { query } => {
@@ -94,7 +136,7 @@ pub fn render_popup(
                     Some(ref playback) => playback.device.id.as_deref().unwrap_or_default(),
                     None => "",
                 };
-                let items = player
+                let mut items = player
                     .devices
                     .iter()
                     .map(|d| {
@@ -108,6 +150,17 @@ pub fn render_popup(
                         (format!("{name} | {}", d.id), current_device_id == d.id)
                     })
                     .collect();
+
+                if let Some(message) = request_status_message(
+                    state,
+                    &RequestKey::Devices,
+                    !player.devices.is_empty(),
+                    "Loading devices...",
+                    "No playback devices available.",
+                    "Could not load devices",
+                ) {
+                    items = vec![(message, false)];
+                }
 
                 let rect = render_list_popup(frame, rect, "Devices", items, 5, ui);
                 (rect, false)
@@ -146,10 +199,23 @@ pub fn render_popup(
                 // Filter items based on search query if present
                 let filtered_items = filtered_items_from_query(search_query, &items);
 
-                let display_items = filtered_items
+                let mut display_items = filtered_items
                     .iter()
                     .map(|p| (p.to_string(), false))
-                    .collect();
+                    .collect::<Vec<_>>();
+
+                if let Some(message) = request_status_message(
+                    state,
+                    &RequestKey::UserPlaylists,
+                    !items.is_empty(),
+                    "Loading playlists...",
+                    "No playlists available.",
+                    "Could not load playlists",
+                ) {
+                    display_items = vec![(message, false)];
+                } else if display_items.is_empty() && !search_query.is_empty() {
+                    display_items = vec![("No matching playlists.".to_owned(), false)];
+                }
 
                 let chunks = Layout::vertical([
                     Constraint::Length(3),
@@ -174,27 +240,47 @@ pub fn render_popup(
                 (rect, false)
             }
             PopupState::UserFollowedArtistList { .. } => {
-                let items = state
-                    .data
-                    .read()
+                let data = state.data.read();
+                let mut items = data
                     .user_data
                     .followed_artists
                     .iter()
                     .map(|a| (a.to_string(), false))
-                    .collect();
+                    .collect::<Vec<_>>();
+
+                if let Some(message) = request_status_message(
+                    state,
+                    &RequestKey::UserFollowedArtists,
+                    !items.is_empty(),
+                    "Loading followed artists...",
+                    "No followed artists available.",
+                    "Could not load followed artists",
+                ) {
+                    items = vec![(message, false)];
+                }
 
                 let rect = render_list_popup(frame, rect, "User Followed Artists", items, 7, ui);
                 (rect, false)
             }
             PopupState::UserSavedAlbumList { .. } => {
-                let items = state
-                    .data
-                    .read()
+                let data = state.data.read();
+                let mut items = data
                     .user_data
                     .saved_albums
                     .iter()
                     .map(|a| (a.to_string(), false))
-                    .collect();
+                    .collect::<Vec<_>>();
+
+                if let Some(message) = request_status_message(
+                    state,
+                    &RequestKey::UserSavedAlbums,
+                    !items.is_empty(),
+                    "Loading saved albums...",
+                    "No saved albums available.",
+                    "Could not load saved albums",
+                ) {
+                    items = vec![(message, false)];
+                }
 
                 let rect = render_list_popup(frame, rect, "User Saved Albums", items, 7, ui);
                 (rect, false)


### PR DESCRIPTION
## Summary

- track loading, success, and failure for client requests without allowing stale completions to replace newer request state
- show explicit loading, empty, and error states across search, context, library, browse, lyrics, queue, device, and library-selection views
- show pending, success, and failure feedback for state-changing actions in the main UI
- keep playlist creation input available while the request is pending or recoverable after failure
- return an actionable error instead of panicking when current-user data is unavailable during playlist creation

## Why

Client requests previously exposed no result state to the UI. Failures were written only to logs, missing data was often rendered as an indefinite loading label or a blank view, and playlist creation closed its form before Spotify returned a result. Playlist creation could also panic when account data had not loaded.

This adds a generation-aware request tracker so pages and mutations can report their current state while preventing an older concurrent request from overwriting a newer result.

Closes #1029.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p spotify_player`
- `cargo test --no-default-features --features rodio-backend,media-control,image,notify,fzf`
- `cargo clippy --no-default-features --features rodio-backend,media-control,image,notify,fzf -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
