### PR TITLE
fix: harden CLI IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ For more details, run `spotify_player -h` or `spotify_player {command} -h`.
 **Notes**
 
 - On first use, run `spotify_player authenticate` to authenticate the app.
-- CLI commands communicate with a client socket on port `client_port` (default: `8080`). If no instance is running, a new client is started, which may increase latency.
+- CLI commands use length-prefixed TCP on `client_port` (default: `8080`). Connection attempts time out after 5 seconds, and request and response I/O operations time out after 30 seconds. If no instance is running, a new client is started, which may increase latency.
 
 #### Scripting
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,7 +33,7 @@ spotify_player -o device.volume=80 -o theme=dracula
 | `client_id`                       | Spotify client ID for API access. **Leave unset unless you know you need a custom one** (see notes). | See code (default: ncspot's client ID)                                 |
 | `client_id_command`               | Shell command that outputs client ID to stdout (overrides `client_id`).                              | `None`                                                                 |
 | `login_redirect_uri`              | Redirect URI for authentication.                                                                     | `http://127.0.0.1:8989/login`                                          |
-| `client_port`                     | Port for the application's client to handle CLI commands.                                            | `8080`                                                                 |
+| `client_port`                     | Local TCP port used by the application's client to handle CLI commands.                              | `8080`                                                                 |
 | `log_folder`                      | Path to store log files.                                                                             | `None`                                                                 |
 | `tracks_playback_limit`           | Maximum number of tracks in a playback session.                                                      | `50`                                                                   |
 | `playback_format`                 | Format string for the playback window.                                                               | `{status} {track} • {artists} {liked}\n{album} • {genres}\n{metadata}` |

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -29,6 +29,8 @@ sha2 = "0.11.0"
 open = "5.3.6"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.52.3", features = [
+	"io-util",
+	"net",
 	"rt",
 	"rt-multi-thread",
 	"macros",

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -3,12 +3,11 @@ use std::{
     fmt::Write as _,
     fs::{create_dir_all, remove_dir_all},
     io::Write,
-    net::SocketAddr,
 };
 
 use anyhow::{Context as _, Result};
 use rand::seq::SliceRandom;
-use tokio::net::UdpSocket;
+use tokio::net::{TcpListener, TcpStream};
 use tracing::Instrument;
 
 use crate::{
@@ -23,92 +22,122 @@ use crate::{
 use rspotify::prelude::{BaseClient, OAuthClient};
 
 use super::{
+    ipc::{read_frame_async, write_frame_async, IO_TIMEOUT, MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE},
     Command, Deserialize, EditAction, GetRequest, IdOrName, ItemId, ItemType, Key, PlaylistCommand,
-    Response, Serialize, MAX_REQUEST_SIZE,
+    Response, Serialize,
 };
 
 pub async fn start_socket(
     client: &AppClient,
     state: Option<&SharedState>,
-    socket: Option<tokio::net::UdpSocket>,
+    listener: Option<TcpListener>,
 ) {
-    let socket = if let Some(s) = socket {
-        s
+    let listener = if let Some(listener) = listener {
+        listener
     } else {
         let configs = config::get_config();
         let port = configs.app_config.client_port;
-        tracing::info!("Starting a client socket at 127.0.0.1:{port}");
+        tracing::info!("Starting the CLI listener at 127.0.0.1:{port}");
 
-        match tokio::net::UdpSocket::bind(("127.0.0.1", port)).await {
-            Ok(socket) => socket,
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => listener,
             Err(err) => {
-                tracing::warn!(
-                    "Failed to create a client socket for handling CLI commands: {err:#}"
-                );
+                tracing::warn!("Failed to create the CLI listener: {err:#}");
                 return;
             }
         }
     };
 
-    let mut buf = [0; MAX_REQUEST_SIZE];
-
     loop {
-        match socket.recv_from(&mut buf).await {
-            Err(err) => tracing::warn!("Failed to receive from the socket: {err:#}"),
-            Ok((n_bytes, dest_addr)) => {
-                if n_bytes == 0 {
-                    // received a connection request from the destination address
-                    socket.send_to(&[], dest_addr).await.unwrap_or_default();
-                    continue;
-                }
-
-                let req_buf = &buf[0..n_bytes];
-                let request: Request = match serde_json::from_slice(req_buf) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        tracing::error!("Cannot deserialize the socket request: {err:#}");
-                        continue;
-                    }
-                };
-
-                let span = tracing::info_span!("socket_request", request = ?request, dest_addr = ?dest_addr);
-
-                async {
-                    let response = match handle_socket_request(client, state, request).await {
-                        Err(err) => {
-                            tracing::error!("Failed to handle socket request: {err:#}");
-                            let msg = format!("Bad request: {err:#}");
-                            Response::Err(msg.into_bytes())
+        match listener.accept().await {
+            Err(err) => tracing::warn!("Failed to accept a CLI connection: {err:#}"),
+            Ok((stream, peer_addr)) => {
+                let client = client.clone();
+                let state = state.cloned();
+                let span = tracing::info_span!("cli_request", ?peer_addr);
+                tokio::spawn(
+                    async move {
+                        if let Err(err) = handle_connection(&client, state.as_ref(), stream).await {
+                            tracing::warn!("CLI connection failed: {err:#}");
                         }
-                        Ok(data) => Response::Ok(data),
-                    };
-                    send_response(response, &socket, dest_addr)
-                        .await
-                        .unwrap_or_default();
-
-                    tracing::info!("Successfully handled the socket request.",);
-                }
-                .instrument(span)
-                .await;
+                    }
+                    .instrument(span),
+                );
             }
         }
     }
 }
 
-async fn send_response(
-    response: Response,
-    socket: &UdpSocket,
-    dest_addr: SocketAddr,
+async fn handle_connection(
+    client: &AppClient,
+    state: Option<&SharedState>,
+    mut stream: TcpStream,
 ) -> Result<()> {
-    let data = serde_json::to_vec(&response)?;
+    let request_data = match tokio::time::timeout(
+        IO_TIMEOUT,
+        read_frame_async(&mut stream, MAX_REQUEST_SIZE, "CLI request"),
+    )
+    .await
+    .context("timed out while reading a CLI request")?
+    {
+        Ok(data) => data,
+        Err(err) => {
+            tracing::error!("Cannot read the CLI request: {err:#}");
+            let response = Response::Err(format!("Bad request: {err:#}").into_bytes());
+            send_response(response, &mut stream).await?;
+            return Ok(());
+        }
+    };
 
-    // as the result data can be large and may not be sent in a single UDP datagram,
-    // split it into smaller chunks
-    for chunk in data.chunks(4096) {
-        socket.send_to(chunk, dest_addr).await?;
-    }
-    // send an empty buffer to indicate end of chunk
-    socket.send_to(&[], dest_addr).await?;
+    let request: Request = match serde_json::from_slice(&request_data) {
+        Ok(request) => request,
+        Err(err) => {
+            tracing::error!("Cannot deserialize the CLI request: {err:#}");
+            let response = Response::Err(format!("Bad request: {err:#}").into_bytes());
+            send_response(response, &mut stream).await?;
+            return Ok(());
+        }
+    };
+
+    let response =
+        match tokio::time::timeout(IO_TIMEOUT, handle_socket_request(client, state, request)).await
+        {
+            Err(_) => Response::Err(
+                format!("Request timed out after {} seconds", IO_TIMEOUT.as_secs()).into_bytes(),
+            ),
+            Ok(Err(err)) => {
+                tracing::error!("Failed to handle CLI request: {err:#}");
+                Response::Err(format!("Bad request: {err:#}").into_bytes())
+            }
+            Ok(Ok(data)) => Response::Ok(data),
+        };
+    send_response(response, &mut stream).await?;
+    tracing::info!("Successfully handled the CLI request.");
+    Ok(())
+}
+
+async fn send_response(response: Response, stream: &mut TcpStream) -> Result<()> {
+    let data = serde_json::to_vec(&response).context("serialize CLI response")?;
+    let data = if data.len() > MAX_RESPONSE_SIZE {
+        serde_json::to_vec(&Response::Err(
+            format!(
+                "Response is {} bytes, but the maximum is {} bytes",
+                data.len(),
+                MAX_RESPONSE_SIZE
+            )
+            .into_bytes(),
+        ))
+        .context("serialize oversized-response error")?
+    } else {
+        data
+    };
+
+    tokio::time::timeout(
+        IO_TIMEOUT,
+        write_frame_async(stream, &data, MAX_RESPONSE_SIZE, "CLI response"),
+    )
+    .await
+    .context("timed out while sending a CLI response")??;
     Ok(())
 }
 

--- a/spotify_player/src/cli/handlers.rs
+++ b/spotify_player/src/cli/handlers.rs
@@ -1,30 +1,58 @@
 use crate::{auth::AuthConfig, client};
 
 use super::{
-    config, init_cli, start_socket, AlbumId, Command, ContextType, EditAction, GetRequest,
-    IdOrName, ItemType, Key, PlaylistCommand, PlaylistId, Request, Response, TrackId,
-    MAX_REQUEST_SIZE,
+    config, init_cli,
+    ipc::{
+        read_frame, write_frame, CONNECT_TIMEOUT, IO_TIMEOUT, MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE,
+    },
+    start_socket, AlbumId, Command, ContextType, EditAction, GetRequest, IdOrName, ItemType, Key,
+    PlaylistCommand, PlaylistId, Request, Response, TrackId,
 };
 use anyhow::{Context, Result};
 use clap::{ArgMatches, Id};
 use clap_complete::{generate, Shell};
-use std::net::UdpSocket;
+use std::{
+    io,
+    net::{SocketAddr, TcpStream},
+    time::Duration,
+};
 
-fn receive_response(socket: &UdpSocket) -> Result<Response> {
-    // read response from the server's socket, which can be split into
-    // smaller chunks of data
-    let mut data = Vec::new();
-    let mut buf = [0; 4096];
-    loop {
-        let (n_bytes, _) = socket.recv_from(&mut buf)?;
-        if n_bytes == 0 {
-            // end of chunk
-            break;
-        }
-        data.extend_from_slice(&buf[..n_bytes]);
-    }
+fn receive_response(stream: &mut TcpStream) -> Result<Response> {
+    let data = read_frame(stream, MAX_RESPONSE_SIZE, "CLI response").with_context(|| {
+        format!(
+            "receive a complete response within {} seconds",
+            IO_TIMEOUT.as_secs()
+        )
+    })?;
+    serde_json::from_slice(&data).context("deserialize CLI response")
+}
 
-    Ok(serde_json::from_slice(&data)?)
+fn serialize_request(request: &Request) -> Result<Vec<u8>> {
+    let data = serde_json::to_vec(request).context("serialize CLI request")?;
+    anyhow::ensure!(
+        data.len() <= MAX_REQUEST_SIZE,
+        "CLI request is {} bytes, but the maximum is {} bytes; shorten the query or text fields",
+        data.len(),
+        MAX_REQUEST_SIZE
+    );
+    Ok(data)
+}
+
+fn connect_with_timeout(addr: SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
+    TcpStream::connect_timeout(&addr, timeout)
+}
+
+fn configure_stream(stream: TcpStream) -> Result<TcpStream> {
+    stream
+        .set_read_timeout(Some(IO_TIMEOUT))
+        .context("set CLI response deadline")?;
+    stream
+        .set_write_timeout(Some(IO_TIMEOUT))
+        .context("set CLI request deadline")?;
+    stream
+        .set_nodelay(true)
+        .context("configure CLI connection")?;
+    Ok(stream)
 }
 
 fn get_id_or_name(args: &ArgMatches) -> IdOrName {
@@ -139,18 +167,16 @@ fn handle_playback_subcommand(args: &ArgMatches) -> Result<Request> {
     Ok(Request::Playback(command))
 }
 
-/// Tries to connect to a running client, if exists, by sending a connection request
-/// to the client via a UDP socket.
+/// Tries to connect to a running client using a bounded TCP connection.
 /// If no running client found, create a new client running in a separate thread to
 /// handle the socket request.
-fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Result<()> {
+fn try_connect_to_client(configs: &config::Configs) -> Result<TcpStream> {
     let port = configs.app_config.client_port;
-    socket.connect(("127.0.0.1", port))?;
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
-    // send an empty buffer as a connection request to the client
-    socket.send(&[])?;
-    if let Err(err) = socket.recv(&mut [0; 1]) {
-        if let std::io::ErrorKind::ConnectionRefused = err.kind() {
+    match connect_with_timeout(addr, CONNECT_TIMEOUT) {
+        Ok(stream) => configure_stream(stream),
+        Err(err) if err.kind() == io::ErrorKind::ConnectionRefused => {
             // no running `spotify_player` instance found,
             // initialize a new client to handle the current CLI command
 
@@ -163,21 +189,28 @@ fn try_connect_to_client(socket: &UdpSocket, configs: &config::Configs) -> Resul
             rt.block_on(client.new_session(None, false))
                 .context("new session")?;
 
-            // create a client socket for handling CLI commands
-            // NOTE: the socket must be bound *before* spawning the thread to avoid a
-            // race condition where the caller sends a request before the socket is ready.
-            let client_socket = rt.block_on(tokio::net::UdpSocket::bind(("127.0.0.1", port)))?;
+            // Bind before spawning the thread so the caller cannot race the listener startup.
+            let client_listener = rt.block_on(tokio::net::TcpListener::bind(addr))?;
 
-            // spawn a thread to handle the CLI request
             std::thread::spawn(move || {
-                rt.block_on(start_socket(&client, None, Some(client_socket)));
+                rt.block_on(start_socket(&client, None, Some(client_listener)));
             });
-        } else {
-            return Err(err.into());
-        }
-    }
 
-    Ok(())
+            let stream = connect_with_timeout(addr, CONNECT_TIMEOUT).with_context(|| {
+                format!(
+                    "connect to the new Spotify client within {} seconds",
+                    CONNECT_TIMEOUT.as_secs()
+                )
+            })?;
+            configure_stream(stream)
+        }
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "connect to the Spotify client within {} seconds",
+                CONNECT_TIMEOUT.as_secs()
+            )
+        }),
+    }
 }
 
 pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
@@ -214,9 +247,6 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
         _ => {}
     }
 
-    let socket = UdpSocket::bind("127.0.0.1:0")?;
-    try_connect_to_client(&socket, configs).context("try to connect to a client")?;
-
     // construct a socket request based on the CLI command and its arguments
     let request = match cmd {
         "get" => handle_get_subcommand(args),
@@ -238,13 +268,13 @@ pub fn handle_cli_subcommand(cmd: &str, args: &ArgMatches) -> Result<()> {
         _ => unreachable!(),
     };
 
-    // send the request to the client's socket
-    let request_buf = serde_json::to_vec(&request)?;
-    assert!(request_buf.len() <= MAX_REQUEST_SIZE);
-    socket.send(&request_buf)?;
+    let request_buf = serialize_request(&request)?;
+    let mut stream = try_connect_to_client(configs).context("connect to a Spotify client")?;
+    write_frame(&mut stream, &request_buf, MAX_REQUEST_SIZE, "CLI request")
+        .with_context(|| format!("send the request within {} seconds", IO_TIMEOUT.as_secs()))?;
 
     // receive and handle a response from the client's socket
-    match receive_response(&socket)? {
+    match receive_response(&mut stream)? {
         Response::Err(err) => {
             eprintln!("{}", String::from_utf8_lossy(&err));
             std::process::exit(1);
@@ -398,4 +428,58 @@ fn print_features() {
     print_feature!("jackaudio-backend");
     print_feature!("sdl-backend");
     print_feature!("gstreamer-backend");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{TcpListener, TcpStream},
+        thread,
+        time::Duration,
+    };
+
+    use super::{connect_with_timeout, receive_response, serialize_request, Request};
+    use crate::cli::ipc::MAX_REQUEST_SIZE;
+
+    #[test]
+    fn oversized_user_input_returns_an_error() {
+        let request = Request::Search {
+            query: "x".repeat(MAX_REQUEST_SIZE),
+        };
+
+        let error = serialize_request(&request).unwrap_err();
+
+        assert!(error.to_string().contains("maximum"));
+        assert!(error.to_string().contains("shorten"));
+    }
+
+    #[test]
+    fn missing_server_connection_fails_within_the_deadline() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let result = connect_with_timeout(addr, Duration::from_millis(100));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn stalled_server_response_returns_an_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (_stream, _) = listener.accept().unwrap();
+            thread::sleep(Duration::from_millis(150));
+        });
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_millis(25)))
+            .unwrap();
+
+        let error = receive_response(&mut stream).unwrap_err();
+
+        assert!(error.to_string().contains("complete response"));
+        server.join().unwrap();
+    }
 }

--- a/spotify_player/src/cli/ipc.rs
+++ b/spotify_player/src/cli/ipc.rs
@@ -1,0 +1,204 @@
+use std::{
+    io::{Read, Write},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const IO_TIMEOUT: Duration = Duration::from_secs(30);
+pub const MAX_REQUEST_SIZE: usize = 4 * 1024;
+pub const MAX_RESPONSE_SIZE: usize = 32 * 1024 * 1024;
+
+fn frame_length(size: usize, max_size: usize, description: &str) -> Result<u32> {
+    anyhow::ensure!(
+        size <= max_size,
+        "{description} is {size} bytes, but the maximum is {max_size} bytes"
+    );
+    u32::try_from(size).context("frame length exceeds the protocol limit")
+}
+
+pub fn read_frame(reader: &mut impl Read, max_size: usize, description: &str) -> Result<Vec<u8>> {
+    let mut header = [0; size_of::<u32>()];
+    reader
+        .read_exact(&mut header)
+        .with_context(|| format!("read {description} length"))?;
+    let size = u32::from_be_bytes(header) as usize;
+    frame_length(size, max_size, description)?;
+
+    let mut data = vec![0; size];
+    reader
+        .read_exact(&mut data)
+        .with_context(|| format!("read complete {description} body ({size} bytes)"))?;
+    Ok(data)
+}
+
+pub fn write_frame(
+    writer: &mut impl Write,
+    data: &[u8],
+    max_size: usize,
+    description: &str,
+) -> Result<()> {
+    let size = frame_length(data.len(), max_size, description)?;
+    writer
+        .write_all(&size.to_be_bytes())
+        .with_context(|| format!("write {description} length"))?;
+    writer
+        .write_all(data)
+        .with_context(|| format!("write complete {description} body"))?;
+    writer.flush().context("flush IPC stream")?;
+    Ok(())
+}
+
+pub async fn read_frame_async(
+    reader: &mut (impl AsyncRead + Unpin),
+    max_size: usize,
+    description: &str,
+) -> Result<Vec<u8>> {
+    let mut header = [0; size_of::<u32>()];
+    reader
+        .read_exact(&mut header)
+        .await
+        .with_context(|| format!("read {description} length"))?;
+    let size = u32::from_be_bytes(header) as usize;
+    frame_length(size, max_size, description)?;
+
+    let mut data = vec![0; size];
+    reader
+        .read_exact(&mut data)
+        .await
+        .with_context(|| format!("read complete {description} body ({size} bytes)"))?;
+    Ok(data)
+}
+
+pub async fn write_frame_async(
+    writer: &mut (impl AsyncWrite + Unpin),
+    data: &[u8],
+    max_size: usize,
+    description: &str,
+) -> Result<()> {
+    let size = frame_length(data.len(), max_size, description)?;
+    writer
+        .write_all(&size.to_be_bytes())
+        .await
+        .with_context(|| format!("write {description} length"))?;
+    writer
+        .write_all(data)
+        .await
+        .with_context(|| format!("write complete {description} body"))?;
+    writer.flush().await.context("flush IPC stream")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Cursor, Read},
+        net::{TcpListener, TcpStream},
+        thread,
+    };
+
+    use super::{
+        read_frame, read_frame_async, write_frame, write_frame_async, MAX_REQUEST_SIZE,
+        MAX_RESPONSE_SIZE,
+    };
+
+    struct ChunkedReader<R> {
+        inner: R,
+        max_chunk_size: usize,
+    }
+
+    impl<R: Read> Read for ChunkedReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let limit = buf.len().min(self.max_chunk_size);
+            self.inner.read(&mut buf[..limit])
+        }
+    }
+
+    #[test]
+    fn oversized_frame_returns_an_error() {
+        let mut output = Vec::new();
+        let data = vec![0; MAX_REQUEST_SIZE + 1];
+
+        let error = write_frame(&mut output, &data, MAX_REQUEST_SIZE, "CLI request").unwrap_err();
+
+        assert!(error.to_string().contains("maximum"));
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn incomplete_frame_returns_an_error() {
+        let mut data = (5_u32).to_be_bytes().to_vec();
+        data.extend_from_slice(b"ab");
+
+        let error = read_frame(&mut Cursor::new(data), 10, "CLI response").unwrap_err();
+
+        assert!(error.to_string().contains("complete CLI response body"));
+    }
+
+    #[test]
+    fn response_can_arrive_in_many_transport_chunks() {
+        let expected = vec![7; 3 * 4096 + 17];
+        let mut frame = Vec::new();
+        write_frame(&mut frame, &expected, MAX_RESPONSE_SIZE, "CLI response").unwrap();
+        let mut reader = ChunkedReader {
+            inner: Cursor::new(frame),
+            max_chunk_size: 37,
+        };
+
+        let actual = read_frame(&mut reader, MAX_RESPONSE_SIZE, "CLI response").unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn async_frames_support_payloads_larger_than_the_stream_buffer() {
+        let expected = vec![3; 8193];
+        let sent = expected.clone();
+        let (mut sender, mut receiver) = tokio::io::duplex(31);
+        let write_task = tokio::spawn(async move {
+            write_frame_async(&mut sender, &sent, MAX_RESPONSE_SIZE, "CLI response").await
+        });
+
+        let actual = read_frame_async(&mut receiver, MAX_RESPONSE_SIZE, "CLI response")
+            .await
+            .unwrap();
+
+        write_task.await.unwrap().unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn concurrent_tcp_clients_keep_responses_isolated() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let handlers = (0..2)
+                .map(|_| {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    thread::spawn(move || {
+                        let request = read_frame(&mut stream, 128, "test request").unwrap();
+                        write_frame(&mut stream, &request, 128, "test response").unwrap();
+                    })
+                })
+                .collect::<Vec<_>>();
+            for handler in handlers {
+                handler.join().unwrap();
+            }
+        });
+
+        let clients = [b"first client".as_slice(), b"second client".as_slice()].map(|request| {
+            thread::spawn(move || {
+                let mut stream = TcpStream::connect(addr).unwrap();
+                write_frame(&mut stream, request, 128, "test request").unwrap();
+                read_frame(&mut stream, 128, "test response").unwrap()
+            })
+        });
+
+        let [first, second] = clients.map(|client| client.join().unwrap());
+        assert_eq!(first, b"first client");
+        assert_eq!(second, b"second client");
+        server.join().unwrap();
+    }
+}

--- a/spotify_player/src/cli/mod.rs
+++ b/spotify_player/src/cli/mod.rs
@@ -1,12 +1,11 @@
 mod client;
 mod commands;
 mod handlers;
+mod ipc;
 
 use crate::config;
 use rspotify::model::{AlbumId, ArtistId, Id, PlaylistId, TrackId};
 use serde::{Deserialize, Serialize};
-
-const MAX_REQUEST_SIZE: usize = 4096;
 
 pub use client::start_socket;
 pub use handlers::handle_cli_subcommand;


### PR DESCRIPTION
## Summary

- replace the unframed UDP CLI protocol with one length-prefixed TCP stream per command
- reject serialized requests larger than 4 KiB with an actionable error instead of asserting
- enforce a 5-second connection deadline and 30-second request and response I/O deadlines
- detect incomplete frames and cap responses at 32 MiB
- handle each accepted connection independently so concurrent CLI callers cannot consume one another's responses
- document the transport and deadlines

## Why

The UDP protocol split large responses across anonymous datagrams and used an empty datagram as an end marker. It had no request identity, ordering, integrity check, or timeout. It also asserted when user-controlled input serialized beyond the request buffer, which allowed a long query or playlist field to panic the CLI.

Length-prefixed TCP makes response boundaries explicit and isolates each caller on its own connection. Bounded connect, read, write, and request handling ensure a missing, stalled, or incomplete peer returns an error instead of waiting indefinitely.

The configured loopback port and CLI commands remain unchanged.

Closes #1030.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p spotify_player` (34 passed)
- `cargo test --no-default-features --features rodio-backend,media-control,image,notify,fzf` (34 passed)
- `cargo clippy --no-default-features --features rodio-backend,media-control,image,notify,fzf -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`

The tests cover oversized input, a missing listener, a stalled listener, incomplete frames, responses split across many reads, and concurrent client isolation.
