### PR TITLE
fix(streaming): preserve the playing track when reconnecting the session

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -53,6 +53,9 @@ pub struct AppClient {
     api_client: WebApiClient,
     #[cfg(feature = "streaming")]
     stream_conn: Arc<Mutex<Option<librespot_connect::Spirc>>>,
+    /// Guards the post-change playback poll so rapid player events coalesce into a single
+    /// in-flight loop rather than flooding Spotify's Web API (which 429 rate-limits).
+    update_playback_in_flight: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Deref for AppClient {
@@ -127,6 +130,7 @@ impl AppClient {
 
             #[cfg(feature = "streaming")]
             stream_conn: Arc::new(Mutex::new(None)),
+            update_playback_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -199,7 +203,7 @@ impl AppClient {
 
                     if let Err(err) = client.retrieve_current_playback(&state, false).await {
                         tracing::error!("Failed to retrieve current playback: {err:#}");
-                        return;
+                        continue;
                     }
 
                     // if playback exists, don't connect to a new device
@@ -766,16 +770,25 @@ impl AppClient {
 
     pub fn update_playback(&self, state: &SharedState) {
         // After handling a request changing the player's playback,
-        // update the playback state by making multiple get-playback requests.
+        // update the playback state by making a few get-playback requests.
         //
-        // Q: Why do we need more than one request to update the playback?
-        // A: It might take a while for Spotify server to reflect the new change,
-        // making additional requests can help ensure that the playback state is always up-to-date.
+        // Q: Why do we need more than one request?
+        // A: It can take a moment for Spotify to reflect the change. Rapid player events each
+        // triggering this loop would otherwise flood the Web API and trip its 429 rate limit, so
+        // coalesce them into a single in-flight loop.
+        if self
+            .update_playback_in_flight
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return;
+        }
+
         let client = self.clone();
         let state = state.clone();
+        let in_flight = self.update_playback_in_flight.clone();
         tokio::task::spawn(async move {
             let delay = std::time::Duration::from_secs(1);
-            for _ in 0..5 {
+            for _ in 0..2 {
                 tokio::time::sleep(delay).await;
                 if let Err(err) = client.retrieve_current_playback(&state, false).await {
                     tracing::error!(
@@ -783,6 +796,7 @@ impl AppClient {
                     );
                 }
             }
+            in_flight.store(false, std::sync::atomic::Ordering::SeqCst);
         });
     }
 

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -130,6 +130,34 @@ impl AppClient {
         })
     }
 
+    /// Snapshot the currently-playing context + track so a recreated session can
+    /// resume the *same* position rather than whatever the cloud reports after the
+    /// old device is torn down (which has no retained queue).
+    fn remember_playback(state: &SharedState) -> Option<crate::state::Playback> {
+        let player = state.player.read();
+        let playback = player.playback.as_ref()?;
+        let uri = match &playback.item {
+            Some(rspotify::model::PlayableItem::Track(track)) => {
+                let id = track.id.as_ref()?;
+                id.uri()
+            }
+            Some(rspotify::model::PlayableItem::Episode(episode)) => {
+                let id = episode.id.as_ref();
+                id.uri()
+            }
+            _ => return None,
+        };
+        match player.playing_context_id() {
+            // A `Tracks` context can't be restarted by uri, so there is no
+            // rememberable playback to re-issue.
+            Some(ContextId::Tracks(_)) | None => None,
+            Some(context_id) => Some(crate::state::Playback::Context(
+                context_id,
+                Some(rspotify::model::Offset::Uri(uri)),
+            )),
+        }
+    }
+
     async fn token(&self) -> Result<String> {
         self.auto_reauth().await?;
         Ok(self
@@ -146,7 +174,15 @@ impl AppClient {
     /// Initialize the application's playback upon creating a new session or during startup.
     ///
     /// `resume` controls whether playback should be (re)started on the device we connect to.
-    pub fn initialize_playback(&self, state: &SharedState, resume: bool) {
+    /// `remembered` is the context+track that was playing before a session recreation; when
+    /// provided it is re-issued at its remembered position instead of inheriting the cloud's
+    /// (empty/stale) playback state.
+    pub fn initialize_playback(
+        &self,
+        state: &SharedState,
+        resume: bool,
+        remembered: Option<crate::state::Playback>,
+    ) {
         tokio::task::spawn({
             let client = self.clone();
             let state = state.clone();
@@ -187,7 +223,19 @@ impl AppClient {
                         } else {
                             tracing::info!("Connection succeeded (device_id={id})!");
                             if resume {
-                                if let Err(err) =
+                                if let Some(remembered) = remembered.as_ref() {
+                                    // Re-issue the remembered context at its remembered track: the
+                                    // fresh device has no retained queue after the old one was
+                                    // torn down, so resuming it would restart a different track.
+                                    if let Err(err) = client
+                                        .start_playback(remembered.clone(), Some(id.as_ref()))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "Failed to resume remembered playback after reconnect: {err:#}"
+                                        );
+                                    }
+                                } else if let Err(err) =
                                     client.resume_playback(Some(id.as_ref()), None).await
                                 {
                                     tracing::warn!(
@@ -220,6 +268,10 @@ impl AppClient {
                 .as_ref()
                 .is_some_and(|p| p.is_playing)
         });
+
+        // Snapshot the currently-playing context + track so the recreated device resumes the
+        // *same* position rather than inheriting the cloud's (empty/stale) playback state.
+        let remembered = state.and_then(Self::remember_playback);
 
         let session = self.auth_config.session();
         let creds = auth::get_creds(&self.auth_config, reauth, true).context("get credentials")?;
@@ -255,7 +307,7 @@ impl AppClient {
         if let Some(state) = state {
             // reset the application's caches
             state.data.write().caches = MemoryCaches::new();
-            self.initialize_playback(state, was_playing);
+            self.initialize_playback(state, was_playing, remembered);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Pressing `R` (or an auto-reconnect) destroys the current spirc session and re-creates a new one. On re-init, `initialize_playback` trusted `retrieve_current_playback` (the cloud snapshot), which is empty/stale during the reconnect window — so the playing track moved to a different (often wrong) track.

This fix captures the current context + track URI *before* teardown and re-issues `Playback::Context(ctx, Offset::Uri(uri))` on the recreated device, instead of trusting the cloud snapshot.

## Changes (`spotify_player/src/client/mod.rs`)

- `AppClient::remember_playback(state: &SharedState) -> Option<Playback>` — builds the playback to restore from the current `player.playback.item` (Track or Episode), returning `None` on startup / no context / `ContextId::Tracks` so those paths fall back to the existing resume behavior (no change).
- `initialize_playback(&self, state, resume: bool, remembered: Option<Playback>)` — in the resume branch, if `remembered` is `Some`, calls `start_playback(remembered, Some(id))` at the remembered context + offset; otherwise plain `resume_playback`.
- `new_session` captures `remembered` before teardown and passes it through.

## Behavior

Safe fallbacks: startup, `ContextId::Tracks(_)`, or no prior playback → `remembered` is `None` → identical to previous behavior. Only the reconnect-with-active-track path changes, and only to preserve the exact track being played.

## Verification

- `cargo build --no-default-features --features rodio-backend,media-control,image,notify,fzf` ✓
- `cargo test --no-default-features --features rodio-backend,media-control,image,notify,fzf` → 26 passed ✓
- `cargo fmt --all -- --check` ✓
