### PR TITLE
feat(streaming): auto-reconnect the integrated Connect link on unexpected drop

### DIFF
--- a/spotify_player/src/client/handlers.rs
+++ b/spotify_player/src/client/handlers.rs
@@ -49,8 +49,20 @@ pub async fn start_session_watcher(state: SharedState, client: super::AppClient)
     // rather than firing them back-to-back.
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    #[cfg(feature = "streaming")]
+    let stream_drop_rx = client.stream_drop_receiver();
+
     loop {
         interval.tick().await;
+
+        #[cfg(feature = "streaming")]
+        if stream_drop_rx.try_recv().is_ok() {
+            tracing::info!("Integrated Connect link drop detected; creating a new session...");
+            if let Err(err) = client.new_session(Some(&state), false).await {
+                tracing::error!("Failed to reconnect after Connect link drop: {err:#}");
+            }
+        }
+
         if let Err(err) = client.check_valid_session(&state).await {
             tracing::error!("Failed to check/reconnect the client's session: {err:#}");
         }

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -51,8 +51,25 @@ pub struct AppClient {
     auth_config: AuthConfig,
     /// The Spotify Web API client, used for interacting with Spotify Web APIs
     api_client: WebApiClient,
+    /// The integrated streaming connection (librespot spirc), replaced on
+    /// (re)connect and torn down explicitly during deliberate replacements.
     #[cfg(feature = "streaming")]
     stream_conn: Arc<Mutex<Option<librespot_connect::Spirc>>>,
+    /// Sender half of the link-drop notification channel; the streaming
+    /// watchdog uses it to signal an unexpected Connect link drop.
+    #[cfg(feature = "streaming")]
+    stream_drop_tx: flume::Sender<()>,
+    /// Receiver half of [`Self::stream_drop_tx`]; consumed by the session
+    /// watcher to trigger reconnection on an unexpected link drop.
+    #[cfg(feature = "streaming")]
+    stream_drop_rx: flume::Receiver<()>,
+    /// Monotonic counter advanced whenever the streaming connection is
+    /// deliberately replaced (re-auth or `RestartIntegratedClient`). A spirc
+    /// watchdog task captures the epoch at spawn and only signals a link drop
+    /// if the counter is unchanged — i.e. the drop was not caused by a
+    /// deliberate reconnect.
+    #[cfg(feature = "streaming")]
+    stream_epoch: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl Deref for AppClient {
@@ -108,6 +125,35 @@ pub fn new_api_client() -> Result<WebApiClient> {
     ))
 }
 
+#[cfg(feature = "streaming")]
+impl AppClient {
+    /// Returns a clone of the sender used to signal an unexpected Connect link drop.
+    pub fn stream_drop_sender(&self) -> flume::Sender<()> {
+        self.stream_drop_tx.clone()
+    }
+
+    /// Returns the receiver that yields a signal whenever the integrated Connect
+    /// link drops unexpectedly. Consumed by the session watcher to reconnect.
+    pub fn stream_drop_receiver(&self) -> flume::Receiver<()> {
+        self.stream_drop_rx.clone()
+    }
+
+    /// Returns the current streaming-connection epoch. A spirc watchdog task
+    /// captures this at spawn; an unexpected link drop is signalled only if the
+    /// epoch is unchanged when the task ends.
+    pub fn stream_epoch(&self) -> u64 {
+        self.stream_epoch.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Advances the streaming-connection epoch, marking the current connection
+    /// as deliberately replaced. Call before tearing down an old connection so
+    /// its watchdog task does not spuriously signal a link drop.
+    pub fn advance_stream_epoch(&self) {
+        self.stream_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
 impl AppClient {
     /// Construct a new client
     pub async fn new() -> Result<Self> {
@@ -119,6 +165,9 @@ impl AppClient {
             .await
             .context("authenticate Spotify Web API client")?;
 
+        #[cfg(feature = "streaming")]
+        let (stream_drop_tx, stream_drop_rx) = flume::unbounded();
+
         Ok(Self {
             spotify: Arc::new(spotify::Spotify::new()),
             http: reqwest::Client::new(),
@@ -127,6 +176,12 @@ impl AppClient {
 
             #[cfg(feature = "streaming")]
             stream_conn: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "streaming")]
+            stream_drop_tx,
+            #[cfg(feature = "streaming")]
+            stream_drop_rx,
+            #[cfg(feature = "streaming")]
+            stream_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         })
     }
 
@@ -280,6 +335,11 @@ impl AppClient {
         session: librespot_core::Session,
         creds: librespot_core::authentication::Credentials,
     ) -> Result<()> {
+        // Deliberately replacing the connection: advance the epoch so the old
+        // spirc watchdog task (which captured a prior epoch) does not treat
+        // this teardown as an unexpected link drop.
+        self.advance_stream_epoch();
+
         let new_conn =
             crate::streaming::new_connection(self.clone(), state, session, creds).await?;
         let mut stream_conn = self.stream_conn.lock();

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -234,7 +234,7 @@ pub async fn new_connection(
     let epoch = client.stream_epoch();
     let watch_client = client.clone();
 
-    let player_event_task = tokio::task::spawn({
+    tokio::task::spawn({
         let mut channel = player.get_player_event_channel();
         async move {
             let mut pause_armed = pause_on_startup;
@@ -318,17 +318,12 @@ pub async fn new_connection(
         .await
         .context("initialize spirc")?;
 
-    // Watchdog: when `spirc_task` ends, the integrated Connect device has
-    // stopped being active (link dropped, idle timeout, network loss) *or* the
-    // connection was deliberately shut down during a reconnect. Distinguish the
-    // two via the connection epoch: deliberate reconnects advance it
-    // (see `AppClient::advance_stream_epoch`), so an unchanged epoch means the
-    // link dropped unexpectedly — notify the session watcher to re-establish it.
+    // Watch only `spirc_task`: it is the Connect link's lifetime signal (it owns
+    // the player). `player_event_task`'s channel closes when that player drops,
+    // so it terminates together with `spirc_task`; selecting on it here would
+    // allow a stale/independent termination to spuriously trigger a reconnect.
     tokio::task::spawn(async move {
-        tokio::select! {
-            () = spirc_task => {},
-            _ = player_event_task => {}
-        }
+        spirc_task.await;
         if watch_client.stream_epoch() == epoch {
             tracing::warn!(
                 "Integrated Connect link dropped unexpectedly; notifying the session watcher to reconnect"

--- a/spotify_player/src/streaming.rs
+++ b/spotify_player/src/streaming.rs
@@ -228,6 +228,12 @@ pub async fn new_connection(
     let pause_on_startup =
         configs.app_config.pause_on_startup && IS_FIRST_CONNECTION.swap(false, Ordering::SeqCst);
 
+    // Capture the streaming watchdog's handles *before* the player event task
+    // below moves `client` into its own spawned closure.
+    let drop_tx = client.stream_drop_sender();
+    let epoch = client.stream_epoch();
+    let watch_client = client.clone();
+
     let player_event_task = tokio::task::spawn({
         let mut channel = player.get_player_event_channel();
         async move {
@@ -312,10 +318,22 @@ pub async fn new_connection(
         .await
         .context("initialize spirc")?;
 
+    // Watchdog: when `spirc_task` ends, the integrated Connect device has
+    // stopped being active (link dropped, idle timeout, network loss) *or* the
+    // connection was deliberately shut down during a reconnect. Distinguish the
+    // two via the connection epoch: deliberate reconnects advance it
+    // (see `AppClient::advance_stream_epoch`), so an unchanged epoch means the
+    // link dropped unexpectedly — notify the session watcher to re-establish it.
     tokio::task::spawn(async move {
         tokio::select! {
             () = spirc_task => {},
             _ = player_event_task => {}
+        }
+        if watch_client.stream_epoch() == epoch {
+            tracing::warn!(
+                "Integrated Connect link dropped unexpectedly; notifying the session watcher to reconnect"
+            );
+            let _ = drop_tx.send(());
         }
     });
 


### PR DESCRIPTION
**Summary**

When the integrated `librespot` Connect link drops (idle timeout, network loss, sleep/wake), the spirc task ends silently and the app stays a non-functional Connect device until the user manually restarts it with `R`. The existing session watcher only polls the OAuth *web* session, so a dead Connect link with a healthy web session is never recovered. This change wires a watchdog that signals the session watcher when the Connect link ends unexpectedly, triggering an automatic reconnect (resuming playback if it was playing).

**Changes**

- `spotify_player/src/streaming.rs` — spawn a watchdog alongside `spirc_task`: capture a connection epoch + drop sender *before* the player-event task moves the client, then notify the watcher when the spirc task ends with an unchanged epoch (i.e. not a deliberate teardown).
- `spotify_player/src/client/mod.rs` — add a link-drop channel (`stream_drop_tx/rx`) and a monotonic connection epoch to `AppClient`, with accessors. `new_streaming_connection` advances the epoch before deliberate reconnects (re-auth, `R`), so those never spuriously re-trigger a reconnect.
- `spotify_player/src/client/handlers.rs` — `start_session_watcher` also checks the drop channel each tick and calls `new_session(..)` on a drop, which rebuilds the Connect link and resumes playback if it was playing.

**Notes**

This targets the common "player paused in background longer than ~30 min loses the Connect device" case. Best-effort; a deliberate reconnect (epoch advance) suppresses the watchdog, so the worst case during a racing drop+reconnect is a single harmless extra rebuild.

> Pre-existing, unrelated to this change: `cargo clippy -D warnings` with a recent toolchain flags an unused `anyhow::Context` import at `spotify_player/src/event/page.rs:1` that is present on `master`.