### PR TITLE
fix: backspace on empty search input navigates to previous page #1061

### DIFF
--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -221,6 +221,17 @@ fn handle_key_sequence_for_search_page(
                     }
                     Ok(true)
                 }
+                Key::None(crossterm::event::KeyCode::Backspace) => {
+                    if line_input.is_empty() {
+                        if ui.history.len() > 1 {
+                            ui.history.pop();
+                            ui.popup = None;
+                        }
+                    } else {
+                        line_input.input(&Key::None(crossterm::event::KeyCode::Backspace));
+                    }
+                    Ok(true)
+                }
                 k => match line_input.input(k) {
                     None => Ok(false),
                     _ => Ok(true),


### PR DESCRIPTION
When the search input is empty, pressing Backspace now triggers PreviousPage navigation instead of being silently consumed.

Closes: https://github.com/aome510/spotify-player/issues/1061