### PR TITLE
fix invalid token with Spotify's new token expiration policy

### DIFF
--- a/spotify_player/src/auth.rs
+++ b/spotify_player/src/auth.rs
@@ -133,30 +133,50 @@ pub fn get_creds(auth_config: &AuthConfig, reauth: bool, use_cached: bool) -> Re
 /// When `force` is set, any cached token is ignored and a fresh interactive authorization flow is
 /// always run. This is used by the `authenticate` CLI command to re-authenticate on demand.
 pub async fn prompt_for_user_token(
-    client: &mut rspotify::AuthCodePkceSpotify,
+    client: &mut crate::client::WebApiClient,
     force: bool,
 ) -> Result<()> {
     // Reuse a cached token when possible, refreshing it if it has expired.
     if !force {
         if let Ok(Some(token)) = client.read_token_cache(true).await {
             let expired = token.is_expired();
+            // A token without a refresh token cannot be renewed once it expires and
+            // gets wiped by the next refresh (e.g. caches nulled by Spotify's
+            // refresh-token change). Treat it as unusable so we re-authenticate and
+            // obtain a fresh refresh token instead of serving a dead-end token.
+            let renewable = token.refresh_token.is_some();
             *client.get_token().lock().await.unwrap() = Some(token);
 
-            if !expired {
+            if !expired && renewable {
                 return Ok(());
             }
 
-            if let Some(refreshed) = client
-                .refetch_token()
-                .await
-                .context("refresh expired token from cache")?
-            {
-                *client.get_token().lock().await.unwrap() = Some(refreshed);
-                client
-                    .write_token_cache()
-                    .await
-                    .context("write refreshed token to cache")?;
-                return Ok(());
+            // A refresh may fail because the refresh token expired (Spotify expires
+            // refresh tokens 6 months after the original authorization, returning
+            // `invalid_grant`) or because no refresh token is available. In either
+            // case, fall through to the interactive flow below rather than failing.
+            match client.refetch_token().await {
+                Ok(Some(refreshed)) => {
+                    *client.get_token().lock().await.unwrap() = Some(refreshed);
+                    client
+                        .write_token_cache()
+                        .await
+                        .context("write refreshed token to cache")?;
+                    return Ok(());
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        "Cached token could not be refreshed (no refresh token available); \
+                         falling back to interactive re-authentication."
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to refresh the cached token (the refresh token may have expired \
+                         per Spotify's 6-month refresh-token expiration policy); \
+                         falling back to interactive re-authentication: {err:#}"
+                    );
+                }
             }
         }
     }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -34,6 +34,7 @@ mod spotify;
 pub use handlers::*;
 pub use request::*;
 use serde::Deserialize;
+pub(crate) use spotify::WebApiClient;
 
 const SPOTIFY_API_ENDPOINT: &str = "https://api.spotify.com/v1";
 const PLAYBACK_TYPES: [&rspotify::model::AdditionalType; 2] = [
@@ -49,13 +50,13 @@ pub struct AppClient {
     spotify: Arc<spotify::Spotify>,
     auth_config: AuthConfig,
     /// The Spotify Web API client, used for interacting with Spotify Web APIs
-    api_client: rspotify::AuthCodePkceSpotify,
+    api_client: WebApiClient,
     #[cfg(feature = "streaming")]
     stream_conn: Arc<Mutex<Option<librespot_connect::Spirc>>>,
 }
 
 impl Deref for AppClient {
-    type Target = rspotify::AuthCodePkceSpotify;
+    type Target = WebApiClient;
     fn deref(&self) -> &Self::Target {
         &self.api_client
     }
@@ -65,7 +66,7 @@ impl Deref for AppClient {
 ///
 /// The returned client is unauthenticated; call [`auth::prompt_for_user_token`] to obtain an
 /// access token.
-pub fn new_api_client() -> Result<rspotify::AuthCodePkceSpotify> {
+pub fn new_api_client() -> Result<WebApiClient> {
     let configs = config::get_config();
 
     let id = configs.app_config.get_client_id()?;
@@ -102,8 +103,8 @@ pub fn new_api_client() -> Result<rspotify::AuthCodePkceSpotify> {
         cache_path: configs.cache_folder.join("user_client_token.json"),
         ..Default::default()
     };
-    Ok(rspotify::AuthCodePkceSpotify::with_config(
-        creds, oauth, config,
+    Ok(WebApiClient::new(
+        rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config),
     ))
 }
 

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -4,7 +4,7 @@ use rspotify::{
     clients::{BaseClient, OAuthClient},
     http::HttpClient,
     sync::Mutex,
-    ClientResult, Config, Credentials, OAuth, Token,
+    AuthCodePkceSpotify, ClientResult, Config, Credentials, OAuth, Token,
 };
 use std::{fmt, sync::Arc};
 
@@ -118,5 +118,85 @@ impl OAuthClient for Spotify {
 
     async fn request_token(&self, _code: &str) -> ClientResult<()> {
         panic!("`OAuthClient::request_token` should never be called!")
+    }
+}
+
+/// Thin wrapper over [`rspotify::AuthCodePkceSpotify`] for the Spotify Web API.
+///
+/// It exists solely to override `refetch_token` so that a refresh grant which
+/// omits `refresh_token` preserves the previously stored refresh token instead
+/// of overwriting it with `None`. Spotify stopped rotating (and now expires)
+/// refresh tokens, so the refresh response no longer echoes one back.
+///
+/// See:
+/// - <https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration>
+/// - <https://github.com/aome510/spotify-player/issues/1040>
+#[derive(Clone, Debug, Default)]
+pub struct WebApiClient(AuthCodePkceSpotify);
+
+impl WebApiClient {
+    pub fn new(inner: AuthCodePkceSpotify) -> Self {
+        Self(inner)
+    }
+
+    /// Forwards the inherent [`AuthCodePkceSpotify::get_authorize_url`], which needs
+    /// `&mut self` to store the PKCE verifier later read by `request_token`.
+    pub fn get_authorize_url(&mut self, verifier_bytes: Option<usize>) -> ClientResult<String> {
+        self.0.get_authorize_url(verifier_bytes)
+    }
+}
+
+#[maybe_async]
+impl BaseClient for WebApiClient {
+    fn get_http(&self) -> &HttpClient {
+        self.0.get_http()
+    }
+
+    fn get_token(&self) -> Arc<Mutex<Option<Token>>> {
+        self.0.get_token()
+    }
+
+    fn get_creds(&self) -> &Credentials {
+        self.0.get_creds()
+    }
+
+    fn get_config(&self) -> &Config {
+        self.0.get_config()
+    }
+
+    async fn refetch_token(&self) -> ClientResult<Option<Token>> {
+        // Capture the current refresh token before refreshing. The guard is a
+        // statement-level temporary released at the `;`, so it is not held across
+        // the inner refetch (which locks the same mutex) — avoids a deadlock.
+        let previous_refresh_token = self
+            .0
+            .get_token()
+            .lock()
+            .await
+            .unwrap()
+            .as_ref()
+            .and_then(|token| token.refresh_token.clone());
+
+        // Spotify's refresh response no longer includes `refresh_token`; carry the
+        // previous one forward so it is not lost on the round-trip and nulled in the
+        // token cache.
+        let refreshed = self.0.refetch_token().await?;
+        Ok(refreshed.map(|mut token| {
+            if token.refresh_token.is_none() {
+                token.refresh_token = previous_refresh_token;
+            }
+            token
+        }))
+    }
+}
+
+#[maybe_async]
+impl OAuthClient for WebApiClient {
+    fn get_oauth(&self) -> &OAuth {
+        self.0.get_oauth()
+    }
+
+    async fn request_token(&self, code: &str) -> ClientResult<()> {
+        self.0.request_token(code).await
     }
 }

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -139,8 +139,6 @@ impl WebApiClient {
         Self(inner)
     }
 
-    /// Forwards the inherent [`AuthCodePkceSpotify::get_authorize_url`], which needs
-    /// `&mut self` to store the PKCE verifier later read by `request_token`.
     pub fn get_authorize_url(&mut self, verifier_bytes: Option<usize>) -> ClientResult<String> {
         self.0.get_authorize_url(verifier_bytes)
     }
@@ -165,9 +163,7 @@ impl BaseClient for WebApiClient {
     }
 
     async fn refetch_token(&self) -> ClientResult<Option<Token>> {
-        // Capture the current refresh token before refreshing. The guard is a
-        // statement-level temporary released at the `;`, so it is not held across
-        // the inner refetch (which locks the same mutex) — avoids a deadlock.
+        // Capture the current refresh token before refreshing
         let previous_refresh_token = self
             .0
             .get_token()


### PR DESCRIPTION
### Summary

Resolves #1040

As of 2026-07-20 Spotify [stopped rotating and now expires refresh tokens](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration), so the Authorization-Code-with-PKCE refresh grant no longer returns a `refresh_token`. The Web API client is a stock `rspotify::AuthCodePkceSpotify`, whose `refetch_token` stores the refresh response verbatim — so `refresh_token` got nulled in `user_client_token.json`, and the next forced refresh then had nothing to refresh with and wiped the token entirely, leaving every request failing with `Token is not valid` / `get token: no access token`. This change wraps the Web API client so refreshes preserve the existing refresh token, and re-authenticates instead of crashing (or serving a dead-end token) when a refresh token is missing or expired.

### Changes

- **Preserve the refresh token across refreshes** (`client/spotify.rs`): add `WebApiClient`, a thin wrapper over `rspotify::AuthCodePkceSpotify` that overrides `refetch_token` to carry the previously stored refresh token forward when Spotify's refresh response omits one. All other behaviour delegates to the inner client.
- **Route all refreshes through the wrapper** (`client/mod.rs`): `AppClient`'s Web API client, `Deref` target, and `new_api_client` now use `WebApiClient`, so endpoint calls, `AppClient::token()`, and the post-session refresh all go through the override.
- **Recover already-corrupted caches** (`auth.rs`): only reuse a cached token when it is both unexpired *and* has a refresh token; otherwise re-authenticate. This auto-recovers tokens already nulled by the bug (previously such a token was reused, then wiped by the next refresh).
- **Graceful re-auth on refresh failure** (`auth.rs`): when a startup refresh fails — `invalid_grant` from an expired refresh token, or no refresh token available — log and fall back to interactive re-authentication instead of propagating the error and aborting startup.

### Notes

- Users whose `user_client_token.json` was already nulled by this bug will be prompted to log in once on next launch (the recovery step); it stays working across restarts afterwards.
- The same interactive fallback also covers Spotify's new 6-month refresh-token expiry.
