### PR TITLE
Apply volume locally and show it on screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ This file guides Claude Code when working in this repository.
 | `ui/{page,playback,popup}.rs` | Render functions for pages, playback bar, popups                            |
 | `ui/streaming.rs`             | FFT audio visualizer: `VisualizationSink`, `VisBands`, bar chart            |
 | `streaming.rs`                | librespot connection + audio backend setup (feature-gated)                  |
+| `volume.rs`                   | Volume offset math and persistence of the last level across connections     |
+| `ui/volume.rs`                | Transient volume HUD overlay drawn on volume changes                        |
 | `cli/`                        | Unix socket server and client for inter-process CLI commands                |
 | `auth.rs`                     | OAuth scopes and librespot credential/session building                      |
 | `media_control.rs`            | OS media key integration via `souvlaki` (feature-gated)                     |

--- a/README.md
+++ b/README.md
@@ -283,6 +283,14 @@ Set `enable_audio_visualization` to `true` in your config to enable this feature
 
 ![Audio Visualization](https://github.com/user-attachments/assets/8c21c1b0-5276-4a9e-b719-e0c2bd555537)
 
+### Volume
+
+Volume is adjusted with `+`/`_` (or the unshifted `=`/`-`) in steps of 5%, and muted with `m`. Each press applies locally right away and the requests sent to Spotify are coalesced, so holding a key ramps the volume smoothly instead of lagging behind.
+
+A volume gauge appears in a corner of the screen on every change and disappears again shortly after. Use `enable_volume_hud`, `volume_hud_position`, `volume_hud_timeout_in_ms`, and `volume_hud_width` to configure or disable it. See [config docs](https://github.com/aome510/spotify-player/blob/master/docs/config.md).
+
+The last volume you set is remembered in `$APP_CACHE_FOLDER/volume.state` and restored when the integrated player reconnects, so restarting the app or losing the network briefly does not reset playback to `device.volume`. That config option now only supplies the starting level before anything has been stored.
+
 ### Media Control
 
 Media control is enabled by default. Set `enable_media_control` to `true` in your config to use it. See [config docs](https://github.com/aome510/spotify-player/blob/master/docs/config.md#media-control).
@@ -425,8 +433,8 @@ List of supported commands:
 | `PlayRandom`                    | play a random track in the current context                                                         | `.`                |
 | `Repeat`                        | cycle the repeat mode                                                                              | `C-r`              |
 | `Shuffle`                       | toggle the shuffle mode                                                                            | `C-s`              |
-| `VolumeChange`                  | change playback volume by an offset (default shortcuts use 5%)                                     | `+`, `-`           |
-| `Mute`                          | toggle playback volume between 0% and previous level                                               | `_`                |
+| `VolumeChange`                  | change playback volume by an offset (default shortcuts use 5%)                                     | `+`, `_`, `=`, `-` |
+| `Mute`                          | toggle playback volume between 0% and previous level                                               | `m`                |
 | `SeekStart`                     | seek start of current track                                                                        | `^`                |
 | `SeekForward`                   | seek forward by a duration in seconds (defaults to `seek_duration_secs`)                           | `>`                |
 | `SeekBackward`                  | seek backward by a duration in seconds (defaults to `seek_duration_secs`)                          | `<`                |
@@ -524,7 +532,7 @@ See [configuration documentation](https://github.com/aome510/spotify-player/blob
 
 ## Caches
 
-By default, cache files are stored in `$HOME/.cache/spotify-player` (logs, credentials, audio cache, etc.). Change this with `-C <FOLDER_PATH>` or `--cache-folder <FOLDER_PATH>`.
+By default, cache files are stored in `$HOME/.cache/spotify-player` (logs, credentials, audio cache, the last volume in `volume.state`, etc.). Change this with `-C <FOLDER_PATH>` or `--cache-folder <FOLDER_PATH>`.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ Set `enable_audio_visualization` to `true` in your config to enable this feature
 
 ### Volume
 
-Volume is adjusted with `+`/`_` (or the unshifted `=`/`-`) in steps of 5%, and muted with `m`. Each press applies locally right away and the requests sent to Spotify are coalesced, so holding a key ramps the volume smoothly instead of lagging behind.
+Volume is adjusted with `+`/`_` (or the unshifted `=`/`-`) in steps of 5%, and muted with `m`.
+
+When playback is on the integrated player, volume is applied straight to its local mixer, so a keypress never waits on the network. Spotify's server-side volume is reconciled with a single deferred request once you stop adjusting. Playback on a remote Spotify Connect device still goes through the Web API, with requests coalesced so that holding a key does not queue one call per press.
 
 A volume gauge appears in a corner of the screen on every change and disappears again shortly after. Use `enable_volume_hud`, `volume_hud_position`, `volume_hud_timeout_in_ms`, and `volume_hud_width` to configure or disable it. See [config docs](https://github.com/aome510/spotify-player/blob/master/docs/config.md).
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -70,6 +70,10 @@ spotify_player -o device.volume=80 -o theme=dracula
 | `sort_artist_albums_by_type`      | Sort albums by type on artist pages.                                                                 | `false`                                                                |
 | `volume_scroll_step`              | Volume change step when using mouse scroll.                                                          | `5`                                                                    |
 | `enable_mouse_scroll_volume`      | Enable volume control via mouse scroll.                                                              | `true`                                                                 |
+| `enable_volume_hud`               | Show a transient volume gauge in a corner whenever the volume changes.                               | `true`                                                                 |
+| `volume_hud_timeout_in_ms`        | How long the volume HUD stays visible after the last change.                                         | `1500`                                                                 |
+| `volume_hud_position`             | Corner the volume HUD is drawn in: `TopLeft`, `TopRight`, `BottomLeft`, `BottomRight`.               | `TopRight`                                                             |
+| `volume_hud_width`                | Width, in terminal cells, of the volume HUD's gauge.                                                 | `20`                                                                   |
 | `custom_queue`                    | Enable app-managed queue for custom playback integration (requires `streaming` feature).             | `true`                                                                 |
 | `pause_on_startup`                | Start with playback paused instead of resuming the previous session (requires `streaming` feature).  | `false`                                                                |
 | `enable_relative_line_number`     | Enable Vim-style relative line numbers for lists and popups.                                         | `false`                                                                |
@@ -141,7 +145,7 @@ Device options are configured in the `[device]` section:
 | --------------- | ---------------------------------------- | ---------------- |
 | `name`          | Device name.                             | `spotify-player` |
 | `device_type`   | Device type.                             | `speaker`        |
-| `volume`        | Initial volume (percent).                | `70`             |
+| `volume`        | Initial volume (percent), used only until a volume has been set and remembered in the cache folder. | `70`             |
 | `bitrate`       | Bitrate in kbps (`96`, `160`, or `320`). | `320`            |
 | `audio_cache`   | Enable audio file caching.               | `false`          |
 | `normalization` | Enable audio normalization.              | `false`          |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -26,6 +26,10 @@ cover_img_pixels = 16
 seek_duration_secs = 5
 custom_queue = true
 enable_relative_line_number = false
+enable_volume_hud = true
+volume_hud_timeout_in_ms = 1500
+volume_hud_position = "TopRight"
+volume_hud_width = 20
 
 [device]
 name = "spotify-player"

--- a/spotify_player/src/cli/client.rs
+++ b/spotify_player/src/cli/client.rs
@@ -429,12 +429,14 @@ async fn handle_playback_request(
                 .context("no active playback found!")?
                 .volume
                 .context("playback has no volume!")?;
+            // Compute in `i32`: an offset applied to a near-max volume overflows `i8`, and the
+            // result needs clamping at both ends before it can be a valid percentage.
             let percent = if is_offset {
-                std::cmp::max(0, (volume as i8) + percent)
+                (i32::try_from(volume)? + i32::from(percent)).clamp(0, 100)
             } else {
-                percent
+                i32::from(percent).clamp(0, 100)
             };
-            PlayerRequest::Volume(percent.try_into()?)
+            PlayerRequest::Volume(u8::try_from(percent)?)
         }
         Command::Seek(position_offset_ms) => {
             // Playback's progress cannot be computed trivially without knowing the `playback` variable in
@@ -452,6 +454,13 @@ async fn handle_playback_request(
         }
     };
 
+    // A volume set from the CLI is just as much "the level the user chose" as one set from a
+    // keypress, so it has to be remembered for the next connection too.
+    let is_volume_request = matches!(
+        player_request,
+        PlayerRequest::Volume(..) | PlayerRequest::ToggleMute
+    );
+
     if let Some(state) = state {
         // A non-null application's state indicates there is a running application instance.
         // To reduce the latency of the CLI command, the player request is handled asynchronously
@@ -462,6 +471,9 @@ async fn handle_playback_request(
             async move {
                 match client.handle_player_request(player_request, playback).await {
                     Ok(playback) => {
+                        if is_volume_request {
+                            persist_volume(playback.as_ref());
+                        }
                         // update application's states
                         state.player.write().buffered_playback = playback;
                         client.update_playback(&state);
@@ -476,11 +488,24 @@ async fn handle_playback_request(
         });
     } else {
         // Handles the player request synchronously
-        client
+        let playback = client
             .handle_player_request(player_request, playback)
             .await?;
+        if is_volume_request {
+            persist_volume(playback.as_ref());
+        }
     }
     Ok(())
+}
+
+/// Remembers the volume of `playback` as the level to restore on the next connection.
+fn persist_volume(playback: Option<&crate::state::PlaybackMetadata>) {
+    if let Some(volume) = playback
+        .and_then(|p| p.mute_state.or(p.volume))
+        .and_then(|v| u8::try_from(v.min(100)).ok())
+    {
+        crate::volume::save(volume);
+    }
 }
 
 async fn handle_playlist_request(client: &AppClient, command: PlaylistCommand) -> Result<String> {

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -196,6 +196,33 @@ fn handle_player_event(
     Ok(())
 }
 
+/// Sends the volume the user settled on, once the throttle window since the last request has
+/// passed.
+///
+/// Volume keypresses apply locally and only dispatch a request every
+/// `state::VOLUME_SEND_INTERVAL`. Without this flush, the final press of a burst -- the one that
+/// actually matters -- would stay local and never reach Spotify.
+fn flush_pending_volume(state: &SharedState, client_pub: &flume::Sender<ClientRequest>) {
+    let volume = {
+        let mut player = state.player.write();
+        match player.volume_sync.pending {
+            Some(volume) if player.volume_sync.may_send() => {
+                player.volume_sync.mark_sent();
+                Some(volume)
+            }
+            _ => None,
+        }
+    };
+
+    if let Some(volume) = volume {
+        client_pub
+            .send(ClientRequest::Player(crate::client::PlayerRequest::Volume(
+                volume,
+            )))
+            .unwrap_or_default();
+    }
+}
+
 /// Starts event watcher listening to events and making update requests to the client if needed
 pub fn start_player_event_watcher(state: &SharedState, client_pub: &flume::Sender<ClientRequest>) {
     let configs = config::get_config();
@@ -218,6 +245,8 @@ pub fn start_player_event_watcher(state: &SharedState, client_pub: &flume::Sende
                 .unwrap_or_default();
             handler_state.last_playback_refresh_timer = Instant::now();
         }
+
+        flush_pending_volume(state, client_pub);
 
         if let Err(err) = handle_player_event(state, client_pub, &mut handler_state) {
             tracing::error!("Encounter error when handling player event: {err:#}");

--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -223,6 +223,35 @@ fn flush_pending_volume(state: &SharedState, client_pub: &flume::Sender<ClientRe
     }
 }
 
+/// Pushes the settled volume to the Web API once the user has stopped adjusting it.
+///
+/// Volume is applied locally on every press; this is the single deferred call that brings
+/// Spotify's server-side state back in line, rather than one call per keypress.
+fn sync_settled_volume_to_api(state: &SharedState, client_pub: &flume::Sender<ClientRequest>) {
+    let volume = {
+        let mut player = state.player.write();
+        let settled = player
+            .volume_sync
+            .last_change
+            .is_some_and(|t| t.elapsed() >= crate::state::VOLUME_API_SYNC_DELAY);
+
+        // Wait for the local dispatch to drain too, so the value pushed upstream is the one that
+        // actually took effect.
+        if settled && player.volume_sync.pending.is_none() {
+            player.volume_sync.last_change = None;
+            player.volume_sync.api_pending.take()
+        } else {
+            None
+        }
+    };
+
+    if let Some(volume) = volume {
+        client_pub
+            .send(ClientRequest::SyncVolumeToApi(volume))
+            .unwrap_or_default();
+    }
+}
+
 /// Starts event watcher listening to events and making update requests to the client if needed
 pub fn start_player_event_watcher(state: &SharedState, client_pub: &flume::Sender<ClientRequest>) {
     let configs = config::get_config();
@@ -247,6 +276,7 @@ pub fn start_player_event_watcher(state: &SharedState, client_pub: &flume::Sende
         }
 
         flush_pending_volume(state, client_pub);
+        sync_settled_volume_to_api(state, client_pub);
 
         if let Err(err) = handle_player_event(state, client_pub, &mut handler_state) {
             tracing::error!("Encounter error when handling player event: {err:#}");

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -463,9 +463,38 @@ impl AppClient {
                 state.data.write().user_data.user = Some(user);
             }
             ClientRequest::Player(request) => {
+                let is_volume_request = matches!(
+                    request,
+                    PlayerRequest::Volume(..) | PlayerRequest::ToggleMute
+                );
                 let playback = state.player.read().buffered_playback.clone();
-                let playback = self.handle_player_request(request, playback).await?;
-                state.player.write().buffered_playback = playback;
+                let mut playback = self.handle_player_request(request, playback).await?;
+
+                {
+                    let mut player = state.player.write();
+                    if is_volume_request {
+                        // The user may have pressed a volume key while this request was in flight.
+                        // That newer level is already applied locally, so keep it rather than
+                        // rolling the UI back to the level this request confirmed.
+                        if let (Some(new), Some(current)) =
+                            (playback.as_mut(), player.buffered_playback.as_ref())
+                        {
+                            if player.volume_sync.pending.is_some() {
+                                new.volume = current.volume;
+                                new.mute_state = current.mute_state;
+                            }
+                        }
+                        if let Some(volume) = playback
+                            .as_ref()
+                            .and_then(|p| p.mute_state.or(p.volume))
+                            .and_then(|v| u8::try_from(v.min(100)).ok())
+                        {
+                            crate::volume::save(volume);
+                        }
+                    }
+                    player.buffered_playback = playback;
+                }
+
                 self.update_playback(state);
             }
             ClientRequest::GetCurrentPlayback => {

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -463,27 +463,28 @@ impl AppClient {
                 state.data.write().user_data.user = Some(user);
             }
             ClientRequest::Player(request) => {
-                let is_volume_request = matches!(
-                    request,
-                    PlayerRequest::Volume(..) | PlayerRequest::ToggleMute
-                );
+                let is_volume_change = matches!(request, PlayerRequest::Volume(..));
+                let is_mute_change = matches!(request, PlayerRequest::ToggleMute);
+
                 let playback = state.player.read().buffered_playback.clone();
                 let mut playback = self.handle_player_request(request, playback).await?;
 
                 {
                     let mut player = state.player.write();
-                    if is_volume_request {
-                        // The user may have pressed a volume key while this request was in flight.
-                        // That newer level is already applied locally, so keep it rather than
-                        // rolling the UI back to the level this request confirmed.
+                    if is_volume_change {
+                        // Volume is driven locally: the key handler applies every press
+                        // immediately, so by the time this request lands the user may already be
+                        // several steps further along. The local level is therefore always the
+                        // newer one -- adopting the level this request carried would rewind the
+                        // display and show up as a flickering percentage.
                         if let (Some(new), Some(current)) =
                             (playback.as_mut(), player.buffered_playback.as_ref())
                         {
-                            if player.volume_sync.pending.is_some() {
-                                new.volume = current.volume;
-                                new.mute_state = current.mute_state;
-                            }
+                            new.volume = current.volume;
+                            new.mute_state = current.mute_state;
                         }
+                    }
+                    if is_volume_change || is_mute_change {
                         if let Some(volume) = playback
                             .as_ref()
                             .and_then(|p| p.mute_state.or(p.volume))
@@ -495,7 +496,13 @@ impl AppClient {
                     player.buffered_playback = playback;
                 }
 
-                self.update_playback(state);
+                // `update_playback` re-polls Spotify five times at one-second intervals to let the
+                // server catch up. Volume needs none of that -- the local value is authoritative --
+                // and spawning that storm per keypress would flood the API while a burst of
+                // presses is still in progress.
+                if !is_volume_change && !is_mute_change {
+                    self.update_playback(state);
+                }
             }
             ClientRequest::GetCurrentPlayback => {
                 self.retrieve_current_playback(state, true).await?;

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -311,6 +311,42 @@ impl AppClient {
         }
     }
 
+    /// Set the volume on the integrated player's local mixer, bypassing the network.
+    ///
+    /// Returns `false` when the request has to go over the Web API instead, either because
+    /// playback is on a remote Spotify Connect device or because no integrated player is running.
+    #[cfg(feature = "streaming")]
+    async fn set_local_volume(&self, device_id: Option<&str>, volume: u8) -> bool {
+        // Only our own device is ours to mix; anything else has to go through Spotify.
+        let session_device_id = self.spotify.session().await.device_id().to_string();
+        if device_id.is_some_and(|id| id != session_device_id) {
+            return false;
+        }
+
+        // librespot volume is a u16 over the full range, the app works in percent.
+        let scaled = (f64::from(volume.min(100)) / 100.0 * f64::from(u16::MAX)).round() as u16;
+
+        // `set_volume` only queues a command for the spirc task, so this holds the lock briefly
+        // and never across an await.
+        let conn = self.stream_conn.lock();
+        let Some(spirc) = conn.as_ref() else {
+            return false;
+        };
+        match spirc.set_volume(scaled) {
+            Ok(()) => true,
+            Err(err) => {
+                tracing::warn!("Failed to set volume on the integrated player: {err:#}");
+                false
+            }
+        }
+    }
+
+    #[cfg(not(feature = "streaming"))]
+    #[allow(clippy::unused_async)]
+    async fn set_local_volume(&self, _device_id: Option<&str>, _volume: u8) -> bool {
+        false
+    }
+
     /// Handle a player request, return a new playback metadata on success
     pub async fn handle_player_request(
         &self,
@@ -390,7 +426,13 @@ impl AppClient {
                 playback.shuffle_state = !playback.shuffle_state;
             }
             PlayerRequest::Volume(volume) => {
-                self.volume(volume, device_id).await?;
+                // Prefer the integrated player's own mixer: it lives in this process, so setting
+                // it costs a channel send rather than a round-trip to Spotify. librespot reports
+                // the new level upstream over its existing connection, and the Web API is
+                // reconciled separately once the user stops adjusting.
+                if !self.set_local_volume(device_id, volume).await {
+                    self.volume(volume, device_id).await?;
+                }
 
                 playback.volume = Some(u32::from(volume));
                 playback.mute_state = None;
@@ -502,6 +544,19 @@ impl AppClient {
                 // presses is still in progress.
                 if !is_volume_change && !is_mute_change {
                     self.update_playback(state);
+                }
+            }
+            ClientRequest::SyncVolumeToApi(volume) => {
+                // Best-effort reconciliation of Spotify's server-side volume. The level the user
+                // hears was already set locally, so a failure here is not worth surfacing.
+                let device_id = state
+                    .player
+                    .read()
+                    .buffered_playback
+                    .as_ref()
+                    .and_then(|p| p.device_id.clone());
+                if let Err(err) = self.volume(volume, device_id.as_deref()).await {
+                    tracing::warn!("Failed to sync volume to the Spotify API: {err:#}");
                 }
             }
             ClientRequest::GetCurrentPlayback => {

--- a/spotify_player/src/client/request.rs
+++ b/spotify_player/src/client/request.rs
@@ -32,6 +32,12 @@ pub enum ClientRequest {
     GetUserFollowedArtists,
     GetContext(ContextId),
     GetCurrentPlayback,
+    /// Push a settled volume to the Web API after local changes have gone quiet.
+    ///
+    /// Volume on the integrated player is applied through the local mixer, which never touches the
+    /// network. This reconciles Spotify's server-side state once the user stops adjusting, instead
+    /// of on every keypress.
+    SyncVolumeToApi(u8),
     Search(String),
     AddPlayableToQueue(PlayableId<'static>),
     AddAlbumToQueue(AlbumId<'static>),

--- a/spotify_player/src/config/keymap.rs
+++ b/spotify_player/src/config/keymap.rs
@@ -59,16 +59,29 @@ impl Default for KeymapConfig {
                     key_sequence: "C-s".into(),
                     command: Command::Shuffle,
                 },
+                // Volume is bound as two symmetric pairs so that either row of the key --
+                // shifted (`+`/`_`) or unshifted (`=`/`-`) -- adjusts it the same way.
                 Keymap {
                     key_sequence: "+".into(),
+                    command: Command::VolumeChange { offset: 5 },
+                },
+                Keymap {
+                    key_sequence: "_".into(),
+                    command: Command::VolumeChange { offset: -5 },
+                },
+                Keymap {
+                    key_sequence: "=".into(),
                     command: Command::VolumeChange { offset: 5 },
                 },
                 Keymap {
                     key_sequence: "-".into(),
                     command: Command::VolumeChange { offset: -5 },
                 },
+                // `_` now adjusts the volume, so mute moves here. Note that `C-m` is not an
+                // option: terminals send it as the same byte as Enter (CR), so binding it would
+                // shadow the `enter` keymap.
                 Keymap {
-                    key_sequence: "_".into(),
+                    key_sequence: "m".into(),
                     command: Command::Mute,
                 },
                 Keymap {

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -131,6 +131,15 @@ pub struct AppConfig {
     pub volume_scroll_step: u8,
     pub enable_mouse_scroll_volume: bool,
 
+    /// Show a transient volume gauge in a corner of the screen whenever the volume changes.
+    pub enable_volume_hud: bool,
+    /// How long the volume HUD stays on screen after the last change.
+    pub volume_hud_timeout_in_ms: u64,
+    /// Which corner the volume HUD is drawn in.
+    pub volume_hud_position: VolumeHudPosition,
+    /// Width, in cells, of the volume HUD's gauge.
+    pub volume_hud_width: u16,
+
     /// Enable app-managed queue for full playlist playback.
     /// Requires streaming. When disabled, playback uses Spotify-native queue
     /// management.
@@ -176,6 +185,16 @@ pub enum ProgressBarPosition {
     Right,
 }
 config_parser_impl!(ProgressBarPosition);
+
+/// Which corner the transient volume HUD is drawn in.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub enum VolumeHudPosition {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+config_parser_impl!(VolumeHudPosition);
 
 #[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 pub struct Command {
@@ -392,6 +411,11 @@ impl Default for AppConfig {
 
             volume_scroll_step: 5,
             enable_mouse_scroll_volume: true,
+
+            enable_volume_hud: true,
+            volume_hud_timeout_in_ms: 1500,
+            volume_hud_position: VolumeHudPosition::TopRight,
+            volume_hud_width: 20,
 
             custom_queue: true,
 

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -59,6 +59,29 @@ pub fn start_event_handler(state: &SharedState, client_pub: &flume::Sender<Clien
     }
 }
 
+/// Adjusts the playback volume by `offset` percent.
+///
+/// The new level is clamped to `0..=100` and applied to the local playback state straight away, so
+/// the UI and any immediately following keypress both see it without waiting for Spotify to
+/// acknowledge the change. Requests are throttled by [`PlayerState::apply_volume`]; the player
+/// event watcher flushes whatever the user settled on.
+fn change_volume_by(
+    offset: i32,
+    client_pub: &flume::Sender<ClientRequest>,
+    state: &SharedState,
+) -> Result<()> {
+    let mut player = state.player.write();
+    let Some(volume) = player.effective_volume() else {
+        return Ok(());
+    };
+    let new_volume = crate::volume::offset_volume(volume, offset);
+
+    if let Some(volume) = player.apply_volume(new_volume) {
+        client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume)))?;
+    }
+    Ok(())
+}
+
 // Handle a terminal mouse event
 fn handle_mouse_event(
     event: crossterm::event::MouseEvent,
@@ -72,21 +95,13 @@ fn handle_mouse_event(
     match event.kind {
         crossterm::event::MouseEventKind::ScrollUp if enable_scroll => {
             let step = config::get_config().app_config.volume_scroll_step;
-            if let Some(ref playback) = state.player.read().buffered_playback {
-                if let Some(volume) = playback.volume {
-                    let new_volume = std::cmp::min(volume as u8 + step, 100);
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(new_volume)))?;
-                }
-            }
+            change_volume_by(i32::from(step), client_pub, state)?;
+            state.ui.lock().volume_hud_shown_at = Some(std::time::Instant::now());
         }
         crossterm::event::MouseEventKind::ScrollDown if enable_scroll => {
             let step = config::get_config().app_config.volume_scroll_step;
-            if let Some(ref playback) = state.player.read().buffered_playback {
-                if let Some(volume) = playback.volume {
-                    let new_volume = (volume as u8).saturating_sub(step);
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(new_volume)))?;
-                }
-            }
+            change_volume_by(-i32::from(step), client_pub, state)?;
+            state.ui.lock().volume_hud_shown_at = Some(std::time::Instant::now());
         }
         // a left click event
         crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
@@ -593,15 +608,12 @@ fn handle_global_command(
             client_pub.send(ClientRequest::Player(PlayerRequest::Shuffle))?;
         }
         Command::VolumeChange { offset } => {
-            if let Some(ref playback) = state.player.read().buffered_playback {
-                if let Some(volume) = playback.volume {
-                    let volume = std::cmp::min(volume as i32 + offset, 100_i32);
-                    client_pub.send(ClientRequest::Player(PlayerRequest::Volume(volume as u8)))?;
-                }
-            }
+            change_volume_by(offset, client_pub, state)?;
+            ui.volume_hud_shown_at = Some(std::time::Instant::now());
         }
         Command::Mute => {
             client_pub.send(ClientRequest::Player(PlayerRequest::ToggleMute))?;
+            ui.volume_hud_shown_at = Some(std::time::Instant::now());
         }
         Command::SeekStart => {
             client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(

--- a/spotify_player/src/main.rs
+++ b/spotify_player/src/main.rs
@@ -15,6 +15,7 @@ mod streaming;
 mod token;
 mod ui;
 mod utils;
+mod volume;
 
 use anyhow::{Context, Result};
 use parking_lot::Mutex;

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -40,14 +40,21 @@ pub struct PlayerState {
 /// player event watcher.
 #[derive(Default, Debug)]
 pub struct VolumeSync {
-    /// A volume the user has dialed in that has not been sent to Spotify yet.
+    /// A volume the user has dialed in that has not been applied yet.
     pub pending: Option<u8>,
     /// When a volume request was last dispatched.
     pub last_sent: Option<std::time::Instant>,
+    /// A volume that has been applied locally but not yet reflected in Spotify's server-side
+    /// state, along with when the user last moved it.
+    pub api_pending: Option<u8>,
+    pub last_change: Option<std::time::Instant>,
 }
 
 /// Minimum spacing between volume requests sent to Spotify.
 pub const VOLUME_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// How long volume must sit still before the settled level is pushed to the Web API.
+pub const VOLUME_API_SYNC_DELAY: std::time::Duration = std::time::Duration::from_millis(800);
 
 impl VolumeSync {
     /// Whether a request may be dispatched right now.
@@ -122,6 +129,11 @@ impl PlayerState {
         playback.volume = Some(u32::from(volume));
         // Changing the volume takes the playback out of the muted state.
         playback.mute_state = None;
+
+        // Spotify's server-side state now owes an update, but it can wait until the user stops
+        // turning the knob.
+        self.volume_sync.api_pending = Some(volume);
+        self.volume_sync.last_change = Some(std::time::Instant::now());
 
         if self.volume_sync.may_send() {
             self.volume_sync.mark_sent();

--- a/spotify_player/src/state/player.rs
+++ b/spotify_player/src/state/player.rs
@@ -23,6 +23,46 @@ pub struct PlayerState {
     /// Active when the integrated librespot player is streaming and the user
     /// started playback from a track-table context.
     pub custom_queue: Option<CustomQueue>,
+
+    /// Rate-limiting state for volume requests, see [`VolumeSync`].
+    pub volume_sync: VolumeSync,
+}
+
+/// Tracks in-flight volume changes so that rapid keypresses stay responsive.
+///
+/// A volume command used to read the volume out of `buffered_playback`, which is only refreshed
+/// *after* the Spotify request completes. Mashing a volume key therefore made every press compute
+/// its target from the same stale value, so a burst of presses collapsed into a single step.
+///
+/// Instead the key handler now updates `buffered_playback` optimistically (so the UI and the next
+/// keypress both see the new level immediately) and records the desired level here. Requests are
+/// dispatched at most once per [`VOLUME_SEND_INTERVAL`], with the trailing value flushed by the
+/// player event watcher.
+#[derive(Default, Debug)]
+pub struct VolumeSync {
+    /// A volume the user has dialed in that has not been sent to Spotify yet.
+    pub pending: Option<u8>,
+    /// When a volume request was last dispatched.
+    pub last_sent: Option<std::time::Instant>,
+}
+
+/// Minimum spacing between volume requests sent to Spotify.
+pub const VOLUME_SEND_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+impl VolumeSync {
+    /// Whether a request may be dispatched right now.
+    pub fn may_send(&self) -> bool {
+        match self.last_sent {
+            Some(t) => t.elapsed() >= VOLUME_SEND_INTERVAL,
+            None => true,
+        }
+    }
+
+    /// Marks a request for `volume` as dispatched.
+    pub fn mark_sent(&mut self) {
+        self.pending = None;
+        self.last_sent = Some(std::time::Instant::now());
+    }
 }
 
 impl PlayerState {
@@ -59,6 +99,37 @@ impl PlayerState {
 
     pub fn currently_playing(&self) -> Option<&rspotify::model::PlayableItem> {
         self.playback.as_ref().and_then(|p| p.item.as_ref())
+    }
+
+    /// The volume a further adjustment should be applied to.
+    ///
+    /// While muted, `volume` holds the pre-mute level, so adjusting from it means unmuting lands
+    /// on a level relative to what the user last heard.
+    pub fn effective_volume(&self) -> Option<u8> {
+        let playback = self.buffered_playback.as_ref()?;
+        let volume = playback.mute_state.or(playback.volume)?;
+        Some(u8::try_from(volume.min(100)).unwrap_or(100))
+    }
+
+    /// Applies `volume` to the buffered playback immediately, without waiting for Spotify to
+    /// confirm it, and queues it for dispatch. Returns the volume to send now, if any.
+    ///
+    /// Applying locally first is what makes a burst of keypresses accumulate correctly: each press
+    /// reads the level the previous one just set instead of the last server-confirmed value.
+    pub fn apply_volume(&mut self, volume: u8) -> Option<u8> {
+        let volume = volume.min(100);
+        let playback = self.buffered_playback.as_mut()?;
+        playback.volume = Some(u32::from(volume));
+        // Changing the volume takes the playback out of the muted state.
+        playback.mute_state = None;
+
+        if self.volume_sync.may_send() {
+            self.volume_sync.mark_sent();
+            Some(volume)
+        } else {
+            self.volume_sync.pending = Some(volume);
+            None
+        }
     }
 
     pub fn playback_progress(&self) -> Option<chrono::Duration> {

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -55,6 +55,9 @@ pub struct UIState {
     /// Count prefix for vim-style navigation (e.g., 5j, 10k)
     pub count_prefix: Option<usize>,
 
+    /// When the volume was last changed, used to show and time out the volume HUD.
+    pub volume_hud_shown_at: Option<std::time::Instant>,
+
     #[cfg(feature = "image")]
     pub last_cover_image_render_info: ImageRenderInfo,
 
@@ -131,6 +134,8 @@ impl Default for UIState {
             playback_progress_bar_rect: Rect::default(),
 
             count_prefix: None,
+
+            volume_hud_shown_at: None,
 
             #[cfg(feature = "image")]
             last_cover_image_render_info: ImageRenderInfo::default(),

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -157,10 +157,14 @@ pub async fn new_connection(
     let configs = config::get_config();
     let device = &configs.app_config.device;
 
+    // Start at the last volume the user set rather than the configured default, so that
+    // reconnecting (after a network drop) or restarting the app does not jump the level.
+    let initial_percent = crate::volume::initial();
+
     // `librespot` volume is a u16 number ranging from 0 to 65535,
     // while a percentage volume value (from 0 to 100) is used for the device configuration.
     // So we need to convert from one format to another
-    let volume = (f64::from(std::cmp::min(device.volume, 100_u8)) / 100.0 * 65535.0).round() as u16;
+    let volume = (f64::from(initial_percent) / 100.0 * 65535.0).round() as u16;
 
     let connect_config = ConnectConfig {
         name: device.name.clone(),

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -33,6 +33,7 @@ pub mod single_line_input;
 #[cfg(feature = "streaming")]
 pub mod streaming;
 pub mod utils;
+mod volume;
 
 /// Run the application UI
 pub fn run(state: &SharedState, mut terminal: Terminal) -> Result<()> {
@@ -139,6 +140,8 @@ fn clean_up(mut terminal: Terminal) -> Result<()> {
 fn render_application(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGuard, rect: Rect) {
     // rendering order: playback window -> shortcut help popup -> other popups -> main layout
 
+    let full_rect = rect;
+
     // render playback window before other popups and windows to ensure nothing is rendered on top
     // of the playback window, which is to avoid "duplicated images" issue
     // See: https://github.com/aome510/spotify-player/issues/498
@@ -149,6 +152,10 @@ fn render_application(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGu
     let (rect, is_active) = popup::render_popup(frame, state, ui, rect);
 
     render_main_layout(is_active, frame, state, ui, rect);
+
+    // The volume HUD is an overlay, so it is drawn last against the full area to sit on top of
+    // whatever is currently on screen.
+    volume::render_volume_hud(frame, state, ui, full_rect);
 }
 
 /// Render the application's main layout

--- a/spotify_player/src/ui/volume.rs
+++ b/spotify_player/src/ui/volume.rs
@@ -1,0 +1,290 @@
+//! A transient volume gauge, drawn in a corner whenever the volume changes.
+//!
+//! The playback window can already list the volume as a metadata field, but that is static text
+//! that only tells you the level if you go looking for it. This overlay pops up on a volume change
+//! and fades out on its own, giving the volume keys immediate visual feedback.
+
+use ratatui::{
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::{
+    config::{self, VolumeHudPosition},
+    state::{SharedState, UIStateGuard},
+};
+
+/// Outer size of the HUD, derived from the configured gauge width plus borders and padding.
+fn hud_size(gauge_width: u16) -> (u16, u16) {
+    // gauge + a space + "100%" (4 cells) + one cell of padding on each side + two borders
+    (gauge_width + 4 + 1 + 2 + 2, 3)
+}
+
+/// Places the HUD in the configured corner of `rect`, inset by one cell so it does not sit flush
+/// against the terminal edge. Returns `None` when the terminal is too small to hold it.
+fn hud_rect(rect: Rect, position: &VolumeHudPosition, gauge_width: u16) -> Option<Rect> {
+    let (width, height) = hud_size(gauge_width);
+    if rect.width < width + 2 || rect.height < height + 2 {
+        return None;
+    }
+
+    let (x, y) = match position {
+        VolumeHudPosition::TopLeft => (rect.x + 1, rect.y + 1),
+        VolumeHudPosition::TopRight => (rect.x + rect.width - width - 1, rect.y + 1),
+        VolumeHudPosition::BottomLeft => (rect.x + 1, rect.y + rect.height - height - 1),
+        VolumeHudPosition::BottomRight => (
+            rect.x + rect.width - width - 1,
+            rect.y + rect.height - height - 1,
+        ),
+    };
+
+    Some(Rect {
+        x,
+        y,
+        width,
+        height,
+    })
+}
+
+/// How many of `width` cells the gauge fills at `volume` percent.
+///
+/// Rounds up so that a quiet-but-audible level never renders as an empty bar, which would read as
+/// muted.
+fn filled_cells(volume: u8, width: u16) -> usize {
+    let width = usize::from(width);
+    (usize::from(volume) * width).div_ceil(100).min(width)
+}
+
+/// Builds the gauge as filled/unfilled block runs, so the bar keeps its shape under any theme.
+fn gauge_spans(volume: u8, width: u16, muted: bool, ui: &UIStateGuard) -> Vec<Span<'static>> {
+    let filled = filled_cells(volume, width);
+    let unfilled = usize::from(width) - filled;
+
+    let filled_style = if muted {
+        ui.theme.playback_metadata()
+    } else {
+        ui.theme.playback_progress_bar()
+    };
+
+    vec![
+        Span::styled("\u{2588}".repeat(filled), filled_style),
+        Span::styled(
+            "\u{2591}".repeat(unfilled),
+            ui.theme.playback_progress_bar_unfilled(),
+        ),
+    ]
+}
+
+/// Renders the volume HUD if it was triggered recently enough, and clears the trigger once its
+/// timeout has elapsed.
+pub fn render_volume_hud(
+    frame: &mut Frame,
+    state: &SharedState,
+    ui: &mut UIStateGuard,
+    rect: Rect,
+) {
+    let configs = config::get_config();
+    if !configs.app_config.enable_volume_hud {
+        return;
+    }
+
+    let timeout = std::time::Duration::from_millis(configs.app_config.volume_hud_timeout_in_ms);
+    match ui.volume_hud_shown_at {
+        Some(shown_at) if shown_at.elapsed() < timeout => {}
+        Some(_) => {
+            ui.volume_hud_shown_at = None;
+            return;
+        }
+        None => return,
+    }
+
+    let (volume, muted) = {
+        let player = state.player.read();
+        let Some(playback) = player.buffered_playback.as_ref() else {
+            return;
+        };
+        // While muted, `volume` holds the pre-mute level; show that so the bar does not collapse
+        // to nothing, and label it instead.
+        match playback.mute_state {
+            Some(volume) => (volume, true),
+            None => match playback.volume {
+                Some(volume) => (volume, false),
+                None => return,
+            },
+        }
+    };
+    let volume = u8::try_from(volume.min(100)).unwrap_or(100);
+
+    let gauge_width = configs.app_config.volume_hud_width.max(4);
+    let Some(area) = hud_rect(rect, &configs.app_config.volume_hud_position, gauge_width) else {
+        return;
+    };
+
+    let mut spans = gauge_spans(volume, gauge_width, muted, ui);
+    spans.push(Span::styled(
+        format!(" {volume:>3}%"),
+        ui.theme
+            .playback_track()
+            .add_modifier(if muted { Modifier::DIM } else { Modifier::BOLD }),
+    ));
+
+    let title = if muted { " MUTED " } else { " VOLUME " };
+    let block = Block::default()
+        .title(Span::styled(title, ui.theme.block_title()))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .style(ui.theme.app());
+
+    // `Clear` keeps whatever the HUD overlaps from bleeding through.
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(Line::from(spans))
+            .alignment(Alignment::Center)
+            .block(block)
+            .style(Style::default()),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filled_cells, hud_rect, hud_size};
+    use crate::config::VolumeHudPosition;
+    use ratatui::layout::Rect;
+
+    const GAUGE: u16 = 20;
+
+    fn terminal(width: u16, height: u16) -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn gauge_fills_proportionally() {
+        assert_eq!(filled_cells(0, GAUGE), 0);
+        assert_eq!(filled_cells(50, GAUGE), 10);
+        assert_eq!(filled_cells(100, GAUGE), 20);
+    }
+
+    /// A barely-audible volume must still show something, or it looks muted.
+    #[test]
+    fn gauge_never_rounds_an_audible_volume_down_to_empty() {
+        assert_eq!(filled_cells(1, GAUGE), 1);
+    }
+
+    #[test]
+    fn gauge_never_overflows_its_width() {
+        for volume in 0..=100u8 {
+            for width in [4u16, 7, 20, 60] {
+                assert!(filled_cells(volume, width) <= usize::from(width));
+            }
+        }
+    }
+
+    /// The HUD is drawn with an absolute `Rect`, so it must stay inside the frame; ratatui panics
+    /// on out-of-bounds areas.
+    #[test]
+    fn hud_stays_within_the_terminal_in_every_corner() {
+        let rect = terminal(120, 40);
+        for position in [
+            VolumeHudPosition::TopLeft,
+            VolumeHudPosition::TopRight,
+            VolumeHudPosition::BottomLeft,
+            VolumeHudPosition::BottomRight,
+        ] {
+            let area = hud_rect(rect, &position, GAUGE).expect("fits in a 120x40 terminal");
+            assert!(area.x >= rect.x, "{position:?} overflows left");
+            assert!(area.y >= rect.y, "{position:?} overflows top");
+            assert!(
+                area.x + area.width <= rect.x + rect.width,
+                "{position:?} overflows right"
+            );
+            assert!(
+                area.y + area.height <= rect.y + rect.height,
+                "{position:?} overflows bottom"
+            );
+        }
+    }
+
+    #[test]
+    fn hud_is_skipped_when_the_terminal_is_too_small() {
+        let (width, height) = hud_size(GAUGE);
+        assert!(hud_rect(terminal(width, height), &VolumeHudPosition::TopRight, GAUGE).is_none());
+        assert!(hud_rect(terminal(10, 3), &VolumeHudPosition::TopRight, GAUGE).is_none());
+        assert!(hud_rect(terminal(1, 1), &VolumeHudPosition::BottomLeft, GAUGE).is_none());
+    }
+
+    #[test]
+    fn hud_fits_the_gauge_and_its_label() {
+        let (width, _) = hud_size(GAUGE);
+        // two borders + two padding cells + gauge + a space + "100%"
+        assert_eq!(width, 2 + 2 + GAUGE + 1 + 4);
+    }
+
+    /// Renders the HUD through a real ratatui frame to confirm the overlay draws the gauge and
+    /// the level, and that the surrounding buffer is left intact.
+    #[test]
+    fn renders_the_gauge_and_level_into_the_frame() {
+        use crate::state::{PlaybackMetadata, State};
+        use parking_lot::Mutex;
+        use ratatui::{backend::TestBackend, Terminal};
+        use std::{collections::VecDeque, sync::Arc};
+
+        let dir = std::env::temp_dir().join("spotify-player-volume-hud-test");
+        std::fs::create_dir_all(&dir).expect("create temp config folder");
+        crate::config::set_config(
+            crate::config::Configs::new(&dir, &dir).expect("build test configs"),
+        );
+
+        let state: crate::state::SharedState =
+            Arc::new(State::new(false, Arc::new(Mutex::new(VecDeque::new()))));
+        state.player.write().buffered_playback = Some(PlaybackMetadata {
+            device_name: "test".to_string(),
+            device_id: None,
+            volume: Some(70),
+            is_playing: true,
+            repeat_state: rspotify::model::RepeatState::Off,
+            shuffle_state: false,
+            mute_state: None,
+        });
+        state.ui.lock().volume_hud_shown_at = Some(std::time::Instant::now());
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).expect("build test terminal");
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let mut ui = state.ui.lock();
+                super::render_volume_hud(frame, &state, &mut ui, area);
+            })
+            .expect("draw the volume HUD");
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+
+        assert!(rendered.contains("VOLUME"), "HUD title is missing");
+        assert!(rendered.contains("70%"), "volume level is missing");
+        assert!(
+            rendered.contains(&"\u{2588}".repeat(14)),
+            "filled gauge is missing"
+        );
+        assert!(
+            rendered.contains(&"\u{2591}".repeat(6)),
+            "unfilled gauge is missing"
+        );
+
+        // The HUD must not have been triggered off; it is still within its timeout.
+        assert!(state.ui.lock().volume_hud_shown_at.is_some());
+    }
+}

--- a/spotify_player/src/volume.rs
+++ b/spotify_player/src/volume.rs
@@ -1,0 +1,106 @@
+//! Persistence for the last known playback volume.
+//!
+//! The integrated `librespot` device is created with a fixed `initial_volume`, so every
+//! reconnection (a new session after the network drops, or simply restarting the app) used to
+//! reset playback to `device.volume` from the config. Remembering the last volume the user
+//! actually set and replaying it on connect keeps the level stable across those events.
+
+use crate::config;
+
+/// File (inside the cache folder) holding the last volume, as a plain percentage.
+const VOLUME_STATE_FILE: &str = "volume.state";
+
+fn state_file_path() -> std::path::PathBuf {
+    config::get_config().cache_folder.join(VOLUME_STATE_FILE)
+}
+
+/// Reads the last persisted volume, or `None` if it was never stored or is unreadable.
+// Only read back when creating an integrated player, which is gated behind `streaming`.
+#[cfg_attr(not(feature = "streaming"), allow(dead_code))]
+pub fn load() -> Option<u8> {
+    let path = state_file_path();
+    let raw = std::fs::read_to_string(&path).ok()?;
+    match raw.trim().parse::<u8>() {
+        Ok(volume) if volume <= 100 => Some(volume),
+        _ => {
+            tracing::warn!("Ignoring malformed persisted volume in {}", path.display());
+            None
+        }
+    }
+}
+
+/// Stores `volume` as the level to restore on the next connection.
+///
+/// Failures are logged rather than propagated: losing the remembered volume should never take
+/// down a playback command.
+pub fn save(volume: u8) {
+    let path = state_file_path();
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            tracing::warn!("Failed to create cache folder for volume state: {err:#}");
+            return;
+        }
+    }
+    if let Err(err) = std::fs::write(&path, volume.to_string()) {
+        tracing::warn!("Failed to persist volume to {}: {err:#}", path.display());
+    }
+}
+
+/// Applies a percentage `offset` to `current`, keeping the result a valid volume.
+///
+/// Both ends must be clamped. The original implementation capped only the maximum, so decreasing
+/// below zero produced a negative number that wrapped into a very large volume when cast to `u8`.
+pub fn offset_volume(current: u8, offset: i32) -> u8 {
+    let volume = (i32::from(current) + offset).clamp(0, 100);
+    u8::try_from(volume).unwrap_or(0)
+}
+
+/// The volume a newly created device should start at: the last persisted level, falling back to
+/// the configured `device.volume` only when nothing has been stored yet.
+// Only called when setting up the integrated player, which is gated behind `streaming`.
+#[cfg_attr(not(feature = "streaming"), allow(dead_code))]
+pub fn initial() -> u8 {
+    let configured = std::cmp::min(config::get_config().app_config.device.volume, 100);
+    if let Some(volume) = load() {
+        tracing::info!("Restoring persisted volume {volume}%");
+        return volume;
+    }
+    tracing::info!("No persisted volume found; starting at configured {configured}%");
+    configured
+}
+
+#[cfg(test)]
+mod tests {
+    use super::offset_volume;
+
+    #[test]
+    fn increases_and_decreases_by_the_offset() {
+        assert_eq!(offset_volume(70, 5), 75);
+        assert_eq!(offset_volume(70, -5), 65);
+    }
+
+    #[test]
+    fn saturates_at_full_volume() {
+        assert_eq!(offset_volume(98, 5), 100);
+        assert_eq!(offset_volume(100, 5), 100);
+    }
+
+    /// Regression: decreasing past zero used to underflow into a near-max volume.
+    #[test]
+    fn saturates_at_silence_instead_of_wrapping() {
+        assert_eq!(offset_volume(3, -5), 0);
+        assert_eq!(offset_volume(0, -5), 0);
+        assert_eq!(offset_volume(0, -100), 0);
+    }
+
+    #[test]
+    fn repeated_steps_walk_all_the_way_down() {
+        // Each press applies to the level the previous one produced, which is what the optimistic
+        // local update in `PlayerState::apply_volume` guarantees.
+        let mut volume = 100;
+        for _ in 0..20 {
+            volume = offset_volume(volume, -5);
+        }
+        assert_eq!(volume, 0);
+    }
+}


### PR DESCRIPTION
Volume goes over the Web API on every keypress, even when the integrated player is mixing the audio in the same process, and every player request also spawns five playback polls one second apart, so a burst of presses lags behind and the displayed percentage flickers between values. Volume down was missing its lower clamp, so dropping below zero produced a negative value that wrapped into a near maximum volume when cast to u8. The integrated player also always started at device.volume, so reconnecting after a network drop or restarting reset the level.

This applies volume to the local mixer via Spirc::set_volume when the integrated player is the active device, falling back to the Web API for remote Connect devices, and reconciles the Web API with one deferred request once changes settle. Presses are applied to the local playback state immediately so a burst accumulates correctly, and a completing request can no longer rewind the level. It also adds a transient volume gauge in a corner of the screen, configurable via enable_volume_hud, volume_hud_position, volume_hud_timeout_in_ms and volume_hud_width, binds volume to + and _ alongside = and -, moves mute to m, and persists the last volume to volume.state in the cache folder.

Two things worth calling out. Moving mute from _ to m is a change to a default keybinding, since _ is now volume down. And the local mixer path builds clean and passes the test suite and clippy at the CI feature configurations, but I have not been able to exercise it against a live session, so that part deserves a closer look.
