### PR TITLE
feat(library): podcast (show) and episode views

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,7 +67,7 @@ spotify_player -o device.volume=80 -o theme=dracula
 | `cover_img_width`                 | Cover image width in terminal rows (requires `image` feature).                                       | `5`                                                                    |
 | `cover_img_pixels`                | Pixels per side for cover image (requires `pixelate` feature).                                       | `16`                                                                   |
 | `seek_duration_secs`              | Seek duration in seconds for seek commands.                                                          | `5`                                                                    |
-| `sort_artist_albums_by_type`      | Sort albums by type on artist pages.                                                                 | `false`                                                                |
+| `seek_duration_secs_podcast`      | Seek duration in seconds for seek commands when playing a podcast episode.                          | `15`                                                                   |
 | `volume_scroll_step`              | Volume change step when using mouse scroll.                                                          | `5`                                                                    |
 | `enable_mouse_scroll_volume`      | Enable volume control via mouse scroll.                                                              | `true`                                                                 |
 | `custom_queue`                    | Enable app-managed queue for custom playback integration (requires `streaming` feature).             | `true`                                                                 |
@@ -153,21 +153,25 @@ See the [Librespot wiki](https://github.com/librespot-org/librespot/wiki/Options
 
 The `[layout]` section configures the UI layout:
 
-| Option                     | Description                                          | Default |
-| -------------------------- | ---------------------------------------------------- | ------- |
-| `library.album_percent`    | Percentage of the album window in the library.       | `40`    |
-| `library.playlist_percent` | Percentage of the playlist window in the library.    | `40`    |
-| `playback_window_position` | Position of the playback window (`Top` or `Bottom`). | `Top`   |
-| `playback_window_height`   | Height of the playback window.                       | `6`     |
+| Option                     | Description                                            | Default |
+| -------------------------- | ------------------------------------------------------ | ------- |
+| `library.album_percent`    | Percentage of the album window in the library.         | `40`    |
+| `library.playlist_percent` | Percentage of the playlist window in the library.      | `40`    |
+| `library.show_percent`     | Percentage of the show (podcast) window in the library. | `0`    |
+| `library.audiobook_percent` | Percentage of the audiobook window in the library.     | `0`     |
+| `playback_window_position` | Position of the playback window (`Top` or `Bottom`).   | `Top`   |
+| `playback_window_height`   | Height of the playback window.                         | `6`     |
+| `detail_window_height`     | Height of the episode detail (description) window shown when browsing a show. | `8` |
+| `detail_window_image`      | Render the episode's cover image inside the detail window (requires the `image` feature). | `true` |
 
 Example:
 
 ```toml
 
-[layout]
-library = { album_percent = 40, playlist_percent = 40 }
+library = { album_percent = 40, playlist_percent = 40, show_percent = 0, audiobook_percent = 0 }
 playback_window_position = "Top"
-
+detail_window_height = 8
+detail_window_image = true
 ```
 
 ## Themes

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -24,7 +24,7 @@ cover_img_length = 0
 cover_img_width = 5
 cover_img_pixels = 16
 seek_duration_secs = 5
-custom_queue = true
+seek_duration_secs_podcast = 15
 enable_relative_line_number = false
 
 [device]
@@ -37,6 +37,8 @@ normalization = false
 autoplay = false
 
 [layout]
-library = { playlist_percent = 40, album_percent = 40 }
+library = { playlist_percent = 40, album_percent = 40, show_percent = 0, audiobook_percent = 0 }
 playback_window_position = "Top"
 playback_window_height = 6
+detail_window_height = 8
+detail_window_image = true

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -8,10 +8,10 @@ use crate::{
     auth::AuthConfig,
     state::{
         store_data_into_file_cache, Album, AlbumId, Artist, ArtistId, Category, Context, ContextId,
-        Device, FileCacheKey, Item, ItemId, MemoryCaches, Playback, PlaybackMetadata, Playlist,
-        PlaylistFolderItem, PlaylistId, SearchResults, SharedState, Show, ShowId, Track, TrackId,
-        UserId, TTL_CACHE_DURATION, USER_LIKED_TRACKS_URI, USER_RECENTLY_PLAYED_TRACKS_URI,
-        USER_TOP_TRACKS_URI,
+        Device, Episode, EpisodeId, FileCacheKey, Item, ItemId, MemoryCaches, Playback,
+        PlaybackMetadata, Playlist, PlaylistFolderItem, PlaylistId, SearchResults, SharedState,
+        Show, ShowId, Track, TrackId, UserId, TTL_CACHE_DURATION, USER_LIKED_TRACKS_URI,
+        USER_RECENTLY_PLAYED_TRACKS_URI, USER_TOP_TRACKS_URI,
     },
 };
 
@@ -106,6 +106,76 @@ pub fn new_api_client() -> Result<WebApiClient> {
     Ok(WebApiClient::new(
         rspotify::AuthCodePkceSpotify::with_config(creds, oauth, config),
     ))
+}
+
+/// Minimal deserialization target for a Spotify show. rspotify 0.15.3's `SimplifiedShow`/
+/// `FullShow` types require the `available_markets` field, which Spotify removed from API
+/// responses; this struct only captures the fields the app uses.
+#[derive(Deserialize, Debug, Clone)]
+struct ShowInfo {
+    id: ShowId<'static>,
+    name: String,
+    #[serde(default)]
+    publisher: String,
+}
+
+/// A saved show object returned by `/me/shows`.
+#[derive(Deserialize, Debug, Clone)]
+struct SavedShow {
+    show: ShowInfo,
+}
+
+/// A full show object returned by `/shows/{id}`.
+#[derive(Deserialize, Debug, Clone)]
+struct FullShow {
+    id: ShowId<'static>,
+    name: String,
+    #[serde(default)]
+    publisher: String,
+    episodes: rspotify::model::Page<SimplifiedEpisodeInfo>,
+}
+
+/// Deserialization target for a show's episodes. Carries the fields the episode table and detail
+/// footer need, avoiding a per-episode `/episodes/{id}` request. `images` is gated on the `image`
+/// feature since only the cover-image footer reads it.
+#[derive(Deserialize, Debug, Clone)]
+struct SimplifiedEpisodeInfo {
+    id: EpisodeId<'static>,
+    name: String,
+    release_date: String,
+    duration_ms: u64,
+    #[serde(default)]
+    description: String,
+    #[cfg(feature = "image")]
+    #[serde(default)]
+    images: Vec<EpisodeImageInfo>,
+}
+
+impl From<SimplifiedEpisodeInfo> for Episode {
+    fn from(e: SimplifiedEpisodeInfo) -> Self {
+        Self {
+            id: e.id,
+            name: e.name,
+            description: e.description,
+            duration: std::time::Duration::from_millis(e.duration_ms),
+            show: None,
+            release_date: e.release_date,
+            #[cfg(feature = "image")]
+            image_url: e.images.first().map(|i| i.url.clone()),
+        }
+    }
+}
+
+/// A `/search?type=show` response body.
+#[derive(Deserialize, Debug)]
+struct ShowSearchResult {
+    shows: rspotify::model::Page<ShowInfo>,
+}
+/// A single cover image from an episode's `images` array.
+#[cfg(feature = "image")]
+#[derive(Deserialize, Debug, Clone)]
+struct EpisodeImageInfo {
+    url: String,
 }
 
 impl AppClient {
@@ -580,7 +650,29 @@ impl AppClient {
                             },
                             uri => anyhow::bail!("unsupported Tracks context: {uri}"),
                         },
-                        ContextId::Show(show_id) => self.show_context(show_id).await?,
+                        ContextId::Show(show_id) => {
+                            let prefetch_id = show_id.clone_static();
+                            let ctx = self.show_context(show_id).await?;
+                            if let Context::Show {
+                                episodes,
+                                total_episodes,
+                                ..
+                            } = &ctx
+                            {
+                                if episodes.len() < *total_episodes {
+                                    self.spawn_show_episodes_prefetch(
+                                        state.clone(),
+                                        prefetch_id,
+                                        uri.clone(),
+                                        episodes.len(),
+                                        *total_episodes,
+                                    );
+                                }
+                                #[cfg(feature = "image")]
+                                self.spawn_episode_images_prefetch(state.clone(), episodes.clone());
+                            }
+                            ctx
+                        }
                     };
 
                     state
@@ -946,13 +1038,20 @@ impl AppClient {
     /// Get all saved shows of the current user
     pub async fn current_user_saved_shows(&self) -> Result<Vec<Show>> {
         let shows = self
-            .all_paging_items::<rspotify::model::Show>(
+            .all_paging_items::<SavedShow>(
                 &format!("{SPOTIFY_API_ENDPOINT}/me/shows"),
                 0, // we don't know the total number of saved shows beforehand
             )
             .await?;
 
-        Ok(shows.into_iter().map(|s| s.show.into()).collect())
+        Ok(shows
+            .into_iter()
+            .map(|s| Show {
+                id: s.show.id,
+                name: s.show.name,
+                publisher: s.show.publisher,
+            })
+            .collect())
     }
 
     /// Get all albums of an artist
@@ -1080,23 +1179,16 @@ impl AppClient {
 
     /// Search for items (tracks, artists, albums, playlists) matching a given query
     pub async fn search(&self, query: &str) -> Result<SearchResults> {
-        let (
-            track_result,
-            artist_result,
-            album_result,
-            playlist_result,
-            show_result,
-            episode_result,
-        ) = tokio::try_join!(
+        let (track_result, artist_result, album_result, playlist_result, shows, episode_result) = tokio::try_join!(
             self.search_specific_type(query, rspotify::model::SearchType::Track),
             self.search_specific_type(query, rspotify::model::SearchType::Artist),
             self.search_specific_type(query, rspotify::model::SearchType::Album),
             self.search_specific_type(query, rspotify::model::SearchType::Playlist),
-            self.search_specific_type(query, rspotify::model::SearchType::Show),
+            self.search_shows(query),
             self.search_specific_type(query, rspotify::model::SearchType::Episode)
         )?;
 
-        let (tracks, artists, albums, playlists, shows, episodes) = (
+        let (tracks, artists, albums, playlists, episodes) = (
             match track_result {
                 rspotify::model::SearchResult::Tracks(p) => p
                     .items
@@ -1124,12 +1216,6 @@ impl AppClient {
                     p.items.into_iter().map(std::convert::Into::into).collect()
                 }
                 _ => anyhow::bail!("expect a playlist search result"),
-            },
-            match show_result {
-                rspotify::model::SearchResult::Shows(p) => {
-                    p.items.into_iter().map(std::convert::Into::into).collect()
-                }
-                _ => anyhow::bail!("expect a show search result"),
             },
             match episode_result {
                 rspotify::model::SearchResult::Episodes(p) => {
@@ -1159,6 +1245,35 @@ impl AppClient {
             .deref()
             .search(query, typ, None, None, None, None)
             .await?)
+    }
+
+    /// Search for shows matching a given query.
+    ///
+    /// Uses a raw request because rspotify's `SearchResult::Shows` deserializes into
+    /// `SimplifiedShow`, which requires the `available_markets` field Spotify no longer sends.
+    pub async fn search_shows(&self, query: &str) -> Result<Vec<Show>> {
+        let result = self
+            .http_get::<ShowSearchResult>(
+                &format!("{SPOTIFY_API_ENDPOINT}/search"),
+                &Query::from([
+                    ("q", query),
+                    ("type", "show"),
+                    ("market", "from_token"),
+                    ("limit", "50"),
+                    ("offset", "0"),
+                ]),
+            )
+            .await?;
+        Ok(result
+            .shows
+            .items
+            .into_iter()
+            .map(|s| Show {
+                id: s.id,
+                name: s.name,
+                publisher: s.publisher,
+            })
+            .collect())
     }
 
     /// Add a playable item to a playlist
@@ -1510,27 +1625,169 @@ impl AppClient {
     }
 
     /// Get a show context data
+    ///
+    /// Only the first page of episodes is fetched eagerly; the rest load in the background so
+    /// the table fills up without requiring the user to scroll.
     pub async fn show_context(&self, show_id: ShowId<'_>) -> Result<Context> {
         let show_uri = show_id.uri();
         tracing::info!("Get show context: {}", show_uri);
 
-        let show = self.get_a_show(show_id.clone(), None).await?;
-
-        // get the show's episodes
-        let episodes = self
-            .all_paging_items::<rspotify::model::SimplifiedEpisode>(
-                &format!("{SPOTIFY_API_ENDPOINT}/shows/{}/episodes", show_id.id()),
-                show.episodes.total as usize,
+        let show = self
+            .http_get::<FullShow>(
+                &format!("{SPOTIFY_API_ENDPOINT}/shows/{}", show_id.id()),
+                &Query::new(),
             )
-            .await?
+            .await?;
+
+        // Reuse the first page of episodes already bundled in the show payload instead of
+        // issuing a second paginated request for the same data.
+        let total_episodes = show.episodes.total as usize;
+        let episodes: Vec<Episode> = show.episodes.items.into_iter().map(Episode::from).collect();
+
+        let show = Show {
+            id: show.id,
+            name: show.name,
+            publisher: show.publisher,
+        };
+
+        Ok(Context::Show {
+            show,
+            episodes,
+            total_episodes,
+        })
+    }
+
+    /// Fetch one page of a show's episodes starting at `offset`.
+    ///
+    /// Chunk size is the configured page of rows (so the first page fills the view), clamped to
+    /// Spotify's practical 25–50 range.
+    async fn show_episodes_page(
+        &self,
+        show_id: &ShowId<'_>,
+        offset: usize,
+    ) -> Result<Vec<Episode>> {
+        let limit = config::get_config()
+            .app_config
+            .page_size_in_rows
+            .clamp(25, 50);
+        let limit_str = limit.to_string();
+        let offset_str = offset.to_string();
+        let params = Query::from([
+            ("market", "from_token"),
+            ("limit", &limit_str),
+            ("offset", &offset_str),
+        ]);
+        let page = self
+            .http_get::<rspotify::model::Page<SimplifiedEpisodeInfo>>(
+                &format!("{SPOTIFY_API_ENDPOINT}/shows/{}/episodes", show_id.id()),
+                &params,
+            )
+            .await?;
+
+        Ok(page
+            .items
             .into_iter()
-            .map(std::convert::Into::into)
-            .collect::<Vec<_>>();
+            .map(Episode::from)
+            .collect::<Vec<_>>())
+    }
 
-        // converts `rspotify::model::FullShow` into `state::Show`
-        let show: Show = show.into();
+    /// Spawn a background task that appends the remaining pages of a show's episodes to the
+    /// cached context as they arrive, so the episode table fills up without user interaction.
+    fn spawn_show_episodes_prefetch(
+        &self,
+        state: SharedState,
+        show_id: ShowId<'static>,
+        uri: String,
+        mut offset: usize,
+        total_episodes: usize,
+    ) {
+        let client = self.clone();
+        tokio::spawn(async move {
+            while offset < total_episodes {
+                match client.show_episodes_page(&show_id, offset).await {
+                    Ok(episodes) => {
+                        if episodes.is_empty() {
+                            break;
+                        }
+                        offset += episodes.len();
+                        #[cfg(feature = "image")]
+                        let fetched = episodes.clone();
+                        let mut data = state.data.write();
+                        if let Some(Context::Show {
+                            episodes: loaded, ..
+                        }) = data.caches.context.get_mut(&uri)
+                        {
+                            loaded.extend(episodes);
+                        }
+                        drop(data);
+                        #[cfg(feature = "image")]
+                        if !fetched.is_empty() {
+                            client.spawn_episode_images_prefetch(state.clone(), fetched);
+                        }
+                    }
+                    Err(err) => {
+                        tracing::warn!("failed to prefetch show episodes: {err:#}");
+                        break;
+                    }
+                }
+            }
+        });
+    }
 
-        Ok(Context::Show { show, episodes })
+    /// Fetch a cover image and cache it in memory (and on disk, when enabled).
+    #[cfg(feature = "image")]
+    async fn fetch_episode_image(&self, state: &SharedState, url: &str) -> Result<()> {
+        if state.data.read().caches.images.contains_key(url) {
+            return Ok(());
+        }
+
+        let configs = config::get_config();
+        let filename = format!(
+            "episode-cover-{}.jpg",
+            url.rsplit('/').next().unwrap_or("img")
+        );
+        let path = configs.cache_folder.join("image").join(filename);
+        let bytes = self
+            .retrieve_image(url, &path, configs.app_config.enable_cover_image_cache)
+            .await?;
+
+        #[cfg(not(feature = "pixelate"))]
+        let image = image::load_from_memory(&bytes).context("Failed to load image from memory")?;
+        #[cfg(feature = "pixelate")]
+        let mut image =
+            image::load_from_memory(&bytes).context("Failed to load image from memory")?;
+        #[cfg(feature = "pixelate")]
+        Self::pixelate_image(&mut image);
+
+        state
+            .data
+            .write()
+            .caches
+            .images
+            .insert(url.to_owned(), image, *TTL_CACHE_DURATION);
+        Ok(())
+    }
+
+    /// Spawn a background task that prefetches and caches cover images for the given episodes'
+    /// unique image URLs, skipping any already cached.
+    #[cfg(feature = "image")]
+    fn spawn_episode_images_prefetch(&self, state: SharedState, episodes: Vec<Episode>) {
+        let client = self.clone();
+        tokio::spawn(async move {
+            if config::get_config().app_config.layout.detail_window_image {
+                let mut urls: Vec<&str> = episodes
+                    .iter()
+                    .filter_map(|e| e.image_url.as_deref())
+                    .collect();
+                urls.sort_unstable();
+                urls.dedup();
+                for url in urls {
+                    if let Err(err) = client.fetch_episode_image(&state, url).await {
+                        tracing::warn!("failed to prefetch episode image: {err:#}");
+                    }
+                }
+            }
+        });
     }
 
     /// Make a GET HTTP request to the Spotify server
@@ -1546,29 +1803,62 @@ impl AppClient {
             text.to_string()
         }
 
-        let access_token = self.token().await.context("get token")?;
-        tracing::debug!("{access_token} {url}");
+        // Respect Spotify's rate limit: on a 429, honor `Retry-After` (bounded) and retry a few
+        // times instead of failing outright or immediately hammering the API.
+        const MAX_RATE_LIMIT_RETRIES: usize = 3;
+        const MAX_BACKOFF_SECS: u64 = 10;
 
-        let response = self
-            .http
-            .get(url)
-            .query(payload)
-            .header(
-                reqwest::header::AUTHORIZATION,
-                format!("Bearer {access_token}"),
-            )
-            .send()
-            .await?;
+        let mut attempt = 0;
+        loop {
+            let access_token = self.token().await.context("get token")?;
+            tracing::debug!("{access_token} {url}");
 
-        let status = response.status();
-        let text = process_spotify_api_response(&response.text().await?);
-        tracing::debug!("{text}");
+            let response = self
+                .http
+                .get(url)
+                .query(payload)
+                .header(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Bearer {access_token}"),
+                )
+                .send()
+                .await?;
 
-        if status != StatusCode::OK {
-            anyhow::bail!("failed to send a Spotify API request {url}: {text}");
+            let status = response.status();
+
+            if status == StatusCode::TOO_MANY_REQUESTS {
+                let retry_after = response
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(1);
+
+                attempt += 1;
+                if attempt >= MAX_RATE_LIMIT_RETRIES {
+                    let text = response.text().await.unwrap_or_default();
+                    anyhow::bail!(
+                        "rate-limited (429) after {MAX_RATE_LIMIT_RETRIES} attempts requesting {url}: {text}"
+                    );
+                }
+
+                let delay = std::time::Duration::from_secs(retry_after.min(MAX_BACKOFF_SECS));
+                tracing::warn!(
+                    "rate-limited (429) requesting {url}; backing off {delay:?} (attempt {attempt}/{MAX_RATE_LIMIT_RETRIES})"
+                );
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+
+            let text = process_spotify_api_response(&response.text().await?);
+            tracing::debug!("{text}");
+
+            if status != StatusCode::OK {
+                anyhow::bail!("failed to send a Spotify API request {url}: {text}");
+            }
+
+            return Ok(serde_json::from_str(&text)?);
         }
-
-        Ok(serde_json::from_str(&text)?)
     }
 
     async fn all_paging_items<T>(&self, base_url: &str, mut count: usize) -> Result<Vec<T>>

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -125,7 +125,7 @@ pub struct AppConfig {
     pub notify_streaming_only: bool,
 
     pub seek_duration_secs: u16,
-
+    pub seek_duration_secs_podcast: u16,
     pub sort_artist_albums_by_type: bool,
 
     pub volume_scroll_step: u8,
@@ -229,12 +229,17 @@ pub struct LayoutConfig {
     pub library: LibraryLayoutConfig,
     pub playback_window_position: Position,
     pub playback_window_height: usize,
+    pub detail_window_height: usize,
+    pub detail_window_image: bool,
 }
 
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Deserialize, Serialize, ConfigParse, Clone)]
 pub struct LibraryLayoutConfig {
     pub playlist_percent: u16,
     pub album_percent: u16,
+    pub show_percent: u16,
+    pub audiobook_percent: u16,
 }
 
 #[allow(dead_code)]
@@ -387,7 +392,7 @@ impl Default for AppConfig {
             notify_streaming_only: false,
 
             seek_duration_secs: 5,
-
+            seek_duration_secs_podcast: 15,
             sort_artist_albums_by_type: false,
 
             volume_scroll_step: 5,
@@ -423,17 +428,26 @@ impl Default for LayoutConfig {
             library: LibraryLayoutConfig {
                 playlist_percent: 40,
                 album_percent: 40,
+                show_percent: 0,
+                audiobook_percent: 0,
             },
             playback_window_position: Position::Top,
             playback_window_height: 6,
+            detail_window_height: 8,
+            detail_window_image: true,
         }
     }
 }
 
 impl LayoutConfig {
     fn check_values(&self) -> anyhow::Result<()> {
-        if self.library.album_percent + self.library.playlist_percent > 99 {
-            anyhow::bail!("Invalid library layout: summation of album_percent and playlist_percent cannot be greater than 99!");
+        if self.library.album_percent
+            + self.library.playlist_percent
+            + self.library.show_percent
+            + self.library.audiobook_percent
+            > 99
+        {
+            anyhow::bail!("Invalid library layout: summation of album_percent, playlist_percent, show_percent, and audiobook_percent cannot be greater than 99!");
         }
         Ok(())
     }

--- a/spotify_player/src/event/mod.rs
+++ b/spotify_player/src/event/mod.rs
@@ -566,6 +566,22 @@ fn handle_global_action(
     Ok(false)
 }
 
+/// Resolve the seek step for the current playback item. Podcasts/episodes use a larger default
+/// step than tracks.
+fn current_seek_duration(state: &SharedState) -> u16 {
+    let configs = config::get_config();
+    let is_episode = state
+        .player
+        .read()
+        .currently_playing()
+        .is_some_and(|item| matches!(item, rspotify::model::PlayableItem::Episode(_)));
+    if is_episode {
+        configs.app_config.seek_duration_secs_podcast
+    } else {
+        configs.app_config.seek_duration_secs
+    }
+}
+
 /// Handle a global command that is not specific to any page/popup
 fn handle_global_command(
     command: Command,
@@ -608,10 +624,10 @@ fn handle_global_command(
                 chrono::TimeDelta::try_seconds(0).unwrap(),
             )))?;
         }
+
         Command::SeekForward { duration } => {
             if let Some(progress) = state.player.read().playback_progress() {
-                let duration =
-                    duration.unwrap_or(config::get_config().app_config.seek_duration_secs);
+                let duration = duration.unwrap_or(current_seek_duration(state));
                 client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
                     progress + chrono::Duration::try_seconds(i64::from(duration)).unwrap(),
                 )))?;
@@ -619,8 +635,7 @@ fn handle_global_command(
         }
         Command::SeekBackward { duration } => {
             if let Some(progress) = state.player.read().playback_progress() {
-                let duration =
-                    duration.unwrap_or(config::get_config().app_config.seek_duration_secs);
+                let duration = duration.unwrap_or(current_seek_duration(state));
                 client_pub.send(ClientRequest::Player(PlayerRequest::SeekTrack(
                     std::cmp::max(
                         chrono::Duration::zero(),

--- a/spotify_player/src/event/page.rs
+++ b/spotify_player/src/event/page.rs
@@ -82,6 +82,13 @@ fn handle_action_for_library_page(
             ui,
             client_pub,
         ),
+        LibraryFocusState::SavedShows => window::handle_action_for_selected_item(
+            action,
+            &ui.search_filtered_items(&data.user_data.saved_shows),
+            &data,
+            ui,
+            client_pub,
+        ),
     }
 }
 
@@ -126,6 +133,11 @@ fn handle_command_for_library_page(
         // Sort artists alphabetically
         data.user_data
             .followed_artists
+            .sort_by_key(|x| x.name.to_lowercase());
+
+        // Sort shows alphabetically
+        data.user_data
+            .saved_shows
             .sort_by_key(|x| x.name.to_lowercase());
     }
 
@@ -188,6 +200,15 @@ fn handle_command_for_library_page(
             Ok(window::handle_command_for_artist_list_window(
                 command,
                 &ui.search_filtered_items(&data.user_data.followed_artists),
+                &data,
+                ui,
+            ))
+        }
+        LibraryFocusState::SavedShows => {
+            let data = state.data.read();
+            Ok(window::handle_command_for_show_list_window(
+                command,
+                &ui.search_filtered_items(&data.user_data.saved_shows),
                 &data,
                 ui,
             ))

--- a/spotify_player/src/event/window.rs
+++ b/spotify_player/src/event/window.rs
@@ -5,7 +5,7 @@ use crate::{
         construct_album_actions, construct_artist_actions, construct_playlist_actions,
         construct_show_actions,
     },
-    state::{Episode, MutableWindowState, Show, UIStateGuard},
+    state::{Episode, MutableWindowState, Show, ShowFocusState, UIStateGuard},
 };
 use command::Action;
 use rand::RngExt;
@@ -203,18 +203,81 @@ pub fn handle_command_for_focused_context_window(
                 ui,
                 state,
             ),
-            Context::Show { show, episodes } => handle_command_for_episode_table_window(
-                command,
-                client_pub,
-                &show.id,
-                &ui.search_filtered_items(episodes),
-                &data,
-                ui,
-                state,
-            ),
+            Context::Show { show, episodes, .. } => {
+                let focus = match ui.current_page() {
+                    PageState::Context {
+                        state: Some(ContextPageUIState::Show { focus, .. }),
+                        ..
+                    } => *focus,
+                    _ => ShowFocusState::Episodes,
+                };
+                match focus {
+                    ShowFocusState::Episodes => handle_command_for_episode_table_window(
+                        command,
+                        client_pub,
+                        &show.id,
+                        &ui.search_filtered_items(episodes),
+                        &data,
+                        ui,
+                        state,
+                    ),
+                    ShowFocusState::Details => {
+                        if handle_command_for_episode_detail_window(command, ui) {
+                            Ok(true)
+                        } else {
+                            handle_command_for_episode_table_window(
+                                command,
+                                client_pub,
+                                &show.id,
+                                &ui.search_filtered_items(episodes),
+                                &data,
+                                ui,
+                                state,
+                            )
+                        }
+                    }
+                }
+            }
         },
         None => Ok(false),
     }
+}
+
+/// Handle navigation/scroll commands when the episode detail window is focused, scrolling the
+/// wrapped description body.
+fn handle_command_for_episode_detail_window(command: Command, ui: &mut UIStateGuard) -> bool {
+    let PageState::Context {
+        state: Some(ContextPageUIState::Show {
+            description_scroll, ..
+        }),
+        ..
+    } = ui.current_page_mut()
+    else {
+        return false;
+    };
+
+    let page = crate::config::get_config()
+        .app_config
+        .layout
+        .detail_window_height as u16;
+    match command {
+        Command::SelectNextOrScrollDown => {
+            *description_scroll = description_scroll.saturating_add(1);
+        }
+        Command::SelectPreviousOrScrollUp => {
+            *description_scroll = description_scroll.saturating_sub(1);
+        }
+        Command::PageSelectNextOrScrollDown => {
+            *description_scroll = description_scroll.saturating_add(page);
+        }
+        Command::PageSelectPreviousOrScrollUp => {
+            *description_scroll = description_scroll.saturating_sub(page);
+        }
+        Command::SelectFirstOrScrollToTop => *description_scroll = 0,
+        Command::SelectLastOrScrollToBottom => *description_scroll = u16::MAX,
+        _ => return false,
+    }
+    true
 }
 
 /// Handle commands that may modify a playlist
@@ -651,13 +714,33 @@ fn handle_command_for_episode_table_window(
     ui: &mut UIStateGuard,
     state: &SharedState,
 ) -> Result<bool> {
-    let id = ui.current_page_mut().selected().unwrap_or_default();
+    // Read the selection from the episode table directly: when the detail window has focus,
+    // `PageState::selected()` resolves to `None` (no focused window), but the episode selection
+    // itself is unchanged.
+    let id = match ui.current_page() {
+        PageState::Context {
+            state: Some(ContextPageUIState::Show { episode_table, .. }),
+            ..
+        } => episode_table.selected().unwrap_or_default(),
+        _ => return Ok(false),
+    };
     if id >= episodes.len() {
         return Ok(false);
     }
 
     let count = ui.count_prefix;
     if handle_navigation_command(command, ui.current_page_mut(), id, episodes.len(), count) {
+        // reset the description scroll for the newly selected episode
+        if let PageState::Context {
+            state:
+                Some(ContextPageUIState::Show {
+                    description_scroll, ..
+                }),
+            ..
+        } = ui.current_page_mut()
+        {
+            *description_scroll = 0;
+        }
         return Ok(true);
     }
     match command {

--- a/spotify_player/src/state/model.rs
+++ b/spotify_player/src/state/model.rs
@@ -42,6 +42,7 @@ pub enum Context {
     Show {
         show: Show,
         episodes: Vec<Episode>,
+        total_episodes: usize,
     },
 }
 
@@ -186,10 +187,10 @@ pub struct Playlist {
 pub struct Show {
     pub id: ShowId<'static>,
     pub name: String,
+    pub publisher: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-/// A Spotify episode (podcast episode)
 pub struct Episode {
     pub id: EpisodeId<'static>,
     pub name: String,
@@ -197,6 +198,8 @@ pub struct Episode {
     pub duration: std::time::Duration,
     pub show: Option<Show>,
     pub release_date: String,
+    #[cfg(feature = "image")]
+    pub image_url: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -266,8 +269,9 @@ impl Context {
             }
             Context::Show {
                 ref show,
-                ref episodes,
-            } => format!("{} | {} episodes", show.name, episodes.len()),
+                total_episodes,
+                ..
+            } => format!("{} | {} episodes", show.name, total_episodes),
         }
     }
 }
@@ -597,6 +601,7 @@ impl From<rspotify::model::SimplifiedShow> for Show {
         Self {
             id: show.id,
             name: show.name,
+            publisher: show.publisher,
         }
     }
 }
@@ -606,6 +611,7 @@ impl From<rspotify::model::FullShow> for Show {
         Self {
             id: show.id,
             name: show.name,
+            publisher: show.publisher,
         }
     }
 }
@@ -627,6 +633,8 @@ impl From<rspotify::model::SimplifiedEpisode> for Episode {
             duration: episode.duration.to_std().expect("valid chrono duration"),
             show: None,
             release_date: episode.release_date,
+            #[cfg(feature = "image")]
+            image_url: episode.images.first().map(|i| i.url.clone()),
         }
     }
 }
@@ -640,6 +648,8 @@ impl From<rspotify::model::FullEpisode> for Episode {
             duration: episode.duration.to_std().expect("valid chrono duration"),
             show: Some(episode.show.into()),
             release_date: episode.release_date,
+            #[cfg(feature = "image")]
+            image_url: episode.images.first().map(|i| i.url.clone()),
         }
     }
 }

--- a/spotify_player/src/state/ui/mod.rs
+++ b/spotify_player/src/state/ui/mod.rs
@@ -59,6 +59,9 @@ pub struct UIState {
     pub last_cover_image_render_info: ImageRenderInfo,
 
     #[cfg(feature = "image")]
+    pub episode_detail_image_render_info: ImageRenderInfo,
+
+    #[cfg(feature = "image")]
     pub picker: Picker,
 }
 
@@ -134,6 +137,9 @@ impl Default for UIState {
 
             #[cfg(feature = "image")]
             last_cover_image_render_info: ImageRenderInfo::default(),
+
+            #[cfg(feature = "image")]
+            episode_detail_image_render_info: ImageRenderInfo::default(),
 
             // Will be reinitialize later in ui/mod.rs after init_ui()
             #[cfg(feature = "image")]

--- a/spotify_player/src/state/ui/page.rs
+++ b/spotify_player/src/state/ui/page.rs
@@ -55,6 +55,7 @@ pub struct LibraryPageUIState {
     pub playlist_list: ListState,
     pub saved_album_list: ListState,
     pub followed_artist_list: ListState,
+    pub saved_show_list: ListState,
     pub focus: LibraryFocusState,
     pub playlist_folder_id: usize,
 }
@@ -96,6 +97,8 @@ pub enum ContextPageUIState {
     },
     Show {
         episode_table: TableState,
+        focus: ShowFocusState,
+        description_scroll: u16,
     },
 }
 
@@ -104,6 +107,7 @@ pub enum LibraryFocusState {
     Playlists,
     SavedAlbums,
     FollowedArtists,
+    SavedShows,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -112,6 +116,12 @@ pub enum ArtistFocusState {
     Albums,
     RelatedArtists,
     LikedSongs,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ShowFocusState {
+    Episodes,
+    Details,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -179,6 +189,7 @@ impl PageState {
                         playlist_list,
                         saved_album_list,
                         followed_artist_list,
+                        saved_show_list,
                         focus,
                         ..
                     },
@@ -188,6 +199,7 @@ impl PageState {
                 LibraryFocusState::FollowedArtists => {
                     MutableWindowState::List(followed_artist_list)
                 }
+                LibraryFocusState::SavedShows => MutableWindowState::List(saved_show_list),
             }),
             Self::Search {
                 state:
@@ -210,29 +222,34 @@ impl PageState {
                 SearchFocusState::Shows => Some(MutableWindowState::List(show_list)),
                 SearchFocusState::Episodes => Some(MutableWindowState::List(episode_list)),
             },
-            Self::Context { state, .. } => state.as_mut().map(|state| match state {
+            Self::Context { state, .. } => state.as_mut().and_then(|state| match state {
                 ContextPageUIState::Tracks { track_table }
-                | ContextPageUIState::Playlist { track_table } => {
-                    MutableWindowState::Table(track_table)
+                | ContextPageUIState::Playlist { track_table }
+                | ContextPageUIState::Album { track_table } => {
+                    Some(MutableWindowState::Table(track_table))
                 }
-                ContextPageUIState::Album { track_table } => MutableWindowState::Table(track_table),
                 ContextPageUIState::Artist {
                     top_track_table,
                     album_table,
                     related_artist_list,
                     liked_track_table,
                     focus,
-                } => match focus {
+                } => Some(match focus {
                     ArtistFocusState::TopTracks => MutableWindowState::Table(top_track_table),
                     ArtistFocusState::Albums => MutableWindowState::Table(album_table),
                     ArtistFocusState::RelatedArtists => {
                         MutableWindowState::List(related_artist_list)
                     }
                     ArtistFocusState::LikedSongs => MutableWindowState::Table(liked_track_table),
+                }),
+                ContextPageUIState::Show {
+                    episode_table,
+                    focus,
+                    ..
+                } => match focus {
+                    ShowFocusState::Episodes => Some(MutableWindowState::Table(episode_table)),
+                    ShowFocusState::Details => None,
                 },
-                ContextPageUIState::Show { episode_table } => {
-                    MutableWindowState::Table(episode_table)
-                }
             }),
             Self::Browse { state } => match state {
                 BrowsePageUIState::CategoryList { state } => Some(MutableWindowState::List(state)),
@@ -254,6 +271,7 @@ impl LibraryPageUIState {
             playlist_list: ListState::default(),
             saved_album_list: ListState::default(),
             followed_artist_list: ListState::default(),
+            saved_show_list: ListState::default(),
             focus: LibraryFocusState::Playlists,
             playlist_folder_id: 0,
         }
@@ -321,6 +339,8 @@ impl ContextPageUIState {
     pub fn new_show() -> Self {
         Self::Show {
             episode_table: TableState::default(),
+            focus: ShowFocusState::Episodes,
+            description_scroll: 0,
         }
     }
 }
@@ -365,6 +385,10 @@ impl Focusable for PageState {
                 state: Some(ContextPageUIState::Artist { focus, .. }),
                 ..
             } => focus.next(),
+            Self::Context {
+                state: Some(ContextPageUIState::Show { focus, .. }),
+                ..
+            } => focus.next(),
             _ => {}
         }
 
@@ -386,6 +410,10 @@ impl Focusable for PageState {
             } => focus.previous(),
             Self::Context {
                 state: Some(ContextPageUIState::Artist { focus, .. }),
+                ..
+            } => focus.previous(),
+            Self::Context {
+                state: Some(ContextPageUIState::Show { focus, .. }),
                 ..
             } => focus.previous(),
             _ => {}
@@ -424,7 +452,8 @@ impl_focusable!(
     LibraryFocusState,
     [Playlists, SavedAlbums],
     [SavedAlbums, FollowedArtists],
-    [FollowedArtists, Playlists]
+    [FollowedArtists, SavedShows],
+    [SavedShows, Playlists]
 );
 
 impl_focusable!(
@@ -434,6 +463,8 @@ impl_focusable!(
     [Albums, RelatedArtists],
     [RelatedArtists, TopTracks]
 );
+
+impl_focusable!(ShowFocusState, [Episodes, Details], [Details, Episodes]);
 
 impl_focusable!(
     SearchFocusState,

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -4,7 +4,7 @@ use crate::{
         Album, Artist, ArtistFocusState, BrowsePageUIState, Context, ContextPageUIState,
         DataReadGuard, Id, LibraryFocusState, MutableWindowState, PageState, PageType,
         PlaybackMetadata, PlaylistCreateCurrentField, PlaylistFolderItem, PlaylistPopupAction,
-        PopupState, SearchFocusState, SharedState, Track, UIStateGuard,
+        PopupState, SearchFocusState, SharedState, ShowFocusState, Track, UIStateGuard,
     },
 };
 use anyhow::{Context as AnyhowContext, Result};

--- a/spotify_player/src/ui/page.rs
+++ b/spotify_player/src/ui/page.rs
@@ -4,16 +4,16 @@ use std::{
 };
 
 use chrono_humanize::HumanTime;
-use ratatui::text::Line;
+use ratatui::{text::Line, widgets::Wrap};
 
-use crate::{state::Episode, utils::format_duration};
+use crate::{state::Episode, state::Show, utils::format_duration};
 
 use super::{
     config, utils, utils::construct_and_render_block, Album, Alignment, Artist, ArtistFocusState,
     Borders, BrowsePageUIState, Cell, Constraint, Context, ContextPageUIState, DataReadGuard,
     Frame, Id, Layout, LibraryFocusState, MutableWindowState, Orientation, PageState, Paragraph,
-    PlaylistFolderItem, Rect, Row, SearchFocusState, SharedState, Style, Table, Text, Track,
-    UIStateGuard,
+    PlaylistFolderItem, Rect, Row, SearchFocusState, SharedState, ShowFocusState, Style, Table,
+    Text, Track, UIStateGuard,
 };
 use crate::state::BidiDisplay;
 use crate::ui::utils::to_bidi_string;
@@ -299,17 +299,6 @@ pub fn render_context_page(
     else {
         return;
     };
-
-    // 2. Construct the page's layout
-    let rect = construct_and_render_block(
-        &context_page_type.title(),
-        &ui.theme,
-        Borders::ALL,
-        frame,
-        rect,
-    );
-
-    // 3+4. Construct and render the page's widgets
     let Some(id) = id else {
         frame.render_widget(
             Paragraph::new("Cannot determine the current page's context"),
@@ -319,7 +308,34 @@ pub fn render_context_page(
     };
 
     let data = state.data.read();
-    match data.caches.context.get(&id.uri()) {
+    let context = data.caches.context.get(&id.uri());
+
+    // Shows render their episode detail in a sibling panel below the show panel, so reserve a
+    // bottom strip for it before the show panel's border is drawn.
+    let detail_height = config::get_config()
+        .app_config
+        .layout
+        .detail_window_height
+        .clamp(1, u16::MAX as usize) as u16;
+    let (content_rect, footer_rect) = if matches!(context, Some(Context::Show { .. })) {
+        let chunks =
+            Layout::vertical([Constraint::Fill(0), Constraint::Length(detail_height)]).split(rect);
+        (chunks[0], Some(chunks[1]))
+    } else {
+        (rect, None)
+    };
+
+    // 2. Construct the page's title panel around the content area.
+    let rect = construct_and_render_block(
+        &context_page_type.title(),
+        &ui.theme,
+        Borders::ALL,
+        frame,
+        content_rect,
+    );
+
+    // 3+4. Construct and render the page's widgets.
+    match context {
         Some(context) => {
             // render context description
             let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(0)]).split(rect);
@@ -413,6 +429,13 @@ pub fn render_context_page(
             frame.render_widget(Paragraph::new("Loading..."), rect);
         }
     }
+
+    // Render the episode detail below the show panel.
+    if let (Some(footer_rect), Some(Context::Show { show, episodes, .. })) = (footer_rect, context)
+    {
+        let filtered = ui.search_filtered_items(episodes);
+        render_episode_detail_footer(frame, footer_rect, &data, ui, show, &filtered);
+    }
 }
 
 pub fn render_library_page(
@@ -433,10 +456,11 @@ pub fn render_library_page(
     };
 
     // 2. Construct the page's layout
-    // Split the library page into 3 windows:
+    // Split the library page into 4 windows:
     // - a playlists window
     // - a saved albums window
     // - a followed artists window
+    // - a saved shows window
 
     let chunks = ui
         .orientation
@@ -445,8 +469,10 @@ pub fn render_library_page(
             Constraint::Percentage(configs.app_config.layout.library.album_percent),
             Constraint::Percentage(
                 100 - (configs.app_config.layout.library.album_percent
-                    + configs.app_config.layout.library.playlist_percent),
+                    + configs.app_config.layout.library.playlist_percent
+                    + configs.app_config.layout.library.show_percent),
             ),
+            Constraint::Percentage(configs.app_config.layout.library.show_percent),
         ])
         .split(rect);
 
@@ -472,6 +498,7 @@ pub fn render_library_page(
     );
     let artist_rect =
         construct_and_render_block("Artists", &ui.theme, Borders::ALL, frame, chunks[2]);
+    let show_rect = construct_and_render_block("Shows", &ui.theme, Borders::ALL, frame, chunks[3]);
 
     // 3. Construct the page's widgets
     // Construct the playlist window
@@ -488,7 +515,8 @@ pub fn render_library_page(
 
     let is_playlist_active = is_active
         && focus_state != LibraryFocusState::SavedAlbums
-        && focus_state != LibraryFocusState::FollowedArtists;
+        && focus_state != LibraryFocusState::FollowedArtists
+        && focus_state != LibraryFocusState::SavedShows;
     let playlist_selected = if is_playlist_active {
         ui.current_page_mut().selected()
     } else {
@@ -528,6 +556,22 @@ pub fn render_library_page(
         is_artist_active,
         artist_selected,
     );
+    // Construct the saved show window
+    let is_show_active = is_active && focus_state == LibraryFocusState::SavedShows;
+    let show_selected = if is_show_active {
+        ui.current_page_mut().selected()
+    } else {
+        None
+    };
+    let (show_list, n_shows) = utils::construct_list_widget(
+        &ui.theme,
+        ui.search_filtered_items(&data.user_data.saved_shows)
+            .into_iter()
+            .map(|s| (s.to_bidi_string(), curr_context_uri == Some(s.id.uri())))
+            .collect(),
+        is_show_active,
+        show_selected,
+    );
 
     // 4. Render the page's widgets
     // Render the library page's windows.
@@ -556,6 +600,13 @@ pub fn render_library_page(
         artist_rect,
         n_artists,
         &mut page_state.followed_artist_list,
+    );
+    utils::render_list_window(
+        frame,
+        show_list,
+        show_rect,
+        n_shows,
+        &mut page_state.saved_show_list,
     );
 }
 
@@ -1281,13 +1332,112 @@ fn render_episode_table(
     } = ui.current_page_mut()
     {
         let playable_table_state = match state {
-            ContextPageUIState::Show { episode_table } => episode_table,
+            ContextPageUIState::Show { episode_table, .. } => episode_table,
             s => unreachable!("unexpected state: {s:?}"),
         };
         utils::render_table_window(frame, episode_table, rect, n_episodes, playable_table_state);
     }
 }
 
+/// Renders the selected episode's show/publisher + description below the episode table.
+#[cfg_attr(not(feature = "image"), allow(unused_variables))]
+fn render_episode_detail_footer(
+    frame: &mut Frame,
+    rect: Rect,
+    data: &DataReadGuard,
+    ui: &mut UIStateGuard,
+    show: &Show,
+    episodes: &[&Episode],
+) {
+    let selected = ui.current_page_mut().selected().unwrap_or_default();
+    let Some(episode) = episodes.get(selected) else {
+        return;
+    };
+
+    let (is_focused, description_scroll) = match ui.current_page() {
+        PageState::Context {
+            state:
+                Some(ContextPageUIState::Show {
+                    focus,
+                    description_scroll,
+                    ..
+                }),
+            ..
+        } => (*focus == ShowFocusState::Details, *description_scroll),
+        _ => (false, 0),
+    };
+
+    let inner = construct_and_render_block("Description", &ui.theme, Borders::ALL, frame, rect);
+
+    // When enabled and the episode's cover image is cached, reserve a left strip for it and
+    // render the description text in the remaining area.
+    #[cfg(feature = "image")]
+    let text_rect = {
+        let configs = config::get_config();
+        let image_url = episode.image_url.as_deref();
+        match image_url
+            .filter(|_| configs.app_config.layout.detail_window_image)
+            .and_then(|url| data.caches.images.get(url).map(|img| (url, img)))
+        {
+            Some((url, img)) => {
+                let width = {
+                    let font = ui.picker.font_size();
+                    inner.height.saturating_mul(font.height) / font.width.max(1)
+                };
+                let chunks = Layout::horizontal([Constraint::Length(width), Constraint::Fill(1)])
+                    .spacing(1)
+                    .split(inner);
+                let area = chunks[0];
+
+                let needs_rebuild = {
+                    let info = &ui.episode_detail_image_render_info;
+                    info.url != url || info.render_area != area
+                };
+                if needs_rebuild {
+                    let state = match crate::ui::cover_image::CoverImage::new(&ui.picker, img, area)
+                    {
+                        Ok(cover) => Some(cover),
+                        Err(err) => {
+                            tracing::error!("Failed to encode episode cover image: {err:#}");
+                            None
+                        }
+                    };
+                    let info = &mut ui.episode_detail_image_render_info;
+                    info.state = state;
+                    url.clone_into(&mut info.url);
+                    info.render_area = area;
+                }
+                if let Some(cover) = ui.episode_detail_image_render_info.state.as_mut() {
+                    cover.render(frame, area);
+                }
+                chunks[1]
+            }
+            None => inner,
+        }
+    };
+    #[cfg(not(feature = "image"))]
+    let text_rect = inner;
+
+    let header = format!("{} • {}", show.name, show.publisher);
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).split(text_rect);
+
+    let header_style = if is_focused {
+        ui.theme.selection(true)
+    } else {
+        ui.theme.playback_album()
+    };
+    if !show.name.is_empty() {
+        frame.render_widget(Paragraph::new(header).style(header_style), chunks[0]);
+    }
+
+    frame.render_widget(
+        Paragraph::new(episode.description.clone())
+            .wrap(Wrap { trim: true })
+            .scroll((description_scroll, 0))
+            .style(Style::default()),
+        chunks[1],
+    );
+}
 pub fn render_logs_page(frame: &mut Frame, state: &SharedState, ui: &mut UIStateGuard, rect: Rect) {
     let rect = construct_and_render_block("Logs", &ui.theme, Borders::ALL, frame, rect);
 


### PR DESCRIPTION
Add end-to-end podcast support (issue #770).

## Summary
- **Library Shows window**: new `SavedShows` focus state with window render and command/action dispatch alongside Playlists/Albums/Artists; shows sorted alphabetically.
- **Fix show deserialization**: `rspotify` 0.15.3 dropped `available_markets`, which was still required and broke saved-shows, show search, and show-context fetches. Deserialize with minimal local serde structs instead and surface the show's publisher.
- **Episode loading**: reuse the first page bundled in the show payload, then prefetch the remaining pages in the background so the table fills without user action; remove the on-scroll `GetMoreShowEpisodes` request path.
- **Episode detail footer**: render the selected episode's name/publisher in a bordered, colored panel below the episode table with a scrollable description, resetting the scroll on selection change.
- **Show page focus states** (`Episodes`/`Details`) with command dispatch.
- **Episode cover images** (`image` feature): parse `image_url` into `Episode`, prefetch and cache covers, honor `detail_window_image`, render via `ratatui-image`.
- **Config**: `library.show_percent` / `audiobook_percent` (default 0, included in layout validation), `seek_duration_secs_podcast` (default 15), `detail_window_height` (default 8) / `detail_window_image` (default true).
- **Resilience**: `http_get` honors Spotify 429 `Retry-After` with bounded backoff and retries instead of failing outright.

## Notes
- Lints clean with `cargo clippy --features image` (both `image` and `image,pixelate` cfg branches).
- Interactive UI was not visually smoke-tested in the dev harness (headless terminal); code builds and the CLI runs.
