### PR TITLE
Add TLS backend features (rustls-tls / native-tls) — fixes auth panic on Termux

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ A Spotify Premium account is **required**.
     sudo yum install openssl-devel alsa-lib-devel dbus-devel
     ```
 
+##### Termux (Android)
+
+- Two default components require a JVM context that Termux processes don't have:
+  the default TLS backend (`rustls-platform-verifier`, panics during the auth
+  token exchange) and the rodio audio backend (cpal's AAudio host, panics when
+  streaming starts). Build with the `native-tls` feature and the pulseaudio
+  backend instead:
+
+  ```shell
+  pkg install rust openssl pulseaudio
+  cargo install spotify_player --no-default-features --features pulseaudio-backend,media-control,native-tls
+  ```
+
+  This makes authentication, the Web API, and remote device control work. Integrated
+  streaming additionally requires patching librespot's compile-time OS identity
+  (`librespot-core`'s `config::OS`) to `"linux"` via `[patch.crates-io]`, because
+  librespot built for `target_os = "android"` presents the Android-app identity, which
+  Spotify rejects for keymaster-minted credentials.
+
 ### Binaries
 
 Application's prebuilt binaries can be found in the [Releases Page](https://github.com/aome510/spotify-player/releases).

--- a/spotify_player/Cargo.toml
+++ b/spotify_player/Cargo.toml
@@ -22,7 +22,7 @@ librespot-metadata = { version = "0.8.0" }
 log = "0.4.33"
 chrono = "0.4.45"
 chrono-humanize = "0.2.3"
-reqwest = { version = "0.13.4", features = ["json", "query", "form", "blocking"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["charset", "http2", "system-proxy", "json", "query", "form", "blocking"] }
 rspotify = {version = "0.15.3", features = ["cli"] }
 base64 = "0.22.1"
 sha2 = "0.11.0"
@@ -100,7 +100,15 @@ notify = ["notify-rust"]
 daemon = ["daemonize", "streaming"]
 fzf = ["fuzzy-matcher"]
 
-default = ["rodio-backend", "media-control"]
+# TLS backend used by the application's HTTP client (auth/token exchange).
+# `rustls-tls` keeps reqwest's default backend (rustls + rustls-platform-verifier).
+# `native-tls` uses the system TLS library (e.g. openssl) instead — needed on
+# platforms where rustls-platform-verifier cannot run, such as Termux (Android
+# target without a JVM, see rustls/rustls-platform-verifier#219).
+rustls-tls = ["reqwest/default-tls"]
+native-tls = ["reqwest/native-tls"]
+
+default = ["rodio-backend", "media-control", "rustls-tls"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }"


### PR DESCRIPTION
# Add TLS backend features (`rustls-tls` / `native-tls`) — fixes auth panic on Termux

## Problem

On Termux (Android), authentication always fails with a panic in the token-exchange
thread. The cause is the direct `reqwest = 0.13` dependency: reqwest 0.13's default
TLS backend is rustls with `rustls-platform-verifier`, and on `aarch64-linux-android`
targets that verifier validates certificates by calling into the OS via JNI. A Termux
process has no JVM, so the verifier panics before any TLS connection can be made
(known upstream limitation with no env-var workaround:
rustls/rustls-platform-verifier#219).

Notably, streaming is *not* affected — `librespot-playback` is already pinned to
`native-tls` by this crate — so only the app's own HTTP client (auth/token exchange,
API calls) hits the panic.

## Change

- Declare `reqwest` with `default-features = false` (keeping `charset`, `http2`,
  `system-proxy` plus the existing feature list).
- Add two mutually-independent features:
  - `rustls-tls = ["reqwest/default-tls"]` — **in the default set**, so default
    builds are byte-for-byte the same backend as before.
  - `native-tls = ["reqwest/native-tls"]` — links the system TLS (openssl), which
    resolves certificates through standard paths (`SSL_CERT_FILE`, distro bundles,
    Termux's `$PREFIX/etc/tls/cert.pem`).
- README: add a Termux build note under Linux dependencies:
  `cargo install spotify_player --no-default-features --features rodio-backend,media-control,native-tls`

## Behavior

- **Default builds: unchanged.** `cargo check --no-default-features --features rustls-tls`
  resolves the identical reqwest backend as current master.
- **Termux builds with `native-tls`: authentication works.** Verified on-device
  (Pixel 10 Pro XL, Termux): the same setup that panics 100% of the time on master
  completes the OAuth token exchange, caches credentials, and serves Web API calls
  with the patched feature set. (Full integrated streaming on Termux needs one more,
  librespot-side workaround — outside this PR's scope, noted in the README section —
  but with it, end-to-end playback works on-device.)

## Notes

- `rustls-platform-verifier` disappears entirely from the dependency resolution when
  building with `--no-default-features --features native-tls` (verified via `cargo tree -i`
  on both `x86_64-unknown-linux-gnu` and `aarch64-linux-android`).
- If both TLS features are enabled, reqwest builds both backends and uses default-tls;
  no conflict.
- Termux hits the same no-JVM panic class a second time in the audio layer (rodio →
  cpal's AAudio host → `ndk-context`); no code change needed there since the existing
  `pulseaudio-backend` feature avoids it — the README note recommends that backend for
  Termux accordingly.
