### PR TITLE
Add Regex Pattern Search

### DIFF
--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -1,9 +1,5 @@
 use std::{
-    collections::HashSet,
-    fmt::Write as _,
-    fs::{create_dir_all, remove_dir_all},
-    io::Write,
-    net::SocketAddr,
+    collections::HashSet, fmt::Write as _, fs::{create_dir_all, remove_dir_all}, io::Write, net::SocketAddr, process::exit,
 };
 
 use anyhow::{Context as _, Result};
@@ -191,6 +187,7 @@ async fn handle_socket_request(
             let resp = handle_search_request(client, query).await?;
             Ok(resp)
         }
+        // TODO aqui fica a search por command line, precisa fazer um regex aqui tb
         Request::Lyrics { id_or_name } => handle_lyrics_request(client, state, id_or_name).await,
     }
 }
@@ -337,7 +334,6 @@ async fn handle_get_item_request(
 
 async fn handle_search_request(client: &AppClient, query: String) -> Result<Vec<u8>> {
     let search_result = client.search(&query).await?;
-
     Ok(serde_json::to_vec(&search_result)?)
 }
 

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet, fmt::Write as _, fs::{create_dir_all, remove_dir_all}, io::Write, net::SocketAddr, process::exit,
+    collections::HashSet, fmt::Write as _, fs::{create_dir_all, remove_dir_all}, io::Write, net::SocketAddr,
 };
 
 use anyhow::{Context as _, Result};

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -187,7 +187,6 @@ async fn handle_socket_request(
             let resp = handle_search_request(client, query).await?;
             Ok(resp)
         }
-        // TODO aqui fica a search por command line, precisa fazer um regex aqui tb
         Request::Lyrics { id_or_name } => handle_lyrics_request(client, state, id_or_name).await,
     }
 }

--- a/spotify_player/src/command.rs
+++ b/spotify_player/src/command.rs
@@ -52,6 +52,7 @@ pub enum Command {
     SwitchTheme,
     SwitchDevice,
     Search,
+    SearchRegex,
     Queue,
 
     ShowActionsOnSelectedItem,
@@ -344,6 +345,7 @@ impl Command {
             Self::SwitchTheme => "open a popup for switching theme",
             Self::SwitchDevice => "open a popup for switching device",
             Self::Search => "open a popup for searching in the current page",
+            Self::SearchRegex => "nao esquece de colocar",
             Self::BrowseUserPlaylists => "open a popup for browsing user's playlists",
             Self::BrowseUserFollowedArtists => "open a popup for browsing user's followed artists",
             Self::BrowseUserSavedAlbums => "open a popup for browsing user's saved albums",

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -96,6 +96,10 @@ impl Default for KeymapConfig {
                     command: Command::Search,
                 },
                 Keymap {
+                    key_sequence: ";".into(),
+                    command: Command::SearchRegex
+                },
+                Keymap {
                     key_sequence: "z".into(),
                     command: Command::Queue,
                 },

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -731,9 +731,11 @@ fn handle_global_command(
             });
         }
         Command::SearchPage => {
+            // TODO essa é a janela inteira de search
+            ui.is_running = false;
             ui.new_page(PageState::Search {
                 line_input: LineInput::default(),
-                current_query: String::new(),
+                current_query: String::from("teste"),
                 state: SearchPageUIState::new(),
             });
         }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -731,7 +731,6 @@ fn handle_global_command(
             });
         }
         Command::SearchPage => {
-            // TODO essa é a janela inteira de search
             ui.is_running = false;
             ui.new_page(PageState::Search {
                 line_input: LineInput::default(),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -96,6 +96,11 @@ fn handle_command_for_library_page(
         return Ok(true);
     }
 
+    if command == Command::SearchRegex {
+        ui.new_regex_popup();
+        return Ok(true);
+    }
+
     let (focus_state, folder_id) = match ui.current_page() {
         PageState::Library { state } => (state.focus, state.playlist_folder_id),
         _ => anyhow::bail!("expect a library page state"),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -97,7 +97,7 @@ fn handle_command_for_library_page(
     }
 
     if command == Command::SearchRegex {
-        ui.new_regex_popup();
+        ui.new_regex_search_popup();
         return Ok(true);
     }
 

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -16,7 +16,7 @@ pub fn handle_key_sequence_for_popup(
             return handle_key_sequence_for_search_popup(key_sequence, client_pub, state, ui);
         }
         PopupState::RegexSearch { .. } => {
-            // TODO impl
+            return handle_key_sequence_for_regex_search_popup(key_sequence, client_pub, state, ui)
         }
         PopupState::PlaylistCreate { .. } => {
             return handle_key_sequence_for_create_playlist_popup(key_sequence, client_pub, ui);
@@ -366,6 +366,42 @@ fn handle_key_sequence_for_create_playlist_popup(
     Ok(false)
 }
 
+fn handle_key_sequence_for_regex_search_popup(
+    key_sequence: &KeySequence,
+    client_pub: &flume::Sender<ClientRequest>,
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+) -> Result<bool> {
+    let Some(PopupState::RegexSearch { ref mut pattern }) = &mut ui.popup else {
+        return Ok(false);
+    };
+    if key_sequence.keys.len() == 1 {
+        if let Key::None(c) = key_sequence.keys[0] {
+            match c {
+                crossterm::event::KeyCode::Char(c) => {
+                    pattern.push(c);
+                    ui.current_page_mut().select(0);
+                    return Ok(true);
+                }
+                crossterm::event::KeyCode::Backspace => {
+                    if pattern.is_empty() {
+                        // close regex search popup when user presses backspace on empty search
+                        ui.popup = None;
+                    } else {
+                        pattern.pop().unwrap();
+                        ui.current_page_mut().select(0);
+                    }
+                    return Ok(true);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // key sequence not handle by the popup should be moved to the current page's event handler
+    page::handle_key_sequence_for_page(key_sequence, client_pub, state, ui)
+}
+
 fn handle_key_sequence_for_search_popup(
     key_sequence: &KeySequence,
     client_pub: &flume::Sender<ClientRequest>,
@@ -374,7 +410,7 @@ fn handle_key_sequence_for_search_popup(
 ) -> Result<bool> {
     // handle user's input that updates the search query
     let Some(PopupState::Search { ref mut query }) = &mut ui.popup else {
-        return Ok(false); // TODO impl?
+        return Ok(false);
     };
     if key_sequence.keys.len() == 1 {
         if let Key::None(c) = key_sequence.keys[0] {

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -366,42 +366,6 @@ fn handle_key_sequence_for_create_playlist_popup(
     Ok(false)
 }
 
-fn handle_key_sequence_for_regex_search_popup(
-    key_sequence: &KeySequence,
-    client_pub: &flume::Sender<ClientRequest>,
-    state: &SharedState,
-    ui: &mut UIStateGuard,
-) -> Result<bool> {
-    let Some(PopupState::RegexSearch { ref mut pattern }) = &mut ui.popup else {
-        return Ok(false);
-    };
-    if key_sequence.keys.len() == 1 {
-        if let Key::None(c) = key_sequence.keys[0] {
-            match c {
-                crossterm::event::KeyCode::Char(c) => {
-                    pattern.push(c);
-                    ui.current_page_mut().select(0);
-                    return Ok(true);
-                }
-                crossterm::event::KeyCode::Backspace => {
-                    if pattern.is_empty() {
-                        // close regex search popup when user presses backspace on empty search
-                        ui.popup = None;
-                    } else {
-                        pattern.pop().unwrap();
-                        ui.current_page_mut().select(0);
-                    }
-                    return Ok(true);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    // key sequence not handle by the popup should be moved to the current page's event handler
-    page::handle_key_sequence_for_page(key_sequence, client_pub, state, ui)
-}
-
 fn handle_key_sequence_for_search_popup(
     key_sequence: &KeySequence,
     client_pub: &flume::Sender<ClientRequest>,
@@ -426,6 +390,42 @@ fn handle_key_sequence_for_search_popup(
                         ui.popup = None;
                     } else {
                         query.pop().unwrap();
+                        ui.current_page_mut().select(0);
+                    }
+                    return Ok(true);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // key sequence not handle by the popup should be moved to the current page's event handler
+    page::handle_key_sequence_for_page(key_sequence, client_pub, state, ui)
+}
+
+fn handle_key_sequence_for_regex_search_popup(
+    key_sequence: &KeySequence,
+    client_pub: &flume::Sender<ClientRequest>,
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+) -> Result<bool> {
+    let Some(PopupState::RegexSearch { ref mut pattern }) = &mut ui.popup else {
+        return Ok(false);
+    };
+    if key_sequence.keys.len() == 1 {
+        if let Key::None(c) = key_sequence.keys[0] {
+            match c {
+                crossterm::event::KeyCode::Char(c) => {
+                    pattern.push(c);
+                    ui.current_page_mut().select(0);
+                    return Ok(true);
+                }
+                crossterm::event::KeyCode::Backspace => {
+                    if pattern.is_empty() {
+                        // close regex search popup when user presses backspace on empty search
+                        ui.popup = None;
+                    } else {
+                        pattern.pop().unwrap();
                         ui.current_page_mut().select(0);
                     }
                     return Ok(true);

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -15,6 +15,9 @@ pub fn handle_key_sequence_for_popup(
         PopupState::Search { .. } => {
             return handle_key_sequence_for_search_popup(key_sequence, client_pub, state, ui);
         }
+        PopupState::RegexSearch { .. } => {
+            // TODO impl
+        }
         PopupState::PlaylistCreate { .. } => {
             return handle_key_sequence_for_create_playlist_popup(key_sequence, client_pub, ui);
         }
@@ -56,7 +59,7 @@ pub fn handle_key_sequence_for_popup(
         PopupState::ConfirmAction { .. } => {
             anyhow::bail!("confirm action should be handled before")
         }
-        PopupState::Search { .. } => anyhow::bail!("search popup should be handled before"),
+        PopupState::Search { .. } | PopupState::RegexSearch { .. } => anyhow::bail!("search popup should be handled before"),
         PopupState::PlaylistCreate { .. } => {
             anyhow::bail!("create playlist popup should be handled before")
         }
@@ -371,13 +374,14 @@ fn handle_key_sequence_for_search_popup(
 ) -> Result<bool> {
     // handle user's input that updates the search query
     let Some(PopupState::Search { ref mut query }) = &mut ui.popup else {
-        return Ok(false);
+        return Ok(false); // TODO impl?
     };
     if key_sequence.keys.len() == 1 {
         if let Key::None(c) = key_sequence.keys[0] {
             match c {
                 crossterm::event::KeyCode::Char(c) => {
                     query.push(c);
+                    // TODO isso funfa: query.push(c);
                     ui.current_page_mut().select(0);
                     return Ok(true);
                 }

--- a/spotify_player/src/event/popup.rs
+++ b/spotify_player/src/event/popup.rs
@@ -417,7 +417,6 @@ fn handle_key_sequence_for_search_popup(
             match c {
                 crossterm::event::KeyCode::Char(c) => {
                     query.push(c);
-                    // TODO isso funfa: query.push(c);
                     ui.current_page_mut().select(0);
                     return Ok(true);
                 }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -75,10 +75,10 @@ impl UIState {
         self.current_page_mut().select(0);
         self.popup = Some(PopupState::Search {
             query: String::new(),
-        }); // TODO impl?
+        });
     }
 
-    pub fn new_regex_popup(&mut self){
+    pub fn new_regex_search_popup(&mut self){
         self.current_page_mut().select(0);
          self.popup = Some(PopupState::RegexSearch {
             pattern: String::new(),
@@ -109,6 +109,7 @@ impl UIState {
     pub fn search_filtered_items<'a, T: std::fmt::Display>(&self, items: &'a [T]) -> Vec<&'a T> {
         match self.popup {
             Some(PopupState::Search { ref query }) => filtered_items_from_query(query, items),
+            Some(PopupState::RegexSearch { ref pattern }) => [].iter().collect::<Vec<_>>(),
             _ => items.iter().collect::<Vec<_>>(),
         }
     }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{self, Theme},
     key,
     ui::{self, Orientation},
-    utils::filtered_items_from_query,
+    utils::{filtered_items_from_query, filtered_items_from_regex_pattern},
 };
 
 #[cfg(feature = "image")]
@@ -109,7 +109,7 @@ impl UIState {
     pub fn search_filtered_items<'a, T: std::fmt::Display>(&self, items: &'a [T]) -> Vec<&'a T> {
         match self.popup {
             Some(PopupState::Search { ref query }) => filtered_items_from_query(query, items),
-            Some(PopupState::RegexSearch { ref pattern }) => [].iter().collect::<Vec<_>>(),
+            Some(PopupState::RegexSearch { ref pattern }) => filtered_items_from_regex_pattern(pattern, items),
             _ => items.iter().collect::<Vec<_>>(),
         }
     }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -75,6 +75,13 @@ impl UIState {
         self.current_page_mut().select(0);
         self.popup = Some(PopupState::Search {
             query: String::new(),
+        }); // TODO impl?
+    }
+
+    pub fn new_regex_popup(&mut self){
+        self.current_page_mut().select(0);
+         self.popup = Some(PopupState::RegexSearch {
+            pattern: String::new(),
         });
     }
 

--- a/spotify_player/src/state/ui/popup.rs
+++ b/spotify_player/src/state/ui/popup.rs
@@ -20,6 +20,9 @@ pub enum PopupState {
     Search {
         query: String,
     },
+    RegexSearch {
+        pattern: String
+    },
     UserPlaylistList(PlaylistPopupAction, ListState),
     UserFollowedArtistList(ListState),
     UserSavedAlbumList(ListState),
@@ -94,7 +97,7 @@ impl PopupState {
             | Self::ArtistList(.., list_state)
             | Self::ThemeList(.., list_state)
             | Self::ActionList(.., list_state) => Some(list_state),
-            Self::Search { .. } | Self::PlaylistCreate { .. } | Self::ConfirmAction { .. } => None,
+            Self::Search { .. } | Self::RegexSearch { .. } | Self::PlaylistCreate { .. } | Self::ConfirmAction { .. } => None,
         }
     }
 
@@ -108,7 +111,7 @@ impl PopupState {
             | Self::ArtistList(.., list_state)
             | Self::ThemeList(.., list_state)
             | Self::ActionList(.., list_state) => Some(list_state),
-            Self::Search { .. } | Self::PlaylistCreate { .. } | Self::ConfirmAction { .. } => None,
+            Self::Search { .. } | Self::RegexSearch { .. } | Self::PlaylistCreate { .. } | Self::ConfirmAction { .. } => None,
         }
     }
 

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -68,17 +68,15 @@ pub fn render_popup(
 
                 let rect =
                     construct_and_render_block("Search", &ui.theme, Borders::ALL, frame, chunks[1]);
-                //TODO acheiii
                 frame.render_widget(Paragraph::new(format!("/{query}")), rect);
                 (chunks[0], true)
             },
             PopupState::RegexSearch { pattern } => {
-                //TODO impl
                 let chunks =
                     Layout::vertical([Constraint::Fill(0), Constraint::Length(3)]).split(rect);
 
                 let rect =
-                    construct_and_render_block("Pattern", &ui.theme, Borders::ALL, frame, chunks[1]);
+                    construct_and_render_block("Pattern Search", &ui.theme, Borders::ALL, frame, chunks[1]);
                 frame.render_widget(Paragraph::new(format!(";{pattern}")), rect);
                 (chunks[0], true)
             },

--- a/spotify_player/src/ui/popup.rs
+++ b/spotify_player/src/ui/popup.rs
@@ -68,10 +68,20 @@ pub fn render_popup(
 
                 let rect =
                     construct_and_render_block("Search", &ui.theme, Borders::ALL, frame, chunks[1]);
-
+                //TODO acheiii
                 frame.render_widget(Paragraph::new(format!("/{query}")), rect);
                 (chunks[0], true)
-            }
+            },
+            PopupState::RegexSearch { pattern } => {
+                //TODO impl
+                let chunks =
+                    Layout::vertical([Constraint::Fill(0), Constraint::Length(3)]).split(rect);
+
+                let rect =
+                    construct_and_render_block("Pattern", &ui.theme, Borders::ALL, frame, chunks[1]);
+                frame.render_widget(Paragraph::new(format!(";{pattern}")), rect);
+                (chunks[0], true)
+            },
             PopupState::ActionList(item, _) => {
                 let rect = render_list_popup(
                     frame,

--- a/spotify_player/src/utils.rs
+++ b/spotify_player/src/utils.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use regex::Regex;
 
 /// formats a time duration into a "{minutes}:{seconds}" format
 pub fn format_duration(duration: &chrono::Duration) -> String {
@@ -94,4 +95,24 @@ pub fn filtered_items_from_query<'a, T: std::fmt::Display>(
             }
         })
         .collect::<Vec<_>>()
+}
+
+pub fn filtered_items_from_regex_pattern<'a, T: std::fmt::Display>(
+    pattern: &str,
+    items: &'a [T],
+) -> Vec<&'a T> {
+    let pattern = pattern.to_lowercase();
+    let pattern = pattern.as_str();
+    let re = Regex::new(& pattern);
+    match re {
+        Err( .. ) => { Vec::new() },
+        Ok(re) => { 
+            items
+                .iter()
+                .filter(|t| {
+                    let t = t.to_string().to_lowercase();
+                    re.is_match(&t)
+                }).collect::<Vec<_>>()
+        }
+    }
 }


### PR DESCRIPTION
I'm becoming a bit of a vim psycho, every once in a while i find myself trying to use regex patterns to search my library, I'm PR'ing this as a draft because the feature, for now, is still incomplete

As for the way it works:
- I used the ';' key to activate the feature, just because it's close to the '/' key, I considered making the regex search the default one by enabling some compiling flag, but that would make the fuzzy search feature be unusable with this one
- The string is considered 'matched' if the pattern is fount within any string, as opposed to requiring the whole string to match the Regex
- If you want to match a parentheses character, you have to escape it because regex uses them to capture stuff, regex captures are not particularly useful so maybe
- Just like the normal search, it's case insensitive
- I'm not sure people actually want this lol, I'll leave you to be the judge
- Does not work in the playlist / album window for some reason, when I figure this out I'll undraft the PR
- If the pattern does not compile it just returns an empty vector, I'll figure out a way to signal to the user that the pattern is actually invalid
- It's also not documented anywhere atm

<img width="1366" height="768" alt="S_26-07-20_00:13:15" src="https://github.com/user-attachments/assets/050a40be-dfe1-4b5b-825f-d9996a7abdaa" />
<img width="1366" height="768" alt="S_26-07-20_00:11:35" src="https://github.com/user-attachments/assets/ea0244ca-5fdf-448d-bb7d-d989006de9b9" />
<img width="1366" height="768" alt="S_26-07-20_00:11:22" src="https://github.com/user-attachments/assets/8ffb7c8a-9581-4419-a5ea-a34812807560" />
<img width="1366" height="768" alt="S_26-07-20_00:03:24" src="https://github.com/user-attachments/assets/5bbe7008-2901-484f-bb48-8b2733c3b292" />

https://github.com/user-attachments/assets/ddd8d563-2385-44ef-bb07-a3439152df66

