### PR TITLE
fix(progress): reflect a seek immediately in the local playback state

### DIFF
--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -463,9 +463,23 @@ impl AppClient {
                 state.data.write().user_data.user = Some(user);
             }
             ClientRequest::Player(request) => {
+                let seek_to = match &request {
+                    PlayerRequest::SeekTrack(position) => Some(*position),
+                    _ => None,
+                };
                 let playback = state.player.read().buffered_playback.clone();
                 let playback = self.handle_player_request(request, playback).await?;
                 state.player.write().buffered_playback = playback;
+                if let Some(position) = seek_to {
+                    // Reflect a seek immediately in local state so the progress bar jumps right
+                    // away; the background `update_playback()` poll reconciles the exact
+                    // server-side position shortly after.
+                    let mut player = state.player.write();
+                    if let Some(p) = player.playback.as_mut() {
+                        p.progress = Some(position);
+                    }
+                    player.playback_last_updated_time = Some(std::time::Instant::now());
+                }
                 self.update_playback(state);
             }
             ClientRequest::GetCurrentPlayback => {


### PR DESCRIPTION
Fix the ~1s lag before the progress bar reflects a seek.

## Issue
`SeekTrack` updated the server-side playback position but left the local `playback.progress` and `playback_last_updated_time` untouched. The progress bar derives its time as `playback.progress + elapsed(since last update)`, so after a skip/bound it kept counting from the **pre-seek** position until the background `update_playback()` poll (which sleeps 1s and is now coalesced) refreshed the local state. Result: skips forward/backward (e.g. 15s on a podcast episode) don't update the bar until the next poll tick.

## Change
After a successful `SeekTrack`, immediately set `player.playback.progress` to the requested position and reset `playback_last_updated_time` in local state, so the bar jumps right away. The existing background poll still reconciles the exact server-side position (including any clamping past the track end) shortly after.

## Verification
- `cargo build --features image` passes.
- `cargo clippy --features image --all-targets` clean (no new warnings).
- Live seek display not visually confirmed (headless harness needs an active playback session); verified by code path + build.
