### PR TITLE
media_control: add xesam:url to MPRIS metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,8 +5746,7 @@ dependencies = [
 [[package]]
 name = "souvlaki"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5855c8f31521af07d896b852eaa9eca974ddd3211fc2ae292e58dda8eb129bc8"
+source = "git+https://github.com/bettehem/souvlaki?branch=metadata#17083b6a8324d27ffea6b25f03a90b9e3974ff85"
 dependencies = [
  "base64",
  "block",

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -43,7 +43,7 @@ parking_lot = "0.12.5"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 backtrace = "0.3.76"
-souvlaki = { version = "0.8.3", optional = true }
+souvlaki = { git = "https://github.com/bettehem/souvlaki", branch = "metadata", optional = true }
 image = { version = "0.25.10", optional = true }
 notify-rust = { version = "4.18.0", optional = true, default-features = false, features = [
 	"d",

--- a/spotify_player/src/media_control.rs
+++ b/spotify_player/src/media_control.rs
@@ -46,6 +46,7 @@ fn update_control_metadata(
                             artist: Some(&map_join(&track.artists, |a| &a.name, ", ")),
                             duration: track.duration.to_std().ok(),
                             cover_url: utils::get_track_album_image_url(track),
+                            media_url: Some(&track.external_urls["spotify"]),
                         })?;
 
                         *prev_info = track_info;
@@ -61,6 +62,7 @@ fn update_control_metadata(
                             artist: Some(&episode.show.publisher),
                             duration: episode.duration.to_std().ok(),
                             cover_url: utils::get_episode_show_image_url(episode),
+                            media_url: Some(&episode.external_urls["spotify"]),
                         })?;
 
                         *prev_info = episode_info;


### PR DESCRIPTION
souvlaki v0.9 is under development and has a bunch of breaking changes from v0.8

However, it seems the development of both 0.8 and 0.9 has been inactive for quite a while, so I thought I'd fork the repo and start adding missing features.

Instead of trying to make the 0.9 branch work with the possibility of more breaking changes being introduced, I forked the stable 0.8 master branch and added the missing xesam:url metadata field to it.

I would like to use spotify-player but I control my music players using an external program and xesam:url is one important field missing from the metadata which would be needed for it.

Specification: https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#xesam:url

Link to the xesam:url addition commit which is used my fork of souvlaki: https://github.com/Bettehem/souvlaki/commit/17083b6a8324d27ffea6b25f03a90b9e3974ff85


EDIT: added link to the souvlaki commit used in this PR