### PR TITLE
feat: reload theme dynamically on config changes

### DIFF
--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -4,7 +4,7 @@ mod theme;
 const DEFAULT_CONFIG_FOLDER: &str = ".config/spotify-player";
 const DEFAULT_CACHE_FOLDER: &str = ".cache/spotify-player";
 const APP_CONFIG_FILE: &str = "app.toml";
-const THEME_CONFIG_FILE: &str = "theme.toml";
+pub const THEME_CONFIG_FILE: &str = "theme.toml";
 const KEYMAP_CONFIG_FILE: &str = "keymap.toml";
 
 use anyhow::{anyhow, Result};
@@ -19,7 +19,7 @@ use std::{
 
 use anyhow::Context;
 use keymap::KeymapConfig;
-use theme::ThemeConfig;
+pub use theme::ThemeConfig;
 
 pub use theme::Theme;
 

--- a/spotify_player/src/config/theme.rs
+++ b/spotify_player/src/config/theme.rs
@@ -156,9 +156,11 @@ impl ThemeConfig {
                 let config = toml::from_str::<Self>(&content)?;
 
                 // merge user-defined themes and the application default themes
-                // Skip any theme whose name conflicts with already existed theme in the current application's themes
+                // User-defined themes take precedence and overwrite any existing themes with the same name
                 config.themes.into_iter().for_each(|theme| {
-                    if !self.themes.iter().any(|t| t.name == theme.name) {
+                    if let Some(existing) = self.themes.iter_mut().find(|t| t.name == theme.name) {
+                        *existing = theme;
+                    } else {
                         self.themes.push(theme);
                     }
                 });

--- a/spotify_player/src/ui/mod.rs
+++ b/spotify_player/src/ui/mod.rs
@@ -40,6 +40,8 @@ pub fn run(state: &SharedState, mut terminal: Terminal) -> Result<()> {
         config::get_config().app_config.app_refresh_duration_in_ms,
     );
     let mut last_terminal_size = None;
+    let mut last_theme_check = std::time::Instant::now();
+    let mut last_theme_mtime = None;
 
     loop {
         {
@@ -47,6 +49,26 @@ pub fn run(state: &SharedState, mut terminal: Terminal) -> Result<()> {
             if !ui.is_running {
                 clean_up(terminal).context("clean up UI resources")?;
                 std::process::exit(0);
+            }
+
+            // Live theme hot-reload: check theme.toml every 200ms
+            if last_theme_check.elapsed() > std::time::Duration::from_millis(200) {
+                last_theme_check = std::time::Instant::now();
+                if let Ok(config_folder) = config::get_config_folder_path() {
+                    let theme_file = config_folder.join(config::THEME_CONFIG_FILE);
+                    if let Ok(metadata) = std::fs::metadata(&theme_file) {
+                        if let Ok(mtime) = metadata.modified() {
+                            if last_theme_mtime != Some(mtime) {
+                                last_theme_mtime = Some(mtime);
+                                if let Ok(theme_config) = config::ThemeConfig::new(&config_folder) {
+                                    if let Some(theme) = theme_config.find_theme(&ui.theme.name) {
+                                        ui.theme = theme;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             let terminal_size = terminal.size()?;


### PR DESCRIPTION
### Summary
Adds live theme reloading to the UI loop without requiring an application restart.

### Changes
- Check `theme.toml` modification time periodically in the UI loop.
- Reload and update `ui.theme` in-place when the theme configuration changes.
- Allow user-defined themes in `theme.toml` to update existing theme definitions by name.