### PR TITLE
add a config option for configuring ncspot-only GET endpoints

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ spotify_player -o device.volume=80 -o theme=dracula
 | --------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `client_id`                       | Primary Spotify client ID for API access; rejected requests can fall back to ncspot (see notes).    | See code (default: ncspot's client ID)                                 |
 | `client_id_command`               | Shell command that outputs client ID to stdout (overrides `client_id`).                             | `None`                                                                 |
+| `ncspot_only_get_endpoints`       | Endpoint prefixes for GET requests that should always use the ncspot client.                        | `["me/playlists", "search", "playlists/"]`                             |
 | `login_redirect_uri`              | Redirect URI for authentication.                                                                    | `http://127.0.0.1:8989/login`                                          |
 | `client_port`                     | Port for the application's client to handle CLI commands.                                           | `8080`                                                                 |
 | `log_folder`                      | Path to store log files.                                                                            | `None`                                                                 |

--- a/examples/app.toml
+++ b/examples/app.toml
@@ -1,6 +1,7 @@
 theme = "default"
 login_redirect_uri = "http://127.0.0.1:8989/login"
 client_id = "d420a117a32841c2b3474932e49fb54b"
+ncspot_only_get_endpoints = ["me/playlists", "search", "playlists/"]
 client_port = 8080
 tracks_playback_limit = 50
 playback_format = "{status} {track} • {artists}\n{album} • {genres}\n{metadata}"

--- a/spotify_player/src/client/mod.rs
+++ b/spotify_player/src/client/mod.rs
@@ -95,6 +95,7 @@ pub fn new_api_client() -> Result<WebApiClient> {
     let configs = config::get_config();
 
     let id = configs.app_config.get_client_id()?;
+    let ncspot_only_get_endpoints = configs.app_config.ncspot_only_get_endpoints.clone();
     let mut scopes = auth::OAUTH_SCOPES
         .iter()
         .map(ToString::to_string)
@@ -126,7 +127,8 @@ pub fn new_api_client() -> Result<WebApiClient> {
             config,
         )
         .with_middleware(middleware);
-        return Ok(WebApiClient::new(client, None));
+        return Ok(WebApiClient::new(client, None)
+            .with_ncspot_only_get_endpoints(ncspot_only_get_endpoints));
     }
 
     tracing::info!(
@@ -155,7 +157,8 @@ pub fn new_api_client() -> Result<WebApiClient> {
     )
     .with_middleware(fallback_middleware);
 
-    Ok(WebApiClient::new(primary, Some(fallback)))
+    Ok(WebApiClient::new(primary, Some(fallback))
+        .with_ncspot_only_get_endpoints(ncspot_only_get_endpoints))
 }
 
 impl AppClient {

--- a/spotify_player/src/client/spotify.rs
+++ b/spotify_player/src/client/spotify.rs
@@ -202,10 +202,17 @@ impl OAuthClient for PkceWebApiClient {
 }
 
 /// Spotify Web API client with an optional fallback identity.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct WebApiClient {
     primary: PkceWebApiClient,
     fallback: Option<PkceWebApiClient>,
+    ncspot_only_get_endpoints: Vec<String>,
+}
+
+impl Default for WebApiClient {
+    fn default() -> Self {
+        Self::new(AuthCodePkceSpotify::default(), None)
+    }
 }
 
 impl WebApiClient {
@@ -213,7 +220,19 @@ impl WebApiClient {
         Self {
             primary: PkceWebApiClient::new(primary),
             fallback: fallback.map(PkceWebApiClient::new),
+            ncspot_only_get_endpoints: crate::config::DEFAULT_NCSPOT_ONLY_GET_ENDPOINTS
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
         }
+    }
+
+    pub fn with_ncspot_only_get_endpoints(
+        mut self,
+        ncspot_only_get_endpoints: Vec<String>,
+    ) -> Self {
+        self.ncspot_only_get_endpoints = ncspot_only_get_endpoints;
+        self
     }
 
     pub(crate) fn primary_mut(&mut self) -> &mut PkceWebApiClient {
@@ -228,9 +247,10 @@ impl WebApiClient {
         self.fallback.as_ref().unwrap_or(&self.primary)
     }
 
-    fn is_ncspot_only_get(url: &str) -> bool {
-        let path = url.split('?').next().unwrap_or(url).trim_matches('/');
-        matches!(path, "me/playlists" | "search")
+    fn is_ncspot_only_get(&self, url: &str) -> bool {
+        self.ncspot_only_get_endpoints
+            .iter()
+            .any(|endpoint| url.starts_with(endpoint))
     }
 
     fn fallback_status(error: &ClientError) -> Option<reqwest::StatusCode> {
@@ -278,7 +298,7 @@ impl BaseClient for WebApiClient {
     }
 
     async fn api_get(&self, url: &str, payload: &Query<'_>) -> ClientResult<String> {
-        if Self::is_ncspot_only_get(url) {
+        if self.is_ncspot_only_get(url) {
             return self.ncspot().api_get(url, payload).await;
         }
 
@@ -575,6 +595,39 @@ mod tests {
 
         assert_eq!(
             client.api_get("search", &Query::new()).await.unwrap(),
+            "ncspot"
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_endpoint_prefix_uses_ncspot_without_calling_primary() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/artists/artist-id"))
+            .and(header("authorization", "Bearer primary-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("primary"))
+            .expect(0)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/v1/artists/artist-id"))
+            .and(header("authorization", "Bearer fallback-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("ncspot"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = WebApiClient::new(
+            client_with_token(&server, false, "primary-token").await,
+            Some(client_with_token(&server, true, "fallback-token").await),
+        )
+        .with_ncspot_only_get_endpoints(vec!["artists/".to_string()]);
+
+        assert_eq!(
+            client
+                .api_get("artists/artist-id", &Query::new())
+                .await
+                .unwrap(),
             "ncspot"
         );
     }

--- a/spotify_player/src/config/mod.rs
+++ b/spotify_player/src/config/mod.rs
@@ -6,6 +6,8 @@ const DEFAULT_CACHE_FOLDER: &str = ".cache/spotify-player";
 const APP_CONFIG_FILE: &str = "app.toml";
 const THEME_CONFIG_FILE: &str = "theme.toml";
 const KEYMAP_CONFIG_FILE: &str = "keymap.toml";
+pub(crate) const DEFAULT_NCSPOT_ONLY_GET_ENDPOINTS: &[&str] =
+    &["me/playlists", "search", "playlists/"];
 
 use anyhow::{anyhow, Result};
 use config_parser2::{config_parser_impl, ConfigParse, ConfigParser};
@@ -53,6 +55,7 @@ pub struct AppConfig {
     pub theme: String,
     pub client_id: String,
     pub client_id_command: Option<Command>,
+    pub ncspot_only_get_endpoints: Vec<String>,
 
     pub client_port: u16,
 
@@ -304,6 +307,10 @@ impl Default for AppConfig {
             // [spotify API changes]: https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api
             client_id: NCSPOT_CLIENT_ID.to_string(),
             client_id_command: None,
+            ncspot_only_get_endpoints: DEFAULT_NCSPOT_ONLY_GET_ENDPOINTS
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
 
             client_port: 8080,
 


### PR DESCRIPTION
## Summary

Allow users to configure which Spotify Web API GET endpoints should bypass a custom client and use the ncspot client directly.

## Changes

- Add the `ncspot_only_get_endpoints` application setting.
- Match configured entries as prefixes against rspotify's relative request URL.
- Preserve existing ncspot-only routing and include playlist endpoints in the default configuration:
  ```toml
  ncspot_only_get_endpoints = ["me/playlists", "search", "playlists/"]
  ```